### PR TITLE
Yapconf

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.5'
 
-x-environment: &env
+x-definitions: &env
     BG_AMQ_ADMIN_HOST: rabbitmq
     BG_AMQ_ADMIN_USER: beer_garden
     BG_AMQ_ADMIN_PASSWORD: password
@@ -29,30 +29,17 @@ services:
         networks:
             - bg-network
         volumes:
-            - ./plugins:/plugins
+            - ./localplugins:/plugins
         environment:
             <<: *env
 
-            # This must be changed to support remote plugins
-            # The value must be universally resolvable
+            # Change this to support remote plugins outside of docker
+            # Should be resolvable from inside and outside the docker network
             BG_AMQ_PUBLISH_HOST: rabbitmq
         depends_on:
             - mongodb
             - rabbitmq
             - brew-view
-
-    remote-echo:
-        image: bgio/example-plugin:echo
-        restart: on-failure
-        networks:
-            - bg-network
-        environment:
-            <<: *env
-        depends_on:
-            - mongodb
-            - rabbitmq
-            - brew-view
-            - bartender
 
     mongodb:
         image: mongo:3.6

--- a/docker/docker-compose/plugins-compose.yml
+++ b/docker/docker-compose/plugins-compose.yml
@@ -1,0 +1,46 @@
+version: '3.5'
+
+x-definitions: &plugin
+    image: bgio/example-plugins
+    networks:
+        - bg-network
+    environment:
+        BG_HOST: brew-view
+        BG_SSL_ENABLED: "False"
+
+services:
+    complex-c1:
+        command: ["complex", "c1", "c1-host", "c1-port"]
+        <<: *plugin
+
+    complex-c2:
+        command: ["complex", "c2", "c2-host", "c2-port"]
+        <<: *plugin
+
+    custom-display:
+        command: ["custom_display"]
+        <<: *plugin
+
+    dynamic:
+        command: ["dynamic"]
+        <<: *plugin
+
+    echo:
+        command: ["echo"]
+        <<: *plugin
+
+    echo-sleeper:
+        command: ["echo_sleeper"]
+        <<: *plugin
+
+    error:
+        command: ["error"]
+        <<: *plugin
+
+    sleeper:
+        command: ["sleeper"]
+        <<: *plugin
+
+networks:
+    bg-network:
+        external: true


### PR DESCRIPTION
I'd like to use this change to streamline a Beergarden introduction tutorial.

I'd like to split out the example plugins into their own repository and reference them as a submodule. That way they can live in both bartender/plugins and beer-garden/example-plugins. I think it's important to have them easily visible for a tutorial as well as available to bartender.