### PR TITLE
Removing static file handlers from http url map

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -28,7 +28,7 @@ from brewtils.schemas import (
 from prometheus_client.exposition import start_http_server
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
-from tornado.web import Application, StaticFileHandler, RedirectHandler
+from tornado.web import Application, RedirectHandler
 from urllib3.util.url import Url
 
 import beer_garden.bg_utils
@@ -175,7 +175,6 @@ def _setup_tornado_app():
 
     web_config = beer_garden.config.get("web")
     prefix = web_config.url_prefix
-    static_base = os.path.join(os.path.dirname(__file__), "static", "dist")
 
     # These get documented in our OpenAPI (fka Swagger) documentation
     published_url_specs = [
@@ -237,19 +236,8 @@ def _setup_tornado_app():
         (rf"{prefix}version/?", misc.VersionHandler),
         (rf"{prefix}config/?", misc.ConfigHandler),
         (rf"{prefix}config/swagger/?", misc.SwaggerConfigHandler),
-        # Not sure if these are really necessary
+        # Not sure if this is really necessary
         (rf"{prefix[:-1]}", RedirectHandler, {"url": prefix}),
-        (
-            rf"{prefix}swagger/(.*)",
-            StaticFileHandler,
-            {"path": os.path.join(static_base, "swagger")},
-        ),
-        # Static content
-        (
-            rf"{prefix}(.*)",
-            StaticFileHandler,
-            {"path": static_base, "default_filename": "index.html"},
-        ),
     ]
     app_config = beer_garden.config.get("application")
     auth_config = beer_garden.config.get("auth")


### PR DESCRIPTION
This PR removes the static file handlers from the Tornado configuration.