### PR TITLE
Url prefix

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -4,7 +4,6 @@ import os
 import ssl
 
 from apispec import APISpec
-from brewtils.rest import normalize_url_prefix
 from brewtils.schemas import (
     ParameterSchema,
     CommandSchema,
@@ -143,7 +142,7 @@ def _setup_application():
         scheme="https" if http_config.ssl.enabled else "http",
         host=http_config.public_fqdn,
         port=http_config.port,
-        path=normalize_url_prefix(http_config.url_prefix),
+        path=http_config.url_prefix,
     ).url
 
     tornado_app = _setup_tornado_app()
@@ -160,7 +159,7 @@ def _setup_tornado_app():
     import beer_garden.api.http.handlers.vbeta as vbeta
     import beer_garden.api.http.handlers.misc as misc
 
-    prefix = normalize_url_prefix(beer_garden.config.get("entry.http.url_prefix"))
+    prefix = beer_garden.config.get("entry.http.url_prefix")
 
     # These get documented in our OpenAPI (fka Swagger) documentation
     published_url_specs = [

--- a/src/app/beer_garden/api/http/handlers/misc.py
+++ b/src/app/beer_garden/api/http/handlers/misc.py
@@ -1,7 +1,5 @@
 import logging
 
-from brewtils import normalize_url_prefix
-
 import beer_garden.api.http
 from beer_garden.api.http.base_handler import BaseHandler
 
@@ -24,7 +22,7 @@ class ConfigHandler(BaseHandler):
             "application_name": app_config.name,
             "icon_default": app_config.icon_default,
             "debug_mode": app_config.debug_mode,
-            "url_prefix": normalize_url_prefix(http_config.url_prefix),
+            "url_prefix": http_config.url_prefix,
             "metrics_url": metrics_config.prometheus.url,
             "auth_enabled": auth_config.enabled,
             "guest_login_enabled": auth_config.guest_login_enabled,
@@ -54,9 +52,13 @@ class VersionHandler(BaseHandler):
 
 class SwaggerConfigHandler(BaseHandler):
     def get(self):
-        prefix = normalize_url_prefix(beer_garden.config.get("entry.http.url_prefix"))
         self.set_header("Content-Type", "application/json; charset=UTF-8")
-        self.write({"url": f"{prefix}api/v1/spec", "validatorUrl": None})
+        self.write(
+            {
+                "url": f"{beer_garden.config.get('entry.http.url_prefix')}api/v1/spec",
+                "validatorUrl": None,
+            }
+        )
 
 
 class SpecHandler(BaseHandler):

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Tuple, Sequence, Union
 
 from box import Box
+from brewtils.rest import normalize_url_prefix as normalize
 from ruamel.yaml import YAML
 from yapconf import YapconfSpec, dump_data
 
@@ -39,9 +40,18 @@ def load(args: Sequence[str], force: bool = False) -> None:
         return
 
     spec, cli_vars = _parse_args(args)
-
     config_sources = _setup_config_sources(spec, cli_vars)
-    _CONFIG = Box(spec.load_config(*config_sources).to_dict(), frozen_box=True)
+
+    raw_config = spec.load_config(*config_sources)
+
+    # Create a Box with default to avoid KeyErrors
+    config = Box(raw_config.to_dict(), default_box=True)
+    if config.entry.http.url_prefix:
+        config.entry.http.url_prefix = normalize(config.entry.http.url_prefix)
+    if config.event.brew_view.url_prefix:
+        config.event.brew_view.url_prefix = normalize(config.event.brew_view.url_prefix)
+
+    _CONFIG = Box(config.to_dict(), frozen_box=True)
 
 
 def generate(args: Sequence[str]):
@@ -635,7 +645,7 @@ _HTTP_SPEC = {
         },
         "url_prefix": {
             "type": "str",
-            "default": None,
+            "default": "/",
             "description": "URL path prefix",
             "required": False,
             "previous_names": ["url_prefix"],
@@ -735,7 +745,7 @@ _EVENT_SPEC = {
                 },
                 "url_prefix": {
                     "type": "str",
-                    "default": None,
+                    "default": "/",
                     "description": "URL prefix of the API server",
                     "required": False,
                 },

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -62,7 +62,7 @@ entry:
       enabled: false
       private_key: null
       public_key: null
-    url_prefix: null
+    url_prefix: /
   thrift:
     enable: false
 event:
@@ -77,7 +77,7 @@ event:
     host: localhost
     port: 2337
     ssl_enabled: false
-    url_prefix: null
+    url_prefix: /
   mongo:
     enable: true
 log:

--- a/src/app/test/config_test.py
+++ b/src/app/test/config_test.py
@@ -17,7 +17,7 @@ class TestLoadConfig(object):
     def test_no_config_file(self):
         beer_garden.config.load([], force=True)
         spec = YapconfSpec(beer_garden.config._SPECIFICATION)
-        assert beer_garden.config._CONFIG == spec.defaults
+        assert beer_garden.config._CONFIG.to_dict() == spec.defaults
 
     @pytest.mark.parametrize(
         "extension,contents",

--- a/src/app/test/config_test.py
+++ b/src/app/test/config_test.py
@@ -38,6 +38,32 @@ class TestLoadConfig(object):
         beer_garden.config.load(["-c", str(config_file)], force=True)
         assert beer_garden.config.get("log.level") == "DEBUG"
 
+    # These are pretty much identical to the brewtils tests for normalize prefix
+    @pytest.mark.parametrize(
+        "normalized,initial",
+        [
+            ("/", "/"),
+            ("/example/", "example"),
+            ("/example/", "/example"),
+            ("/example/", "example/"),
+            ("/example/", "/example/"),
+            ("/beer/garden/", "beer/garden"),
+            ("/beer/garden/", "/beer/garden"),
+            ("/beer/garden/", "/beer/garden/"),
+        ],
+    )
+    def test_normalize_url_prefix(self, normalized, initial):
+        cli_args = [
+            "--entry-http-url-prefix",
+            initial,
+            "--event-brew_view-url-prefix",
+            initial,
+        ]
+        beer_garden.config.load(cli_args, force=True)
+
+        assert beer_garden.config.get("entry.http.url_prefix") == normalized
+        assert beer_garden.config.get("event.brew_view.url_prefix") == normalized
+
 
 class TestGenerateConfig(object):
     def test_correctness(self, tmpdir):


### PR DESCRIPTION
This PR removes an issue I've been bitten by a couple of times. It normalizes the url_prefix config values when they are loaded, which removes the need to call `normalize_url_prefix` everywhere the value is used.