### PR TITLE
Local tests

### DIFF
--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -152,7 +152,7 @@ class LocalPluginsManager(object):
                 system_version,
             )
             self.logger.error(message)
-            raise Exception(message)
+            raise Exception(message)  # TODO - Should not be raising Exception
 
         path_to_plugin = plugins[0].path_to_plugin
 

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -323,25 +323,3 @@ class LocalPluginsManager(object):
                 self.logger.exception(ex)
 
         self._start_multiple_plugins(new_plugins)
-
-    def pause_plugin(self, unique_name):
-        """Pause a plugin. Not Used yet."""
-        plugin = self.registry.get_plugin(unique_name)
-
-        if plugin is None:
-            self.logger.warning("Plugin %s is not loaded.", unique_name)
-            return
-
-        if plugin.status == "RUNNING":
-            plugin.status = "PAUSED"
-
-    def unpause_plugin(self, unique_name):
-        """Unpause a plugin. Not Used yet."""
-        plugin = self.registry.get_plugin(unique_name)
-
-        if plugin is None:
-            self.logger.warning("Plugin %s is not loaded.", unique_name)
-            return
-
-        if plugin.status == "PAUSED":
-            plugin.status = "RUNNING"

--- a/src/app/test/local_plugins/manager_test.py
+++ b/src/app/test/local_plugins/manager_test.py
@@ -442,38 +442,6 @@ class LocalPluginsManagerTest(unittest.TestCase):
         )
         start_mock.assert_called_once_with([self.fake_plugin])
 
-    def test_pause_plugin_none(self):
-        self.registry.get_plugin = Mock(return_value=None)
-        self.manager.logger = Mock()
-        self.manager.pause_plugin("unique_name")
-        self.assertEqual(self.manager.logger.warning.call_count, 1)
-
-    def test_pause_plugin_not_running(self):
-        self.fake_plugin.status = "STOPPED"
-        self.manager.pause_plugin("unique_name")
-        self.assertEqual(self.fake_plugin.status, "STOPPED")
-
-    def test_pause_plugin_running(self):
-        self.fake_plugin.status = "RUNNING"
-        self.manager.pause_plugin("unique_name")
-        self.assertEqual(self.fake_plugin.status, "PAUSED")
-
-    def test_unpause_plugin_none(self):
-        self.registry.get_plugin = Mock(return_value=None)
-        self.manager.logger = Mock()
-        self.manager.unpause_plugin("unique_name")
-        self.assertTrue(self.manager.logger.warning.called)
-
-    def test_unpause_plugin_not_paused(self):
-        self.fake_plugin.status = "RUNNING"
-        self.manager.unpause_plugin("unique_name")
-        self.assertEqual(self.fake_plugin.status, "RUNNING")
-
-    def test_unpause_plugin_paused(self):
-        self.fake_plugin.status = "PAUSED"
-        self.manager.unpause_plugin("unique_name")
-        self.assertEqual(self.fake_plugin.status, "RUNNING")
-
     @patch("beer_garden.local_plugins.manager.System.find_unique")
     def test_mark_as_failed(self, find_system_mock):
         find_system_mock.return_value = self.system_mock

--- a/src/app/test/local_plugins/manager_test.py
+++ b/src/app/test/local_plugins/manager_test.py
@@ -1,189 +1,252 @@
-import unittest
+# -*- coding: utf-8 -*-
+import logging
 
-from box import Box
-from mock import call, patch, MagicMock, Mock, PropertyMock
+import pytest
+from brewtils.models import Instance, System
+from mock import call, Mock
 
 import beer_garden
 from beer_garden.errors import PluginStartupError
 from beer_garden.local_plugins.manager import LocalPluginsManager
 
 
-class LocalPluginsManagerTest(unittest.TestCase):
-    def setUp(self):
-        beer_garden.config = Box(default_box=True)
+@pytest.fixture
+def loader():
+    return Mock()
 
-        self.fake_plugin_loader = Mock()
-        self.fake_plugin_validator = Mock()
-        self.clients = MagicMock()
 
-        self.instance_mock = Mock(status="RUNNING")
-        type(self.instance_mock).name = PropertyMock(return_value="default")
-        self.system_mock = Mock(version="1.0.0", instances=[self.instance_mock])
-        type(self.system_mock).name = PropertyMock(return_value="system_name")
+@pytest.fixture
+def validator():
+    return Mock()
 
-        self.fake_plugin = Mock(
-            system=self.system_mock,
-            unique_name="unique_name",
-            path_to_plugin="path/name-0.0.1",
-            requirements=[],
-            entry_point="main.py",
-            plugin_args=[],
-            instance_name="default",
-            status="RUNNING",
-        )
 
-        self.registry = Mock(
-            get_plugin=Mock(return_value=self.fake_plugin),
-            get_unique_plugin_names=Mock(return_value=["system_name"]),
-            get_all_plugins=Mock(return_value=[self.fake_plugin]),
-            get_plugins_by_system=Mock(return_value=[self.fake_plugin]),
-        )
+@pytest.fixture
+def registry(plugin, bg_system):
+    return Mock(
+        get_plugin=Mock(return_value=plugin),
+        get_unique_plugin_names=Mock(return_value=[bg_system.name]),
+        get_all_plugins=Mock(return_value=[plugin]),
+        get_plugins_by_system=Mock(return_value=[plugin]),
+    )
 
-        self.manager = LocalPluginsManager(
-            self.fake_plugin_loader,
-            self.fake_plugin_validator,
-            self.registry,
-            self.clients,
-            shutdown_timeout=10,
-        )
 
-    def test_start_plugin_initializing(self):
-        self.fake_plugin.status = "INITIALIZING"
-        self.assertTrue(self.manager.start_plugin(self.fake_plugin))
-        self.fake_plugin.start.assert_called_once_with()
+@pytest.fixture
+def pika_client():
+    return Mock()
 
-    def test_start_plugin_running(self):
-        self.assertTrue(self.manager.start_plugin(self.fake_plugin))
-        self.assertFalse(self.fake_plugin.start.called)
 
-    def test_start_plugin_bad_state(self):
-        self.fake_plugin.status = "BAD STATUS"
-        self.assertRaises(
-            PluginStartupError, self.manager.start_plugin, self.fake_plugin
-        )
-        self.assertFalse(self.fake_plugin.start.called)
+@pytest.fixture
+def plugin(bg_system):
+    return Mock(
+        system=bg_system,
+        unique_name="unique_name",
+        path_to_plugin="path/name-0.0.1",
+        requirements=[],
+        entry_point="main.py",
+        plugin_args=[],
+        instance_name="default",
+        status="RUNNING",
+    )
 
-    @patch("beer_garden.local_plugins.manager.LocalPluginRunner")
-    def test_start_plugin_stopped(self, plugin_mock):
-        self.fake_plugin.status = "STOPPED"
+
+@pytest.fixture
+def manager(loader, validator, registry, pika_client):
+    return LocalPluginsManager(loader, validator, registry, {"pika": pika_client}, 1)
+
+
+# class TestLocalPluginsManager(object):
+# def setUp(self):
+#     beer_garden.config = Box(default_box=True)
+#
+#     self.fake_plugin_loader = Mock()
+#     self.fake_plugin_validator = Mock()
+#     self.clients = MagicMock()
+#
+#     self.instance_mock = Mock(status="RUNNING")
+#     type(self.instance_mock).name = PropertyMock(return_value="default")
+#     self.system_mock = Mock(version="1.0.0", instances=[self.instance_mock])
+#     type(self.system_mock).name = PropertyMock(return_value="system_name")
+#
+#     self.fake_plugin = Mock(
+#         system=self.system_mock,
+#         unique_name="unique_name",
+#         path_to_plugin="path/name-0.0.1",
+#         requirements=[],
+#         entry_point="main.py",
+#         plugin_args=[],
+#         instance_name="default",
+#         status="RUNNING",
+#     )
+#
+#     self.registry = Mock(
+#         get_plugin=Mock(return_value=self.fake_plugin),
+#         get_unique_plugin_names=Mock(return_value=["system_name"]),
+#         get_all_plugins=Mock(return_value=[self.fake_plugin]),
+#         get_plugins_by_system=Mock(return_value=[self.fake_plugin]),
+#     )
+#
+#     self.manager = LocalPluginsManager(
+#         self.fake_plugin_loader,
+#         self.fake_plugin_validator,
+#         self.registry,
+#         self.clients,
+#         shutdown_timeout=10,
+#     )
+
+
+class TestStartPlugin(object):
+    def test_initializing(self, manager, plugin):
+        plugin.status = "INITIALIZING"
+        assert manager.start_plugin(plugin) is True
+        assert plugin.start.called is True
+        assert plugin.status == "STARTING"
+
+    def test_running(self, manager, plugin):
+        assert manager.start_plugin(plugin) is True
+        assert plugin.start.called is False
+
+    def test_bad_status(self, manager, plugin):
+        plugin.status = "BAD STATUS"
+        with pytest.raises(PluginStartupError):
+            manager.start_plugin(plugin)
+
+        assert plugin.start.called is False
+
+    def test_stopped(self, monkeypatch, manager, plugin, registry):
+        plugin.status = "STOPPED"
+
         new_plugin = Mock()
-        plugin_mock.return_value = new_plugin
-
-        self.assertTrue(self.manager.start_plugin(self.fake_plugin))
-        self.assertEqual(0, self.fake_plugin.start.call_count)
-        self.registry.remove.assert_called_once_with(self.fake_plugin.unique_name)
-        self.registry.register_plugin.assert_called_once_with(new_plugin)
-        self.assertTrue(plugin_mock.called)
-        new_plugin.start.assert_called_once_with()
-
-    def test_stop_plugin(self):
-        self.fake_plugin.is_alive = Mock(return_value=False)
-
-        self.manager.stop_plugin(self.fake_plugin)
-        self.fake_plugin.stop.assert_called_once_with()
-        self.assertTrue(self.clients["pika"].publish_request.called)
-        self.assertTrue(self.fake_plugin.join.called)
-        self.assertFalse(self.fake_plugin.kill.called)
-
-    def test_stop_plugin_already_stopped(self):
-        self.fake_plugin.status = "STOPPED"
-        self.manager.stop_plugin(self.fake_plugin)
-        self.assertEqual(self.fake_plugin.stop.call_count, 0)
-
-    def test_stop_plugin_unknown_status(self):
-        self.fake_plugin.status = "UNKNOWN"
-        self.manager.stop_plugin(self.fake_plugin)
-        self.fake_plugin.stop.assert_called_once_with()
-
-    def test_stop_plugin_exception(self):
-        self.fake_plugin.stop = Mock(side_effect=Exception)
-        self.fake_plugin.is_alive = Mock(return_value=True)
-
-        self.manager.stop_plugin(self.fake_plugin)
-        self.assertTrue(self.fake_plugin.kill.called)
-        self.assertFalse(self.fake_plugin.join.called)
-        self.assertEqual("DEAD", self.fake_plugin.status)
-
-    def test_unsuccessful_stop_plugin(self):
-        self.fake_plugin.is_alive = Mock(return_value=True)
-
-        self.manager.stop_plugin(self.fake_plugin)
-        self.assertTrue(self.fake_plugin.kill.called)
-        self.assertTrue(self.fake_plugin.join.called)
-        self.assertEqual("DEAD", self.fake_plugin.status)
-
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.stop_plugin")
-    def test_restart(self, stop_mock, start_mock):
-        self.manager.restart_plugin(self.fake_plugin)
-        stop_mock.assert_called_once_with(self.fake_plugin)
-        start_mock.assert_called_once_with(self.fake_plugin)
-
-    def test_reload_system(self):
-        self.fake_plugin.status = "STOPPED"
-        self.fake_plugin_validator.validate_plugin = Mock(return_value=True)
-
-        self.manager.reload_system(
-            self.fake_plugin.system.name, self.fake_plugin.system.version
-        )
-        self.registry.remove.assert_called_with(self.fake_plugin.unique_name)
-        self.fake_plugin_loader.load_plugin.assert_called_with(
-            self.fake_plugin.path_to_plugin
+        monkeypatch.setattr(
+            beer_garden.local_plugins.manager,
+            "LocalPluginRunner",
+            Mock(return_value=new_plugin),
         )
 
-    def test_reload_system_none(self):
-        self.registry.get_plugins_by_system = Mock(return_value=[])
-        self.assertRaises(Exception, self.manager.reload_system, "name", "version")
+        assert manager.start_plugin(plugin) is True
 
-    def test_reload_system_fail_validation(self):
-        self.fake_plugin_validator.validate_plugin = Mock(return_value=False)
-        self.assertRaises(Exception, self.manager.reload_system, "name", "version")
+        assert plugin.start.called is False
+        assert new_plugin.start.called is True
+        assert new_plugin.status == "STARTING"
 
-    def test_reload_system_running(self):
-        self.fake_plugin.status = "RUNNING"
-        self.fake_plugin_validator.validate_plugin = Mock(return_value=True)
-        self.assertRaises(Exception, self.manager.reload_system, "name", "version")
+        registry.remove.assert_called_once_with(plugin.unique_name)
+        registry.register_plugin.assert_called_once_with(new_plugin)
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._start_multiple_plugins"
-    )
-    def test_start_all_plugins(self, start_multiple_mock):
-        self.manager.start_all_plugins()
-        start_multiple_mock.assert_called_once_with([self.fake_plugin])
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    def test_start_multiple_plugins_empty(self, start_mock):
-        self.manager._start_multiple_plugins([])
-        self.assertEqual(start_mock.call_count, 0)
+class TestStopPlugin(object):
+    def test_running(self, manager, plugin, pika_client):
+        plugin.is_alive.return_value = False
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    def test_start_multiple_plugins_no_requirements(self, start_mock):
-        fake_plugin_2 = Mock(
-            system=self.system_mock,
+        manager.stop_plugin(plugin)
+        assert plugin.status == "STOPPING"
+        assert pika_client.publish_request.called is True
+        assert plugin.stop.called is True
+        assert plugin.join.called is True
+        assert plugin.kill.called is False
+
+    def test_stopped(self, manager, plugin, pika_client):
+        plugin.is_alive.return_value = False
+        plugin.status = "STOPPED"
+
+        manager.stop_plugin(plugin)
+        assert plugin.status == "STOPPED"
+        assert pika_client.publish_request.called is False
+        assert plugin.stop.called is False
+        assert plugin.join.called is False
+        assert plugin.kill.called is False
+
+    def test_unknown(self, manager, plugin, pika_client):
+        plugin.is_alive.return_value = False
+        plugin.status = "UNKNOWN"
+
+        manager.stop_plugin(plugin)
+        assert plugin.status == "UNKNOWN"
+        assert pika_client.publish_request.called is True
+        assert plugin.stop.called is True
+        assert plugin.join.called is True
+        assert plugin.kill.called is False
+
+    def test_exception(self, manager, plugin, pika_client):
+        plugin.is_alive.return_value = True
+        plugin.stop.side_effect = Exception()
+
+        manager.stop_plugin(plugin)
+        assert plugin.status == "DEAD"
+        assert pika_client.publish_request.called is False
+        assert plugin.stop.called is True
+        assert plugin.join.called is False
+        assert plugin.kill.called is True
+
+    def test_unsuccessful(self, manager, plugin, pika_client):
+        plugin.is_alive.return_value = True
+
+        manager.stop_plugin(plugin)
+        assert plugin.status == "DEAD"
+        assert pika_client.publish_request.called is True
+        assert plugin.stop.called is True
+        assert plugin.join.called is True
+        assert plugin.kill.called is True
+
+
+class TestRestartPlugin(object):
+    def test_restart(self, monkeypatch, manager, plugin):
+        start_mock = Mock()
+        stop_mock = Mock()
+        monkeypatch.setattr(manager, "start_plugin", start_mock)
+        monkeypatch.setattr(manager, "stop_plugin", stop_mock)
+
+        manager.restart_plugin(plugin)
+        assert stop_mock.called is True
+        assert start_mock.called is True
+
+
+class TestReloadSystem(object):
+    def test_none(self, manager, registry, plugin):
+        registry.get_plugins_by_system.return_value = []
+        with pytest.raises(Exception):
+            manager.reload_system(plugin.system.name, plugin.system.version)
+
+    def test_fail_validation(self, manager, validator, plugin):
+        validator.validate_plugin.return_value = False
+        with pytest.raises(Exception):
+            manager.reload_system(plugin.system.name, plugin.system.version)
+
+    def test_running(self, manager, validator, plugin):
+        validator.validate_plugin.return_value = True
+        with pytest.raises(Exception):
+            manager.reload_system(plugin.system.name, plugin.system.version)
+
+    def test_stopped(self, manager, validator, registry, loader, plugin):
+        plugin.status = "STOPPED"
+        validator.validate_plugin.return_value = True
+
+        manager.reload_system(plugin.system.name, plugin.system.version)
+        registry.remove.assert_called_once_with(plugin.unique_name)
+        loader.load_plugin.assert_called_once_with(plugin.path_to_plugin)
+
+
+def test_start_all_plugins(monkeypatch, manager, plugin):
+    start_mock = Mock()
+    monkeypatch.setattr(manager, "_start_multiple_plugins", start_mock)
+
+    manager.start_all_plugins()
+    start_mock.assert_called_once_with([plugin])
+
+
+class TestStartMultiple(object):
+    @pytest.fixture(autouse=True)
+    def mock_getter(self, monkeypatch, manager):
+        monkeypatch.setattr(manager, "_get_all_system_names", Mock(return_value=[]))
+        monkeypatch.setattr(manager, "_get_running_system_names", Mock(return_value=[]))
+        monkeypatch.setattr(manager, "_get_failed_system_names", Mock(return_value=[]))
+
+    @pytest.fixture
+    def system_2(self):
+        return System(name="system_name_2")
+
+    @pytest.fixture
+    def plugin_2(self, system_2):
+        return Mock(
+            system=system_2,
             unique_name="unique_name2",
             path_to_plugin="path/name-0.0.1",
             requirements=[],
@@ -193,284 +256,199 @@ class LocalPluginsManagerTest(unittest.TestCase):
             status="RUNNING",
         )
 
-        self.manager._start_multiple_plugins([self.fake_plugin, fake_plugin_2])
-        start_mock.assert_has_calls(
-            [call(self.fake_plugin), call(fake_plugin_2)], any_order=True
-        )
+    def test_empty(self, monkeypatch, manager):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "start_plugin", start_mock)
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager._mark_as_failed")
-    def test_start_multiple_plugins_invalid_requirements(self, fail_mock):
-        self.fake_plugin.requirements = ["DNE"]
-        self.manager._start_multiple_plugins([self.fake_plugin])
-        fail_mock.assert_called_once_with(self.fake_plugin)
+        manager._start_multiple_plugins([])
+        assert start_mock.called is False
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=["system_name", "system_name_2"]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    def test_start_multiple_plugins(self, start_mock):
-        system_mock_2 = Mock(version="1.0.0", instances=[Mock(name="default")])
-        type(system_mock_2).name = PropertyMock(return_value="system_name_2")
-        fake_plugin_2 = Mock(
-            system=system_mock_2,
-            unique_name="unique_name2",
-            path_to_plugin="path/name-0.0.1",
-            requirements=["system_name"],
-            entry_point="main.py",
-            plugin_args=[],
-            instance_name="default2",
-            status="RUNNING",
-        )
+    def test_no_requirements(self, monkeypatch, manager, plugin, plugin_2, bg_system):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "start_plugin", start_mock)
 
-        self.manager._start_multiple_plugins([fake_plugin_2, self.fake_plugin])
-        start_mock.assert_has_calls(
-            [call(self.fake_plugin), call(fake_plugin_2)], any_order=True
-        )
+        manager._start_multiple_plugins([plugin, plugin_2])
+        start_mock.assert_has_calls([call(plugin), call(plugin_2)], any_order=True)
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=["system_name", "system_name_2"]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    def test_start_multiple_plugins_skip_first(self, start_mock):
+    def test_invalid_requirements(self, monkeypatch, manager, plugin):
+        fail_mock = Mock()
+        monkeypatch.setattr(manager, "_mark_as_failed", fail_mock)
 
-        system_mock_2 = Mock(version="1.0.0", instances=[Mock(name="default")])
-        type(system_mock_2).name = PropertyMock(return_value="system_name_2")
-        fake_plugin_2 = Mock(
-            system=system_mock_2,
-            unique_name="unique_name2",
-            path_to_plugin="path/name-0.0.1",
-            requirements=["system_name"],
-            entry_point="main.py",
-            plugin_args=[],
-            instance_name="default2",
-            status="RUNNING",
-        )
+        plugin.requirements = ["DNE"]
 
-        self.manager._start_multiple_plugins([self.fake_plugin, fake_plugin_2])
-        start_mock.assert_has_calls(
-            [call(self.fake_plugin), call(fake_plugin_2)], any_order=True
-        )
+        manager._start_multiple_plugins([plugin])
+        fail_mock.assert_called_once_with(plugin)
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=["system_name", "system_name_2"]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=["system_name"]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    def test_start_multiple_plugins_requirement_already_running(self, start_mock):
-
-        system_mock_2 = Mock(version="1.0.0", instances=[Mock(name="default")])
-        type(system_mock_2).name = PropertyMock(return_value="system_name_2")
-        fake_plugin_2 = Mock(
-            system=system_mock_2,
-            unique_name="unique_name2",
-            path_to_plugin="path/name-0.0.1",
-            requirements=["system_name"],
-            entry_point="main.py",
-            plugin_args=[],
-            instance_name="default2",
-            status="RUNNING",
-        )
-
-        self.manager._start_multiple_plugins([fake_plugin_2])
-        start_mock.assert_has_calls([call(fake_plugin_2)], any_order=True)
-
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_all_system_names",
-        Mock(return_value=["system_name", "system_name_2"]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_running_system_names",
-        Mock(return_value=[]),
-    )
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._get_failed_system_names",
-        Mock(return_value=[]),
-    )
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager._mark_as_failed")
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.start_plugin")
-    def test_start_multiple_plugins_failed_requirement_start(
-        self, start_mock, fail_mock
+    def test_skip_first(
+        self, monkeypatch, manager, bg_system, system_2, plugin, plugin_2
     ):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "start_plugin", start_mock)
 
-        system_mock_2 = Mock(version="1.0.0", instances=[Mock(name="default")])
-        type(system_mock_2).name = PropertyMock(return_value="system_name_2")
-        fake_plugin_2 = Mock(
-            system=system_mock_2,
-            unique_name="unique_name2",
-            path_to_plugin="path/name-0.0.1",
-            requirements=["system_name"],
-            entry_point="main.py",
-            plugin_args=[],
-            instance_name="default2",
-            status="RUNNING",
+        manager._get_all_system_names.return_value = [bg_system.name, system_2.name]
+
+        plugin_2.requirements = [bg_system.name]
+
+        manager._start_multiple_plugins([plugin, plugin_2])
+        start_mock.assert_has_calls([call(plugin), call(plugin_2)], any_order=True)
+
+    def test_requirement_already_running(
+        self, monkeypatch, manager, bg_system, plugin_2
+    ):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "start_plugin", start_mock)
+
+        manager._get_all_system_names.return_value = [
+            bg_system.name,
+            plugin_2.system.name,
+        ]
+        manager._get_running_system_names.return_value = [bg_system.name]
+
+        plugin_2.requirements = [bg_system.name]
+
+        manager._start_multiple_plugins([plugin_2])
+        start_mock.assert_has_calls([call(plugin_2)], any_order=True)
+
+    def test_failed_requirement_start(
+        self, monkeypatch, manager, bg_system, plugin, plugin_2
+    ):
+        start_mock = Mock(return_value=False)
+        monkeypatch.setattr(manager, "start_plugin", start_mock)
+        fail_mock = Mock()
+        monkeypatch.setattr(manager, "_mark_as_failed", fail_mock)
+
+        manager._get_all_system_names.return_value = [
+            bg_system.name,
+            plugin_2.system.name,
+        ]
+
+        plugin_2.requirements = [bg_system.name]
+
+        manager._start_multiple_plugins([plugin, plugin_2])
+        start_mock.assert_called_once_with(plugin)
+        fail_mock.assert_called_once_with(plugin_2)
+
+
+def test_get_all_system_names(monkeypatch, manager, bg_system):
+    system_mock = Mock()
+    system_mock.objects.return_value = [bg_system]
+    monkeypatch.setattr(beer_garden.local_plugins.manager, "System", system_mock)
+
+    assert manager._get_all_system_names() == [bg_system.name]
+
+
+class TestStopAllPlugins(object):
+    def test_empty(self, monkeypatch, manager, registry, plugin):
+        stop_mock = Mock()
+        monkeypatch.setattr(manager, "stop_plugin", stop_mock)
+
+        registry.get_all_plugins.return_value = []
+
+        manager.stop_all_plugins()
+        assert stop_mock.called is False
+
+    def test_one_running(self, monkeypatch, manager, plugin):
+        stop_mock = Mock()
+        monkeypatch.setattr(manager, "stop_plugin", stop_mock)
+
+        manager.stop_all_plugins()
+        stop_mock.assert_called_once_with(plugin)
+
+    def test_exception(self, monkeypatch, caplog, manager, registry, plugin):
+        stop_mock = Mock(side_effect=[Exception(), None])
+        monkeypatch.setattr(manager, "stop_plugin", stop_mock)
+
+        registry.get_all_plugins.return_value = [plugin, plugin]
+
+        with caplog.at_level(logging.WARNING):
+            manager.stop_all_plugins()
+
+        stop_mock.assert_has_calls([call(plugin), call(plugin)])
+        assert len(caplog.records) == 2
+        assert caplog.records[0].levelno == logging.ERROR
+        assert caplog.records[1].levelno == logging.ERROR
+
+
+class TestScanPluginPath(object):
+    def test_no_change(self, monkeypatch, manager, loader, registry, plugin):
+        monkeypatch.setattr(manager, "_start_multiple_plugins", Mock())
+
+        loader.scan_plugin_path.return_value = [plugin.path_to_plugin]
+        registry.get_all_plugins.return_value = [plugin]
+
+        manager.scan_plugin_path()
+        assert loader.load_plugin.called is False
+
+    def test_one_new(self, monkeypatch, manager, loader, registry, plugin):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "_start_multiple_plugins", start_mock)
+
+        loader.scan_plugin_path.return_value = [plugin.path_to_plugin]
+        loader.load_plugin.return_value = [plugin]
+        registry.get_all_plugins.return_value = []
+
+        manager.scan_plugin_path()
+        loader.load_plugin.assert_called_once_with(plugin.path_to_plugin)
+        start_mock.assert_called_once_with([plugin])
+
+    def test_two_new_could_not_load_one(
+        self, monkeypatch, manager, loader, registry, plugin
+    ):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "_start_multiple_plugins", start_mock)
+
+        loader.scan_plugin_path.return_value = [plugin.path_to_plugin, "path/tw-0.0.1"]
+        loader.load_plugin.side_effect = [[plugin], []]
+        registry.get_all_plugins.return_value = []
+
+        manager.scan_plugin_path()
+        loader.load_plugin.assert_has_calls(
+            [call(plugin.path_to_plugin), call("path/tw-0.0.1")], any_order=True
         )
+        start_mock.assert_called_once_with([plugin])
 
-        start_mock.return_value = False
+    def test_one_exception(self, monkeypatch, manager, loader, registry, plugin):
+        start_mock = Mock()
+        monkeypatch.setattr(manager, "_start_multiple_plugins", start_mock)
 
-        self.manager._start_multiple_plugins([self.fake_plugin, fake_plugin_2])
-        start_mock.assert_called_once_with(self.fake_plugin)
-        fail_mock.assert_called_once_with(fake_plugin_2)
+        loader.scan_plugin_path.return_value = [plugin.path_to_plugin, "path/tw-0.0.1"]
+        loader.load_plugin.side_effect = [[plugin], Exception()]
+        registry.get_all_plugins.return_value = []
 
-    @patch("beer_garden.local_plugins.manager.System")
-    def test_get_all_system_names(self, system_mock):
-        system_mock.objects.return_value = [self.system_mock]
-        self.assertEqual([self.system_mock.name], self.manager._get_all_system_names())
-
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.stop_plugin")
-    def test_stop_all_plugins(self, stop_mock):
-        self.manager.stop_all_plugins()
-        stop_mock.assert_called_once_with(self.fake_plugin)
-
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.stop_plugin")
-    def test_stop_all_plugins_empty(self, stop_mock):
-        self.registry.get_all_plugins = Mock(return_value=[])
-        self.manager.stop_all_plugins()
-        self.assertEqual(stop_mock.call_count, 0)
-
-    @patch("beer_garden.local_plugins.manager.LocalPluginsManager.stop_plugin")
-    def test_stop_all_plugins_exception(self, stop_mock):
-        stop_mock.side_effect = [Exception(), None]
-        self.manager.logger = Mock()
-        self.registry.get_all_plugins = Mock(
-            return_value=[self.fake_plugin, self.fake_plugin]
+        manager.scan_plugin_path()
+        loader.load_plugin.assert_has_calls(
+            [call(plugin.path_to_plugin), call("path/tw-0.0.1")], any_order=True
         )
+        start_mock.assert_called_once_with([plugin])
 
-        self.manager.stop_all_plugins()
-        self.assertTrue(self.manager.logger.exception.called)
-        self.assertTrue(self.manager.logger.error.called)
-        stop_mock.assert_has_calls([call(self.fake_plugin), call(self.fake_plugin)])
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._start_multiple_plugins",
-        Mock(),
-    )
-    def test_scan_plugin_path_no_change(self):
-        self.fake_plugin_loader.scan_plugin_path = Mock(
-            return_value=[self.fake_plugin.path_to_plugin]
-        )
-        self.registry.get_all_plugins = Mock(return_value=[self.fake_plugin])
-        self.manager.scan_plugin_path()
-        self.assertEqual(0, self.fake_plugin_loader.load_plugin.call_count)
+def test_mark_as_failed(monkeypatch, manager, plugin, bg_instance):
+    bg_system_mock = Mock(instances=[bg_instance])
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._start_multiple_plugins"
-    )
-    def test_scan_plugin_path_one_new(self, start_mock):
-        self.fake_plugin_loader.scan_plugin_path = Mock(
-            return_value=[self.fake_plugin.path_to_plugin]
-        )
-        self.fake_plugin_loader.load_plugin = Mock(return_value=[self.fake_plugin])
-        self.registry.get_all_plugins = Mock(return_value=[])
+    system_mock = Mock()
+    system_mock.find_unique.return_value = bg_system_mock
+    monkeypatch.setattr(beer_garden.local_plugins.manager, "System", system_mock)
 
-        self.manager.scan_plugin_path()
-        self.fake_plugin_loader.load_plugin.assert_called_once_with(
-            self.fake_plugin.path_to_plugin
-        )
-        start_mock.assert_called_once_with([self.fake_plugin])
+    manager._mark_as_failed(plugin)
+    assert bg_instance.status == "DEAD"
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._start_multiple_plugins"
-    )
-    def test_scan_plugin_path_two_new_could_not_load_one(self, start_mock):
-        self.fake_plugin_loader.scan_plugin_path = Mock(
-            return_value=[self.fake_plugin.path_to_plugin, "path/tw-0.0.1"]
-        )
-        self.fake_plugin_loader.load_plugin = Mock(side_effect=[[self.fake_plugin], []])
-        self.registry.get_all_plugins = Mock(return_value=[])
 
-        self.manager.scan_plugin_path()
-        self.fake_plugin_loader.load_plugin.assert_has_calls(
-            [call(self.fake_plugin.path_to_plugin), call("path/tw-0.0.1")],
-            any_order=True,
-        )
-        start_mock.assert_called_once_with([self.fake_plugin])
+class TestGetFailedSystemNames(object):
+    def test_one_failed(self, monkeypatch, manager, bg_system):
+        bg_system.instances[0].status = "DEAD"
 
-    @patch(
-        "beer_garden.local_plugins.manager.LocalPluginsManager._start_multiple_plugins"
-    )
-    def test_scan_plugin_path_one_exception(self, start_mock):
-        self.fake_plugin_loader.scan_plugin_path = Mock(
-            return_value=[self.fake_plugin.path_to_plugin, "path/tw-0.0.1"]
-        )
-        self.fake_plugin_loader.load_plugin = Mock(
-            side_effect=[[self.fake_plugin], Exception]
-        )
-        self.registry.get_all_plugins = Mock(return_value=[])
+        system_mock = Mock()
+        system_mock.objects.return_value = [bg_system]
+        monkeypatch.setattr(beer_garden.local_plugins.manager, "System", system_mock)
 
-        self.manager.scan_plugin_path()
-        self.fake_plugin_loader.load_plugin.assert_has_calls(
-            [call(self.fake_plugin.path_to_plugin), call("path/tw-0.0.1")],
-            any_order=True,
-        )
-        start_mock.assert_called_once_with([self.fake_plugin])
+        assert manager._get_failed_system_names() == [bg_system.name]
 
-    @patch("beer_garden.local_plugins.manager.System.find_unique")
-    def test_mark_as_failed(self, find_system_mock):
-        find_system_mock.return_value = self.system_mock
+    def test_one_failed_one_running(self, monkeypatch, manager, bg_system):
+        # Add one dead instance to system with one running one
+        bg_system.instances.append(Instance(status="DEAD"))
 
-        self.manager._mark_as_failed(self.fake_plugin)
-        self.assertEqual(self.instance_mock.status, "DEAD")
-        self.assertTrue(self.system_mock.deep_save.called)
+        system_mock = Mock()
+        system_mock.objects.return_value = [bg_system]
+        monkeypatch.setattr(beer_garden.local_plugins.manager, "System", system_mock)
 
-    @patch("beer_garden.local_plugins.manager.System.objects")
-    def test_get_failed_system_names(self, objects_mock):
-
-        # Construct another fake system with all dead instances
-        instance_mock_2 = Mock(status="DEAD")
-        type(instance_mock_2).name = PropertyMock(return_value="default")
-        system_mock_2 = Mock(version="1.0.0", instances=[instance_mock_2])
-        type(system_mock_2).name = PropertyMock(return_value="dead_system")
-
-        objects_mock.return_value = [self.system_mock, system_mock_2]
-
-        failed_plugins = self.manager._get_failed_system_names()
-        self.assertEqual(failed_plugins, ["dead_system"])
-
-    @patch("beer_garden.local_plugins.manager.System.objects")
-    def test_get_failed_system_names_one_live_instance(self, objects_mock):
-        instance_mock_2 = Mock(status="DEAD")
-        type(instance_mock_2).name = PropertyMock(return_value="default_2")
-        self.system_mock.instances = [self.instance_mock, instance_mock_2]
-
-        objects_mock.return_value = [self.system_mock]
-
-        failed_plugins = self.manager._get_failed_system_names()
-        self.assertFalse(failed_plugins)
+        assert manager._get_failed_system_names() == []

--- a/src/app/test/local_plugins/registry_test.py
+++ b/src/app/test/local_plugins/registry_test.py
@@ -1,123 +1,130 @@
-import unittest
-
+# -*- coding: utf-8 -*-
+import pytest
 from mock import Mock, PropertyMock
+from pytest_lazyfixture import lazy_fixture
 
 from beer_garden.local_plugins.registry import LocalPluginRegistry
 
 
-class RegistryTest(unittest.TestCase):
-    def setUp(self):
-        self.registry = LocalPluginRegistry()
+@pytest.fixture
+def system_1():
+    sys1 = Mock(version="0.0.1")
+    type(sys1).name = PropertyMock(return_value="plugin1")
+    return sys1
 
-        self.fake_system_1 = Mock(version="0.0.1")
-        self.fake_system_2 = Mock(version="0.0.1")
-        type(self.fake_system_1).name = PropertyMock(return_value="plugin1")
-        type(self.fake_system_2).name = PropertyMock(return_value="plugin2")
 
-        self.mock_plugin_1 = Mock(
-            system=self.fake_system_1,
-            unique_name="plugin1[inst1]-0.0.1",
-            instance_name="inst1",
-            status="INITIALIZING",
-        )
-        self.mock_plugin_2 = Mock(
-            system=self.fake_system_2,
-            unique_name="plugin2[inst1]-0.0.1",
-            instance_name="inst1",
-            status="INITIALIZING",
-        )
-        self.mock_plugin_3 = Mock(
-            system=self.fake_system_2,
-            unique_name="plugin2[inst2]-0.0.1",
-            instance_name="inst2",
-            status="INITIALIZING",
-        )
+@pytest.fixture
+def system_2():
+    sys2 = Mock(version="0.0.1")
+    type(sys2).name = PropertyMock(return_value="plugin2")
+    return sys2
 
-        self.registry._registry = [
-            self.mock_plugin_1,
-            self.mock_plugin_2,
-            self.mock_plugin_3,
+
+@pytest.fixture
+def plugin_1(system_1):
+    return Mock(
+        system=system_1,
+        unique_name="plugin1[inst1]-0.0.1",
+        instance_name="inst1",
+        status="INITIALIZING",
+    )
+
+
+@pytest.fixture
+def plugin_2(system_2):
+    return Mock(
+        system=system_2,
+        unique_name="plugin2[inst1]-0.0.1",
+        instance_name="inst1",
+        status="INITIALIZING",
+    )
+
+
+@pytest.fixture
+def plugin_3(system_2):
+    return Mock(
+        system=system_2,
+        unique_name="plugin2[inst2]-0.0.1",
+        instance_name="inst2",
+        status="INITIALIZING",
+    )
+
+
+@pytest.fixture
+def registry(plugin_1, plugin_2, plugin_3):
+    registry = LocalPluginRegistry()
+    registry._registry = [plugin_1, plugin_2, plugin_3]
+    return registry
+
+
+class TestRegistry(object):
+    def test_get_all_plugins(self, registry, plugin_1, plugin_2, plugin_3):
+        assert registry.get_all_plugins() == [plugin_1, plugin_2, plugin_3]
+
+    def test_get_unique_plugin_names(self, registry):
+        assert registry.get_unique_plugin_names() == {"plugin1", "plugin2"}
+
+    @pytest.mark.parametrize(
+        "name,plugin",
+        [
+            ("plugin1[inst1]-0.0.1", lazy_fixture("plugin_1")),
+            ("plugin2[inst1]-0.0.1", lazy_fixture("plugin_2")),
+            ("plugin2[inst2]-0.0.1", lazy_fixture("plugin_3")),
+        ],
+    )
+    def test_get_plugin(self, registry, name, plugin):
+        assert registry.get_plugin(name) == plugin
+
+    def test_get_plugin_none(self, registry):
+        assert registry.get_plugin("bad") is None
+
+    def test_get_plugins_by_system_none(self, registry):
+        assert registry.get_plugins_by_system("plugin3", "0.0.1") == []
+
+    def test_get_plugins_by_system_one(self, registry, plugin_1):
+        assert registry.get_plugins_by_system("plugin1", "0.0.1") == [plugin_1]
+
+    def test_get_plugins_by_system_multiple(self, registry, plugin_2, plugin_3):
+        assert registry.get_plugins_by_system("plugin2", "0.0.1") == [
+            plugin_2,
+            plugin_3,
         ]
 
-    def test_get_all_plugins(self):
-        all_plugins = self.registry.get_all_plugins()
-        self.assertEqual(3, len(all_plugins))
-        self.assertIn(self.mock_plugin_1, all_plugins)
-        self.assertIn(self.mock_plugin_2, all_plugins)
+    def test_remove(self, registry, plugin_1):
+        registry.remove(plugin_1.unique_name)
+        assert plugin_1 not in registry._registry
+        assert len(registry._registry) == 2
 
-    def test_get_unique_plugin_names(self):
-        unique_names = self.registry.get_unique_plugin_names()
-        self.assertEqual(2, len(unique_names))
-        self.assertIn("plugin1", unique_names)
-        self.assertIn("plugin2", unique_names)
+    def test_remove_missing(self, registry):
+        registry.remove("bad_name")
+        assert len(registry._registry) == 3
 
-    def test_get_plugin(self):
-        self.assertEqual(
-            self.mock_plugin_1, self.registry.get_plugin("plugin1[inst1]-0.0.1")
-        )
-
-    def test_get_plugin_none(self):
-        self.assertIsNone(self.registry.get_plugin("bad_name"))
-
-    def test_get_plugins_by_system_none(self):
-        plugins = self.registry.get_plugins_by_system("plugin3", "0.0.1")
-        self.assertEqual(0, len(plugins))
-
-    def test_get_plugins_by_system_one(self):
-        plugins = self.registry.get_plugins_by_system("plugin1", "0.0.1")
-        self.assertEqual(1, len(plugins))
-        self.assertIn(self.mock_plugin_1, plugins)
-
-    def test_get_plugins_by_system_multiple(self):
-        plugins = self.registry.get_plugins_by_system("plugin2", "0.0.1")
-        self.assertEqual(2, len(plugins))
-        self.assertIn(self.mock_plugin_2, plugins)
-        self.assertIn(self.mock_plugin_3, plugins)
-
-    def test_remove(self):
-        self.registry.remove(self.mock_plugin_1.unique_name)
-        self.assertEqual(2, len(self.registry._registry))
-        self.assertNotIn(self.mock_plugin_1, self.registry._registry)
-
-    def test_remove_not_there(self):
-        self.registry.remove("bad_name")
-        self.assertEqual(3, len(self.registry._registry))
-
-    def test_register_plugin(self):
+    def test_register_plugin(self, registry, system_1):
         mock_plugin = Mock(
-            system=self.fake_system_1,
+            system=system_1,
             unique_name="plugin1[inst2]-0.0.1",
             instance_name="inst2",
             status="INITIALIZING",
         )
 
-        self.assertEqual(3, len(self.registry._registry))
-        self.registry.register_plugin(mock_plugin)
-        self.assertEqual(4, len(self.registry._registry))
-        self.assertIn(mock_plugin, self.registry._registry)
+        registry.register_plugin(mock_plugin)
+        assert mock_plugin in registry._registry
+        assert len(registry._registry) == 4
 
-    def test_register_plugin_already_there(self):
-        self.assertEqual(3, len(self.registry._registry))
-        self.registry.register_plugin(self.mock_plugin_1)
-        self.assertEqual(3, len(self.registry._registry))
+    def test_register_existing(self, registry, plugin_1):
+        registry.register_plugin(plugin_1)
+        assert plugin_1 in registry._registry
+        assert len(registry._registry) == 3
 
-    def test_plugin_exists_true(self):
-        self.assertTrue(
-            self.registry.plugin_exists(
-                plugin_name=self.mock_plugin_1.system.name,
-                plugin_version=self.mock_plugin_1.system.version,
-            )
+    def test_plugin_exists_true(self, registry, system_1):
+        exists = registry.plugin_exists(
+            plugin_name=system_1.name, plugin_version=system_1.version
         )
+        assert exists is True
 
-    def test_plugin_exists_false(self):
-        self.assertFalse(
-            self.registry.plugin_exists(
-                plugin_name="bad_plugin", plugin_version="0.0.1"
-            )
-        )
+    def test_plugin_exists_false(self, registry):
+        exists = registry.plugin_exists(plugin_name="bad", plugin_version="0.0.1")
+        assert exists is False
 
-    def test_get_unique_name(self):
-        self.assertEqual(
-            "echo[default]-0.0.1",
-            self.registry.get_unique_name("echo", "0.0.1", "default"),
-        )
+    def test_get_unique_name(self, registry):
+        assert registry.get_unique_name("echo", "1.0", "default") == "echo[default]-1.0"


### PR DESCRIPTION
This PR:

- Removes unused functionality in the `LocalPluginManager` relating to pausing and unpausing a plugin
- Converts tests for `LocalPluginManager` and `LocalPluginRegistry` to pytest