### PR TITLE
Setting the hostname of the rabbitmq container

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -84,6 +84,7 @@ services:
 
     rabbitmq:
         image: rabbitmq:management-alpine
+        hostname: rabbitmq
         networks:
             - bg-network
         environment:


### PR DESCRIPTION
This is part of the fix for #352. Rabbitmq uses the hostname when constructing its "node name" so the random hostname that docker assigns by default could may cause rabbit to get confused.