### PR TITLE
Linting

### DIFF
--- a/src/app/Makefile
+++ b/src/app/Makefile
@@ -85,8 +85,7 @@ format: ## Run black formatter in-line
 
 # Linting
 lint: ## check style with flake8
-	#flake8 $(MODULE_NAME) $(TEST_DIR)
-	flake8 $(MODULE_NAME)
+	flake8 $(MODULE_NAME) $(TEST_DIR)
 	black --check $(MODULE_NAME) $(TEST_DIR)
 
 

--- a/src/app/beer_garden/api/thrift/server.py
+++ b/src/app/beer_garden/api/thrift/server.py
@@ -14,7 +14,7 @@ import beer_garden.api.thrift
 class BartenderThriftServer(TThreadedServer, StoppableThread):
     """Thrift server that uses a ThreadPoolExecutor to process requests"""
 
-    # Amount of time (in seconds) after shutdown requested to wait for workers to finish processing
+    # Amount of time (in seconds) after shutdown requested to wait for workers to finish
     WORKER_TIMEOUT = 5
 
     def __init__(self, *args, **kwargs):
@@ -42,7 +42,7 @@ class BartenderThriftServer(TThreadedServer, StoppableThread):
         # Mark the thread as stopping
         StoppableThread.stop(self)
 
-        # Close the socket - this will kick us out of the self.trans.accept() call with an exception
+        # Close the socket - this will break self.trans.accept() call with an exception
         self.trans.close()
 
         # Wait some amount of time for all the futures to complete
@@ -50,10 +50,10 @@ class BartenderThriftServer(TThreadedServer, StoppableThread):
             self.futures, timeout=self.WORKER_TIMEOUT, return_when=ALL_COMPLETED
         )
 
-        # If there are still workers remaining after the timeout then we remove references to them.
-        # We need to do this because workers are daemons but concurrent.futures.thread adds a
-        # hook to join all workers with no timeout when shutting down. So any hung worker would
-        # prevent the application from shutting down.
+        # If there are still workers remaining after the timeout then we remove
+        # references to them. We need to do this because workers are daemons but
+        # concurrent.futures.thread adds a hook to join all workers with no timeout when
+        # shutting down. So any hung worker prevents the application from shutting down.
         if futures_status.not_done:
             self.logger.warning(
                 "There were still unfinished worker "
@@ -87,7 +87,7 @@ class BartenderThriftServer(TThreadedServer, StoppableThread):
 
 
 class WrappedTProcessor(TProcessor):
-    """Processor that fails gracefully if a handler method raises an unexpected exception"""
+    """Processor that gracefully handles unexpected exceptions"""
 
     def __init__(self, default_exception_name, default_exception_cls, *args, **kwargs):
         super(WrappedTProcessor, self).__init__(*args, **kwargs)

--- a/src/app/beer_garden/bg_utils/plugin_logging_loader.py
+++ b/src/app/beer_garden/bg_utils/plugin_logging_loader.py
@@ -40,7 +40,8 @@ class PluginLoggingLoader(object):
 
         :param filename: Filename of the plugin logging configuration to load
         :param level: A default level for the loggers
-        :param default_config: A default configuration to fallback on if no plugin log is present
+        :param default_config: A default configuration to fallback on if no plugin log
+        is present
         :return: A valid LoggingConfig object
         """
         config_from_file = cls._load_config_from_file(filename)
@@ -85,7 +86,7 @@ class PluginLoggingLoader(object):
 
     @classmethod
     def _parse_python_logging_config(cls, python_logging_config, level):
-        """Used to convert a python logging configuration into a plugin logging configuration.
+        """Convert a python logging configuration into a plugin logging configuration.
 
         :param python_logging_config:
         :param level:
@@ -115,8 +116,9 @@ class PluginLoggingLoader(object):
     def _parse_python_handlers(cls, handlers, level):
         """Convert python handlers into handlers that the plugins can understand.
 
-        Namely, this takes a python configuration of handlers, inspects class names/handler names
-        and returns only the ones that the bindings are responsible for implementing.
+        Namely, this takes a python configuration of handlers, inspects class
+        names/handler names and returns only the ones that the bindings are responsible
+        for implementing.
 
         :param handlers:
         :param level:

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -592,7 +592,8 @@ _DB_SPEC = {
                 "info": {
                     "type": "int",
                     "default": 15,
-                    "description": "Number of minutes to wait before deleting INFO request",
+                    "description": "Number of minutes to wait before deleting "
+                    "INFO requests (negative number for never)",
                     "previous_names": ["info_request_ttl"],
                     "alt_env_names": ["INFO_REQUEST_TTL"],
                 },
@@ -924,7 +925,8 @@ _PLUGIN_SPEC = {
         "status_timeout": {
             "type": "int",
             "default": 30,
-            "description": "Amount of time to wait before marking a plugin as unresponsive",
+            "description": "Amount of time to wait before marking a plugin as"
+            "unresponsive",
             "previous_names": ["plugin_status_timeout "],
         },
         "local": {
@@ -967,7 +969,8 @@ _PLUGIN_SPEC = {
                         "shutdown": {
                             "type": "int",
                             "default": 10,
-                            "description": "Seconds to wait for a plugin to stop gracefully",
+                            "description": "Seconds to wait for a plugin to stop"
+                            "gracefully",
                             "previous_names": ["plugin_shutdown_timeout"],
                             "alt_env_names": ["PLUGIN_SHUTDOWN_TIMEOUT"],
                         },

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -423,9 +423,9 @@ class System(MongoModel, Document):
 
         Mongoengine cannot save bidirectional references in one shot because
         'You can only reference documents once they have been saved to the database'
-        So we must mangle the System to have no Commands, save it, save the individual Commands
-        with the System reference, update the System with the Command list, and then save the
-        System again
+        So we must mangle the System to have no Commands, save it, save the individual
+        Commands with the System reference, update the System with the Command list, and
+        then save the System again
         """
 
         # Note if this system is already saved
@@ -436,14 +436,15 @@ class System(MongoModel, Document):
         temp_instances = self.instances
 
         try:
-            # Before we start saving things try to make sure everything will validate correctly
-            # This means multiple passes through the collections, but we want to minimize the
-            # chances of having to bail out after saving something since we don't have transactions
+            # Before we start saving things try to make sure everything will validate
+            # correctly. This means multiple passes through the collections, but we want
+            # to minimize the chances of having to bail out after saving something since
+            # we don't have transactions
 
-            # However, we have to start by saving the System. We need it in the database so the
-            # Commands will validate against it correctly (the ability to undo this is why we
-            # saved off delete_on_error earlier) The reference lists must be empty or else we
-            # encounter the bidirectional reference issue
+            # However, we have to start by saving the System. We need it in the database
+            # so the Commands will validate against it correctly (the ability to undo
+            # this is why we saved off delete_on_error earlier) The reference lists must
+            # be empty or else we encounter the bidirectional reference issue
             self.commands = []
             self.instances = []
             self.save()

--- a/src/app/beer_garden/local_plugins/env_help.py
+++ b/src/app/beer_garden/local_plugins/env_help.py
@@ -47,7 +47,7 @@ def string_contains_environment_var(string):
 
 
 def is_string_environment_variable(string):
-    """Determines if string being sent in without the $ is a valid environmnet variable"""
+    """Determine if a string is a valid environment variable"""
     if len(string) == 0:
         return False
 

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -15,7 +15,7 @@ from beer_garden.queue.rabbit import get_routing_key
 
 
 class LocalPluginsManager(object):
-    """LocalPluginsManager that is capable of stopping/starting and restarting plugins"""
+    """Manager that is capable of stopping/starting and restarting plugins"""
 
     def __init__(self, shutdown_timeout):
         self.logger = logging.getLogger(__name__)
@@ -27,14 +27,14 @@ class LocalPluginsManager(object):
     def start_plugin(self, plugin):
         """Start a specific plugin.
 
-        If a plugin cannot Be found (i.e. it was not loaded) then it will not do anything
+        If a plugin cannot be found (i.e. it was not loaded) then it will not do anything
         If the plugin is already running, it will do nothing.
-        If a plugin instance has not started after the PLUGIN_STARTUP_TIMEOUT it will mark that
-        instance as stopped
+        If a plugin instance has not started after the PLUGIN_STARTUP_TIMEOUT it will
+        mark that instance as stopped
 
         :param plugin: The plugin to start
-        :return: True if any plugin instances successfully started. False if the plugin does
-            not exist or all instances failed to start
+        :return: True if any plugin instances successfully started. False if the plugin
+        does not exist or all instances failed to start
         """
         self.logger.info("Starting plugin %s", plugin.unique_name)
 
@@ -109,7 +109,7 @@ class LocalPluginsManager(object):
             # Plugin must be marked as stopped before sending shutdown message
             plugin.stop()
 
-            # Send a stop request. This initiates a graceful shutdown on the plugin side.
+            # Send a stop request to initiate a graceful shutdown
             queue.put(
                 beer_garden.stop_request,
                 routing_key=get_routing_key(
@@ -204,8 +204,8 @@ class LocalPluginsManager(object):
     def _start_multiple_plugins(self, plugins_to_start):
         """Starts multiple plugins, respecting required plugin dependencies.
 
-        It will consider requirements of other plugins. If the plugin requires others, then it
-        will be skipped until its requirements are loaded.
+        It will consider requirements of other plugins. If the plugin requires others,
+        then it will be skipped until its requirements are loaded.
 
         Failure is a little tricky.
 

--- a/src/app/beer_garden/local_plugins/plugin_runner.py
+++ b/src/app/beer_garden/local_plugins/plugin_runner.py
@@ -11,7 +11,7 @@ from brewtils.stoppable_thread import StoppableThread
 from beer_garden.local_plugins.env_help import expand_string_with_environment_var
 from beer_garden.local_plugins.logger import getLogLevels, getPluginLogger
 
-# This is the recommended import pattern, see https://github.com/google/python-subprocess32
+# Recommended import pattern, see https://github.com/google/python-subprocess32
 if os.name == "posix" and sys.version_info[0] < 3:
     import subprocess32 as subprocess
 else:
@@ -109,9 +109,9 @@ class LocalPluginRunner(StoppableThread):
     def run(self):
         """Runs the plugin
 
-        Run the plugin using the entry point specified with the generated environment in its own
-        subprocess. Pipes STDOUT and STDERR such that when the plugin stops executing
-        (or IO is flushed) it will log it.
+        Run the plugin using the entry point specified with the generated environment in
+        its own subprocess. Pipes STDOUT and STDERR such that when the plugin stops
+        executing (or IO is flushed) it will log it.
         """
         try:
             self.logger.info(

--- a/src/app/beer_garden/local_plugins/registry.py
+++ b/src/app/beer_garden/local_plugins/registry.py
@@ -7,7 +7,7 @@ import beer_garden.db.api as db
 
 
 class LocalPluginRegistry(object):
-    """Plugin Registry that is responsible for keeping track of plugins and their status"""
+    """Registry that is responsible for keeping track of plugins and their status"""
 
     _instance = None
 
@@ -66,7 +66,7 @@ class LocalPluginRegistry(object):
         process via the PluginLoader. Only used when there is no need for the plugin
         anymore (system shutdown or plugin is failing to start)
 
-        :param unique_name: The unique name of the plugin, in the form of name[instance]-version
+        :param unique_name: The unique name of the plugin, name[instance]-version
         :return: None
         """
         for index, plugin in enumerate(self._registry):

--- a/src/app/beer_garden/local_plugins/validator.py
+++ b/src/app/beer_garden/local_plugins/validator.py
@@ -108,16 +108,20 @@ class LocalPluginValidator(object):
     def _load_plugin_config(self, path_to_plugin):
         """Loads an already validated plugin Config.
 
-        That is, it assumes path_to_config will exist and that it can load it succesfully"""
+        It assumes path_to_config will exist and that it can load it successfully
+        """
         path_to_config = join(path_to_plugin, self.CONFIG_NAME)
 
         return load_source("BGPLUGINCONFIG", path_to_config)
 
     def validate_entry_point(self, config_module, path_to_plugin):
-        """Validates a plugin's entry point. Returns True or throws a PluginValidationError
+        """Validates a plugin's entry point.
 
-        An entry point is considered valid if the config has an entry with key PLUGIN_ENTRY
-        and the value is a path to either a file or the name of a runnable Python module.
+        Returns True or throws a PluginValidationError
+
+        An entry point is considered valid if the config has an entry with key
+        PLUGIN_ENTRY and the value is a path to either a file or the name of a runnable
+        Python module.
 
         :param config_module: The previously loaded configuration for the plugin
         :param path_to_plugin: The path to the root of the plugin
@@ -172,8 +176,9 @@ class LocalPluginValidator(object):
             for instance_name, instance_args in plugin_args.items():
                 if instances is not None and instance_name not in instances:
                     raise PluginValidationError(
-                        "'%s' contains key '%s' but that instance is not specified in the '%s'"
-                        "entry." % (self.ARGS_KEY, instance_name, self.INSTANCES_KEY)
+                        "'%s' contains key '%s' but that instance is not specified in "
+                        "the '%s'entry."
+                        % (self.ARGS_KEY, instance_name, self.INSTANCES_KEY)
                     )
                 self.validate_individual_plugin_arguments(instance_args)
 
@@ -181,8 +186,8 @@ class LocalPluginValidator(object):
                 for instance_name in instances:
                     if instance_name not in plugin_args.keys():
                         raise PluginValidationError(
-                            "'%s' contains key '%s' but that instance is not specified in the "
-                            "'%s' entry."
+                            "'%s' contains key '%s' but that instance is not specified "
+                            "in the '%s' entry."
                             % (self.INSTANCES_KEY, instance_name, self.ARGS_KEY)
                         )
 
@@ -260,24 +265,27 @@ class LocalPluginValidator(object):
 
                 if key.startswith("BG_"):
                     self.logger.error(
-                        "Invalid key: %s specified for plugin environment. The 'BG_' prefix is a "
-                        "special case for beer-garden only environment variables. You will have to "
-                        "pick another name. Sorry for the inconvenience." % key
+                        "Invalid key: %s specified for plugin environment. The 'BG_' "
+                        "prefix is a special case for beer-garden only environment "
+                        "variables. You will have to pick another name. Sorry for the "
+                        "inconvenience." % key
                     )
                     raise PluginValidationError(
-                        "Invalid key: %s specified for plugin environment. The 'BG_' prefix "
-                        "is a special case for beer-garden only environment variables. You will "
-                        "have to pick another name. Sorry for the inconvenience." % key
+                        "Invalid key: %s specified for plugin environment. The 'BG_' "
+                        "prefix is a special case for beer-garden only environment "
+                        "variables. You will have to pick another name. Sorry for the "
+                        "inconvenience." % key
                     )
 
                 if not isinstance(value, str):
                     self.logger.error(
-                        "Invalid Key: %s specified for plugin environment. This must be a String.",
+                        "Invalid Key: %s specified for plugin environment. This must "
+                        "be a String.",
                         value,
                     )
                     raise PluginValidationError(
-                        "Invalid Value: %s specified for plugin environment. This must be a "
-                        "String." % value
+                        "Invalid Value: %s specified for plugin environment. This must "
+                        "be a String." % value
                     )
 
         return True

--- a/src/app/beer_garden/queue/rabbit.py
+++ b/src/app/beer_garden/queue/rabbit.py
@@ -270,7 +270,7 @@ class PyrabbitClient(object):
 
 
 def get_routing_keys(*args, **kwargs):
-    """Get a list of routing keys for a plugin in order from least specific to most specific.
+    """Get a list of routing keys, ordered from least specific to most specific
 
     Will return all possible routing keys to get a message to a particular system.
 
@@ -286,15 +286,24 @@ def get_routing_keys(*args, **kwargs):
             ['admin', 'admin.test_system', 'admin.test_system.1-0-0']
 
         ['test_system', '1.0.0', 'default'], is_admin=True:
-            ['admin', 'admin.test_system', 'admin.test_system.1-0-0',
-                'admin.test_system.1-0-0.default']
+            [
+                'admin',
+                'admin.test_system',
+                'admin.test_system.1-0-0',
+                'admin.test_system.1-0-0.default',
+            ]
 
         ['test_system', '1.0.0', 'default', 'random_text'], is_admin=True:
-            ['admin', 'admin.test_system', 'admin.test_system.1-0-0',
-                'admin.test_system.1-0-0.default', 'admin.test_system.1-0-0.default.random_text']
+            [
+                'admin',
+                'admin.test_system',
+                'admin.test_system.1-0-0',
+                'admin.test_system.1-0-0.default',
+                'admin.test_system.1-0-0.default.random_text',
+            ]
 
-    NOTE: Because RabbitMQ uses '.' as the word delimiter all '.' in routing words will be
-        replaced with '-'
+    NOTE: Because RabbitMQ uses '.' as the word delimiter all '.' in routing words will
+    be replaced with '-'
 
     :param args: List of routing key words to include in the routing keys
     :param kwargs: is_admin: Will prepend 'admin' to all generated keys if True

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -160,11 +160,11 @@ class RequestValidator(object):
     ):
         """Validates all request parameters
 
-        Note: It is significant that we build the parameters as a separate object and then assign
-        it. This is significant because when you are setting a value to None, mongoengine
-        interprets this as "mark the item for deletion" meaning that when you save that attribute,
-        it will actually get deleted. Sounds weird right? Well at least you didn't have to
-        troubleshoot it.
+        Note: It is significant that we build the parameters as a separate object and
+        then assign it. This is significant because when you are setting a value to
+        None, mongoengine interprets this as "mark the item for deletion" meaning that
+        when you save that attribute, it will actually get deleted. Sounds weird right?
+        Well at least you didn't have to troubleshoot it.
 
         :param request: The Request to validate
         :param command: The the Command for this request. Will attempt to discover if None.
@@ -242,7 +242,7 @@ class RequestValidator(object):
                     if key == "instance_name":
                         key_reference_value = request.instance_name
                     else:
-                        # Mongoengine stores None keys as 'null', so use that instead of None
+                        # Mongoengine stores None keys as 'null', use instead of None
                         key_reference_value = request.parameters.get(key) or "null"
 
                     raw_allowed = choices.value.get(key_reference_value)
@@ -327,8 +327,8 @@ class RequestValidator(object):
                 for single_value in value:
                     if single_value not in allowed_values:
                         raise ModelValidationError(
-                            "Value '%s' is not a valid choice for parameter with key '%s'. "
-                            "Valid choices are: %s"
+                            "Value '%s' is not a valid choice for parameter with key "
+                            "'%s'. Valid choices are: %s"
                             % (single_value, command_parameter.key, allowed_values)
                         )
             else:
@@ -432,8 +432,8 @@ class RequestValidator(object):
     def _validate_required_parameter_is_included_in_request(
         self, request, command_parameter, request_parameters
     ):
-        """If the parameter is required but was not provided in the request_parameters and does
-        not have a default, then raise a ValidationError"""
+        """If the parameter is required but was not provided in the request_parameters
+        and does not have a default, then raise a ValidationError"""
         self.logger.debug(
             "Validating that Required Parameters are included in the request."
         )
@@ -450,8 +450,8 @@ class RequestValidator(object):
     def _validate_no_extra_request_parameter_keys(
         self, request_parameters, command_parameters
     ):
-        """Validate that all the parameters passed in were valid keys. If there is a key specified
-        that is not noted in the database, then a validation error is thrown"""
+        """Validate that all the parameters passed in were valid keys. If there is a key
+         specified that is not noted in the database, then a validation error is thrown"""
         self.logger.debug("Validating Keys")
         valid_keys = [cp.key for cp in command_parameters]
         self.logger.debug("Valid Keys are : %s" % valid_keys)

--- a/src/app/requirements.in
+++ b/src/app/requirements.in
@@ -21,6 +21,7 @@ black ; python_version > "3.5"
 codecov
 coverage
 flake8
+flake8-bugbear
 mock
 mongomock
 pytest < 4

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -24,6 +24,7 @@ docutils==0.15.2          # via readme-renderer, sphinx
 entrypoints==0.3          # via flake8
 filelock==3.0.12          # via tox
 flake8==3.7.8
+flake8-bugbear==19.8.0
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 importlib-metadata==0.19  # via pluggy, tox

--- a/src/app/setup.cfg
+++ b/src/app/setup.cfg
@@ -2,8 +2,9 @@
 universal = 1
 
 [flake8]
-max-line-length = 100
-ignore = E203,W503
+max-line-length = 88
+ignore = E203,E501,W503
+select = B950
 
 [tool:pytest]
 xfail_strict=true

--- a/src/app/test/api/http/integration/controllers/instance_api_test.py
+++ b/src/app/test/api/http/integration/controllers/instance_api_test.py
@@ -42,7 +42,8 @@ class InstanceAPITest(unittest.TestCase):
         self.app.patch(
             "/api/v1/systems/id",
             content_type="application/json",
-            data='{"operations": [{"operation": "replace", "path": "/status", "value": "RUNNING"}]}',
+            data='{"operations": [{"operation": "replace", "path": "/status", '
+            '"value": "RUNNING"}]}',
         )
 
         self.assertEqual(1, backend_mock.startSystem.call_count)
@@ -55,7 +56,8 @@ class InstanceAPITest(unittest.TestCase):
         self.app.patch(
             "/api/v1/systems/id",
             content_type="application/json",
-            data='{"operations": [{"operation": "replace", "path": "/status", "value": "STOPPED"}]}',
+            data='{"operations": [{"operation": "replace", "path": "/status", '
+            '"value": "STOPPED"}]}',
         )
 
         self.assertEqual(1, backend_mock.stopSystem.call_count)

--- a/src/app/test/api/http/integration/controllers/system_api_test.py
+++ b/src/app/test/api/http/integration/controllers/system_api_test.py
@@ -149,7 +149,8 @@ class SystemAPITest(unittest.TestCase):
         response = self.app.patch(
             "/api/v1/systems/id",
             content_type="application/json",
-            data='{"operations": [{"operation": "bad_op", "path": "/status", "value": "STOPPED"}]}',
+            data='{"operations": [{"operation": "bad_op", "path": "/status", '
+            '"value": "STOPPED"}]}',
         )
         self.assertEqual(400, response.status_code)
 
@@ -159,7 +160,8 @@ class SystemAPITest(unittest.TestCase):
         response = self.app.patch(
             "/api/v1/systems/id",
             content_type="application/json",
-            data='{"operations": [{"operation": "replace", "path": "bad_path", "value": "STOPPED"}]}',
+            data='{"operations": [{"operation": "replace", "path": "bad_path", '
+            '"value": "STOPPED"}]}',
         )
         self.assertEqual(400, response.status_code)
 
@@ -169,6 +171,7 @@ class SystemAPITest(unittest.TestCase):
         response = self.app.patch(
             "/api/v1/systems/id",
             content_type="application/json",
-            data='{"operations": [{"operation": "replace", "path": "/status", "value": "bad_value"}]}',
+            data='{"operations": [{"operation": "replace", "path": "/status", '
+            '"value": "bad_value"}]}',
         )
         self.assertEqual(400, response.status_code)


### PR DESCRIPTION
This PR brings our linter rules for line length in line with what we're actually targeting. It also cleans up the final outstanding line length violations.

We now use the flake8 bugbear plugin to be less strict about line length. Basically, our max length is now 88, but if there's a line that goes over by less than 10% the linter won't fail. In the cases where the linter does fail it'll display the correct max of 88, though.