### PR TITLE
Fixes #382

### DIFF
--- a/src/app/beer_garden/db/mongo/parser.py
+++ b/src/app/beer_garden/db/mongo/parser.py
@@ -30,7 +30,9 @@ class MongoParser(SchemaParser):
         }
     )
 
-    @staticmethod
-    def _get_schema_name(model):
+    @classmethod
+    def _get_schema_name(cls, model):
         if isinstance(model, beer_garden.db.mongo.models.MongoModel):
             return model.brewtils_model.schema
+        else:
+            return super(MongoParser, cls)._get_schema_name(model)


### PR DESCRIPTION
This is really a problem for the anonymous principal. The
anonymous principal is actually a Brewtils object while the
MongoParser can only serialize Mongo objects. In the anonymous
case we need to fallback to the brewtils schema parser.