### PR TITLE
Change Forward Event Garden

### DIFF
--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -266,7 +266,9 @@ class Application(StoppableThread):
                 ssl_enabled=http_event.ssl.enabled,
             )
             skip_events = beer_garden.config.get("event.parent.skip_events")
-            event_manager.register(HttpEventProcessor(easy_client=easy_client, skip_events=skip_events))
+            event_manager.register(
+                HttpEventProcessor(easy_client=easy_client, skip_events=skip_events)
+            )
 
         event_manager.register(QueueListener(action=local_callbacks))
         event_manager.register(QueueListener(action=downstream_callbacks))

--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -267,7 +267,7 @@ class Application(StoppableThread):
             )
             skip_events = beer_garden.config.get("event.parent.skip_events")
             event_manager.register(
-                HttpEventProcessor(easy_client=easy_client, skip_events=skip_events)
+                HttpEventProcessor(easy_client=easy_client, black_list=skip_events)
             )
 
         event_manager.register(QueueListener(action=local_callbacks))

--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -265,7 +265,8 @@ class Application(StoppableThread):
                 bg_port=http_event.port,
                 ssl_enabled=http_event.ssl.enabled,
             )
-            event_manager.register(HttpEventProcessor(easy_client=easy_client))
+            skip_events = beer_garden.config.get("event.parent.skip_events")
+            event_manager.register(HttpEventProcessor(easy_client=easy_client, skip_events=skip_events))
 
         event_manager.register(QueueListener(action=local_callbacks))
         event_manager.register(QueueListener(action=downstream_callbacks))

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -104,14 +104,16 @@ class FanoutProcessor(QueueListener):
 class HttpEventProcessor(QueueListener):
     """Publish events using an EasyClient"""
 
-    def __init__(self, easy_client=None, **kwargs):
+    def __init__(self, easy_client=None, skip_events=[], **kwargs):
         super().__init__(**kwargs)
 
         self._ez_client = easy_client
+        self.skip_events = skip_events
 
-    def process(self, item: Event):
+    def process(self, event: Event):
         try:
-            item.garden = beer_garden.config.get("garden.name")
-            self._ez_client.publish_event(item)
+            if event.name not in self.skip_events:
+                event.garden = beer_garden.config.get("garden.name")
+                self._ez_client.publish_event(event)
         except Exception as ex:
             logger.exception(f"Error publishing EasyClient event: {ex}")

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 class BaseProcessor(StoppableThread):
     """Base Processor"""
 
-    def __init__(self, action=None, black_list=list(), **kwargs):
+    def __init__(self, action=None, black_list=None, **kwargs):
         super().__init__(**kwargs)
 
         self._action = action
-        self._black_list = black_list
+        self._black_list = black_list or []
 
     def process(self, item):
         if item.name not in self._black_list:

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -3,6 +3,7 @@ import logging
 from multiprocessing import Queue
 from queue import Empty
 
+from brewtils.models import Event
 from brewtils.stoppable_thread import StoppableThread
 
 import beer_garden.events
@@ -108,8 +109,9 @@ class HttpEventProcessor(QueueListener):
 
         self._ez_client = easy_client
 
-    def process(self, item):
+    def process(self, item: Event):
         try:
+            item.garden = beer_garden.config.get("garden.name")
             self._ez_client.publish_event(item)
         except Exception as ex:
             logger.exception(f"Error publishing EasyClient event: {ex}")


### PR DESCRIPTION
When a Garden forwards an event to their parent, the event will have the forwarding Garden's name applied to it. This is because Parents have no concepts of Grand Children and would not know where the event came from if a Grand Child sent the event. This field is only for routing, so this is should be fine for these scenarios because the payload is not changed.

Also, added in the feature to skip events in the forwarding.