### PR TITLE
Child Event Checks

### DIFF
--- a/src/app/beer_garden/db/api.py
+++ b/src/app/beer_garden/db/api.py
@@ -14,17 +14,14 @@ reload = beer_garden.db.mongo.api.reload
 replace_commands = beer_garden.db.mongo.api.replace_commands
 
 
-@publish_event(Events.DB_CREATE)
 def _create(obj):
     return beer_garden.db.mongo.api.create(obj)
 
 
-@publish_event(Events.DB_CREATE)
 def _update(obj):
     return beer_garden.db.mongo.api.update(obj)
 
 
-@publish_event(Events.DB_DELETE)
 def _delete(obj):
     return beer_garden.db.mongo.api.delete(obj)
 

--- a/src/app/beer_garden/db/api.py
+++ b/src/app/beer_garden/db/api.py
@@ -13,19 +13,6 @@ query = beer_garden.db.mongo.api.query
 reload = beer_garden.db.mongo.api.reload
 replace_commands = beer_garden.db.mongo.api.replace_commands
 
-
-def _create(obj):
-    return beer_garden.db.mongo.api.create(obj)
-
-
-def _update(obj):
-    return beer_garden.db.mongo.api.update(obj)
-
-
-def _delete(obj):
-    return beer_garden.db.mongo.api.delete(obj)
-
-
-create = _create
-update = _update
-delete = _delete
+create = beer_garden.db.mongo.api.create
+update = beer_garden.db.mongo.api.update
+delete = beer_garden.db.mongo.api.delete

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -58,12 +58,6 @@ def downstream_callbacks(event: Event) -> None:
             )
             return
 
-        if not event.payload_type:
-            logger.error(
-                f"Unable to process event ({event} : {event.payload_type}: {event.payload}): No Payload Type"
-            )
-            return
-
         if event.name in (Events.REQUEST_CREATED.name, Events.SYSTEM_CREATED.name):
             try:
                 db.create(event.payload)
@@ -78,6 +72,11 @@ def downstream_callbacks(event: Event) -> None:
             Events.SYSTEM_UPDATED.name,
             Events.INSTANCE_UPDATED.name,
         ):
+            if not event.payload_type:
+                logger.error(
+                    f"Unable to process event ({event} : {event.payload_type}: {event.payload}): No Payload Type"
+                )
+                return
 
             model_class = getattr(brewtils_models, event.payload_type)
             record = db.query_unique(model_class, id=event.payload.id)
@@ -86,10 +85,16 @@ def downstream_callbacks(event: Event) -> None:
                 db.update(event.payload)
             else:
                 logger.error(
-                    f"Unable to update ({event} : {event.payload_type} : {event.payload}): Object does not exists in database"
+                    f"Unable to update ({event} : {event.payload_type} : {event.payload}): Object does not exist in database"
                 )
 
         elif event.name in (Events.SYSTEM_REMOVED.name,):
+
+            if not event.payload_type:
+                logger.error(
+                    f"Unable to process event ({event} : {event.payload_type}: {event.payload}): No Payload Type"
+                )
+                return
 
             model_class = getattr(brewtils_models, event.payload_type)
             record = db.query_unique(model_class, id=event.payload.id)
@@ -98,7 +103,7 @@ def downstream_callbacks(event: Event) -> None:
                 db.delete(event.payload)
             else:
                 logger.error(
-                    f"Unable to delete ({event} : {event.payload_type} : {event.payload}): Object does not exists in database"
+                    f"Unable to delete ({event} : {event.payload_type} : {event.payload}): Object does not exist in database"
                 )
 
 

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from mongoengine import DoesNotExist
+
+from beer_garden.db.mongo import models as mongo_models
+from brewtils import models as brewtils_models
 from brewtils.models import Event, Events
 
 import beer_garden.config
@@ -49,10 +53,45 @@ def downstream_callbacks(event: Event) -> None:
     """
     if event.garden != beer_garden.config.get("garden.name"):
         if event.error:
-            logger.error(f"Downstream error event ({event}): {event.error_message}")
+            logger.error(
+                f"Downstream error event ({event} : {event.payload}): {event.error_message}"
+            )
             return
 
+        if not event.payload_type:
+            logger.error(
+                f"Unable to process event ({event} : {event.payload}): No Payload Type"
+            )
+            return
+
+        # Grab the mongo DB model of the object
+        mongo_model_class_ = getattr(mongo_models, event.payload_type)
+        brewtils_model_class_ = getattr(brewtils_models, event.payload_type)
+
+        # Check model for unique fields
+        if mongo_model_class_._meta and mongo_model_class_._meta["indexes"]:
+
+            for index in mongo_model_class_._meta["indexes"]:
+                if index["unique"]:
+                    query_kwargs = {}
+                    for field in index["fields"]:
+                        query_kwargs[field] = getattr(event.payload, field)
+
+                    try:
+                        db_obj = db.query_unique(brewtils_model_class_, **query_kwargs)
+
+                        if db_obj and db_obj.id is not event.payload.id:
+                            logger.error(
+                                f"Unable to process ({event} : {event.payload}): Object already exists in database"
+                            )
+                            return
+
+                    except DoesNotExist:
+                        # If the record does not exist, then move forward with action
+                        pass
+
         try:
+
             if event.name in (Events.REQUEST_CREATED.name, Events.SYSTEM_CREATED.name):
                 db.create(event.payload)
 


### PR DESCRIPTION
This checks the MongoDB model to determine any unique fields required for storage. Then queries the database to determine if the record already exists. If the record already exists, then it verifies that the records are the same based on the ID.

Child BG instances can only create new records in their parent and update records that they know of. If a child tries to overwrite something the parent or other child created (i.e. identical plugin deployments) then the parent will reject the event request.

** Also removed DB events, this caused a loop in the code.