### PR TITLE
Adding a reverse_delete_rule for the Command model's system field

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -198,6 +198,7 @@ class Command(MongoModel, Document):
     form = DictField()
     template = StringField()
     icon_name = StringField()
+    # reverse_delete_rule=CASCADE is set later, can't set until System is defined
     system = ReferenceField("System")
 
     def clean(self):
@@ -704,3 +705,7 @@ class Garden(MongoModel, Document):
 class SystemGardenMapping(MongoModel, Document):
     system = ReferenceField("System")
     garden = ReferenceField("Garden")
+
+
+# Update the Command field now that all models are defined
+System.register_delete_rule(Command, "system", CASCADE)


### PR DESCRIPTION
This PR fixes #141 by adding a `reverse_delete_rule` for the Command model's system field.