### PR TITLE
Thrift cleanup

### DIFF
--- a/src/app/beer_garden/__main__.py
+++ b/src/app/beer_garden/__main__.py
@@ -4,8 +4,6 @@ import signal
 import sys
 
 import beer_garden
-import beer_garden.api.http
-import beer_garden.api.thrift
 from beer_garden.app import Application
 from beer_garden.config import generate_logging, generate, migrate
 

--- a/src/app/beer_garden/api/entry_point.py
+++ b/src/app/beer_garden/api/entry_point.py
@@ -2,6 +2,7 @@
 import logging
 import multiprocessing
 import signal
+from importlib import import_module
 from multiprocessing.connection import Connection, Pipe
 from multiprocessing.context import SpawnContext
 from multiprocessing.queues import Queue
@@ -220,7 +221,7 @@ class Manager:
                 self.entry_points.append(self.create(entry_name))
 
     def create(self, module_name: str) -> T:
-        module = getattr(beer_garden.api, module_name)
+        module = import_module(f"beer_garden.api.{module_name}")
 
         return EntryPoint(
             name=module_name,

--- a/src/app/beer_garden/api/http/base_handler.py
+++ b/src/app/beer_garden/api/http/base_handler.py
@@ -20,7 +20,6 @@ from mongoengine.errors import (
     ValidationError as MongoValidationError,
 )
 from pymongo.errors import DocumentTooLarge
-from thriftpy2.thrift import TException
 from tornado.web import HTTPError, RequestHandler
 
 import beer_garden.api.http
@@ -53,7 +52,6 @@ class BaseHandler(AuthMixin, RequestHandler):
         NotUniqueError: {"status_code": 409, "message": "Resource already exists"},
         DocumentTooLarge: {"status_code": 413, "message": "Resource too large"},
         RequestPublishException: {"status_code": 502},
-        TException: {"status_code": 503, "message": "Could not connect to Bartender"},
         socket.timeout: {"status_code": 504, "message": "Backend request timed out"},
     }
 

--- a/src/app/beer_garden/api/thrift/__init__.py
+++ b/src/app/beer_garden/api/thrift/__init__.py
@@ -1,4 +1,13 @@
 # -*- coding: utf-8 -*-
+"""Package containing the Thrift entry point
+
+This is DEPRECATED and will not be released in a stable version. It's included here
+purely as a testing tool.
+
+Note that thriftpy2 is not listed in the project's dependencies. If you want to run this
+entry point you must install thriftpy2 first.
+"""
+
 import logging
 import os
 import types

--- a/src/app/requirements.in
+++ b/src/app/requirements.in
@@ -7,7 +7,6 @@ passlib < 1.8
 prometheus_client < 1
 pyrabbit2 < 2
 ruamel.yaml < 0.16
-thriftpy2 < 0.5
 tornado < 7
 yapconf >= 0.3.5
 

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -44,7 +44,6 @@ pathtools==0.1.2          # via watchdog
 pika==1.0.1
 pkginfo==1.5.0.1          # via twine
 pluggy==0.12.0            # via pytest, tox
-ply==3.11                 # via thriftpy2
 prometheus-client==0.7.1
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
@@ -72,7 +71,6 @@ snowballstemmer==1.9.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
-thriftpy2==0.4.5
 toml==0.10.0              # via black, tox
 tornado==6.0.3
 tox==3.13.2

--- a/src/app/setup.cfg
+++ b/src/app/setup.cfg
@@ -9,3 +9,4 @@ exclude = test/api
 
 [tool:pytest]
 xfail_strict=true
+addopts = --ignore test/api/thrift

--- a/src/app/setup.py
+++ b/src/app/setup.py
@@ -37,7 +37,6 @@ setup(
         "pyrabbit2==1.0.7",
         "pytz<2019",
         "ruamel.yaml<0.16",
-        "thriftpy2<0.5",
         "tornado==6.0.3",
         "yapconf>=0.3.5",
     ],


### PR DESCRIPTION
This PR keeps the thrift entry point code but removes all references to thrift outside of the thrift package. It also removes `thriftpy2` from the dependency list.

It also changes the `EntryPoint` class to dynamically import the entry point packages instead of assuming they were already imported (which is why `beer_garden.api.http` and `beer_garden.api.thrift` no longer need to be imported in `__main__`).