### PR TITLE
Config updates

### DIFF
--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -769,7 +769,7 @@ _EVENT_SPEC = {
                     "items": {
                         "enable": {
                             "type": "bool",
-                            "default": True,
+                            "default": False,
                             "description": "Run an HTTP server",
                         },
                         "ssl": {

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -815,43 +815,6 @@ _EVENT_SPEC = {
                                 },
                             },
                         },
-                        "callback": {
-                            "type": "dict",
-                            "items": {
-                                "port": {
-                                    "type": "int",
-                                    "default": 2337,
-                                    "description": "Serve content on this port",
-                                },
-                                "url_prefix": {
-                                    "type": "str",
-                                    "default": "/",
-                                    "description": "URL path prefix",
-                                    "required": False,
-                                },
-                                "host": {
-                                    "type": "str",
-                                    "default": "0.0.0.0",
-                                    "description": "Host for the HTTP Server to bind to",
-                                },
-                                "public_fqdn": {
-                                    "type": "str",
-                                    "default": "localhost",
-                                    "description": "Public fully-qualified domain name",
-                                },
-                                "remote_user": {
-                                    "type": "str",
-                                    "default": "bg_remote",
-                                    "description": "Remote User that Parent can callback as",
-                                },
-                                "ssl_enabled": {
-                                    "type": "bool",
-                                    "default": False,
-                                    "description": "Serve content using SSL",
-                                    "cli_separator": "_",
-                                },
-                            },
-                        },
                         "port": {
                             "type": "int",
                             "default": 2337,

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -770,7 +770,7 @@ _EVENT_SPEC = {
                         "enable": {
                             "type": "bool",
                             "default": False,
-                            "description": "Run an HTTP server",
+                            "description": "Publish events to parent garden over HTTP",
                         },
                         "ssl": {
                             "type": "dict",

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -749,48 +749,6 @@ _EVENT_SPEC = {
                 },
             },
         },
-        "brew_view": {
-            "type": "dict",
-            "items": {
-                "enable": {
-                    "type": "bool",
-                    "default": False,
-                    "description": "Publish events from a Brew-view websocket",
-                },
-                "ca_cert": {
-                    "type": "str",
-                    "description": "Path to CA certificate file to use",
-                    "required": False,
-                },
-                "ca_verify": {
-                    "type": "bool",
-                    "default": True,
-                    "description": "Verify external certificates",
-                    "required": False,
-                },
-                "host": {
-                    "type": "str",
-                    "default": "localhost",
-                    "description": "Hostname of the API server",
-                },
-                "port": {
-                    "type": "int",
-                    "default": 2337,
-                    "description": "Port of the API server",
-                },
-                "ssl_enabled": {
-                    "type": "bool",
-                    "default": False,
-                    "description": "Is the API server using SSL",
-                },
-                "url_prefix": {
-                    "type": "str",
-                    "default": "/",
-                    "description": "URL prefix of the API server",
-                    "required": False,
-                },
-            },
-        },
         "mongo": {
             "type": "dict",
             "items": {

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -52,7 +52,7 @@ def load(args: Sequence[str], force: bool = False) -> None:
     if config.event.brew_view.url_prefix:
         config.event.brew_view.url_prefix = normalize(config.event.brew_view.url_prefix)
 
-    _CONFIG = Box(config.to_dict(), frozen_box=True)
+    _CONFIG = Box(config.to_dict())
 
 
 def generate(args: Sequence[str]):

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -876,7 +876,7 @@ _EVENT_SPEC = {
                         "skip_events": {
                             "type": "list",
                             "items": {"skip_event": {"type": "str"}},
-                            "default": ("DB_CREATE",),
+                            "default": ["DB_CREATE"],
                             "required": False,
                             "description": "Events to be skipped",
                         },

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -74,13 +74,6 @@ event:
     enable: true
   parent:
     http:
-      callback:
-        host: 0.0.0.0
-        port: 2337
-        public_fqdn: localhost
-        remote_user: bg_remote
-        ssl_enabled: false
-        url_prefix: /
       enable: false
       host: 0.0.0.0
       port: 2337

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -70,14 +70,6 @@ event:
     enable: false
     exchange: event
     virtual_host: /
-  brew_view:
-    ca_cert: null
-    ca_verify: true
-    enable: false
-    host: localhost
-    port: 2337
-    ssl_enabled: false
-    url_prefix: /
   mongo:
     enable: true
   parent:

--- a/src/app/test/config_test.py
+++ b/src/app/test/config_test.py
@@ -53,16 +53,10 @@ class TestLoadConfig(object):
         ],
     )
     def test_normalize_url_prefix(self, normalized, initial):
-        cli_args = [
-            "--entry-http-url-prefix",
-            initial,
-            "--event-brew_view-url-prefix",
-            initial,
-        ]
-        beer_garden.config.load(cli_args, force=True)
+        cli_args = ["--entry-http-url-prefix", initial]
 
+        beer_garden.config.load(cli_args, force=True)
         assert beer_garden.config.get("entry.http.url_prefix") == normalized
-        assert beer_garden.config.get("event.brew_view.url_prefix") == normalized
 
 
 class TestGenerateConfig(object):

--- a/src/app/test/config_test.py
+++ b/src/app/test/config_test.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 import yapconf
-from box import BoxError
 from mock import Mock, patch
 from ruamel import yaml
 from yapconf import YapconfSpec
@@ -192,10 +191,6 @@ class TestConfigGet(object):
 
     def test_get_all(self):
         assert beer_garden.config.get() == beer_garden.config._CONFIG
-
-    def test_immutable(self):
-        with pytest.raises(BoxError):
-            beer_garden.config.get("log")["level"] = "not allowed"
 
 
 class TestSafeMigrate(object):


### PR DESCRIPTION
This PR makes some tweaks to the config subsystem:

- Removes the `brew_view` events section that is OBE
- No longer freezes the config when loading it. Freezing is nice, but it breaks the case where the server secret hasn't been set as we're unable to update it.
- The spec default for enabling sending event notifications to a parent needs to be `False` - the default needs to be standalone mode.