### PR TITLE
Fixing incorrect auth provider list setup for the event websocket

### DIFF
--- a/src/app/beer_garden/api/http/authorization.py
+++ b/src/app/beer_garden/api/http/authorization.py
@@ -252,7 +252,7 @@ def _principal_from_token(token):
 
 class AuthMixin(object):
 
-    auth_providers = [bearer_auth, basic_auth]
+    auth_providers: frozenset = None
 
     def get_current_user(self):
         """Use registered handlers to determine current user"""

--- a/src/app/beer_garden/api/http/base_handler.py
+++ b/src/app/beer_garden/api/http/base_handler.py
@@ -24,13 +24,20 @@ from tornado.web import HTTPError, RequestHandler
 
 import beer_garden.api.http
 import beer_garden.db.mongo.models
-from beer_garden.api.http.authorization import AuthMixin, coalesce_permissions
+from beer_garden.api.http.authorization import (
+    AuthMixin,
+    coalesce_permissions,
+    bearer_auth,
+    basic_auth,
+)
 from beer_garden.api.http.client import ExecutorClient
 from beer_garden.api.http.metrics import http_api_latency_total
 
 
 class BaseHandler(AuthMixin, RequestHandler):
     """Base handler from which all handlers inherit"""
+
+    auth_providers = frozenset([bearer_auth, basic_auth])
 
     MONGO_ID_PATTERN = r".*/([0-9a-f]{24}).*"
     REFRESH_COOKIE_NAME = "refresh_id"

--- a/src/app/beer_garden/api/http/handlers/v1/event.py
+++ b/src/app/beer_garden/api/http/handlers/v1/event.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from brewtils.errors import RequestForbidden
 from tornado.web import HTTPError
 from tornado.websocket import WebSocketHandler
 
 from beer_garden.api.http.authorization import (
-    check_permission,
-    query_token_auth,
     AuthMixin,
     Permissions,
+    check_permission,
+    query_token_auth,
 )
-from brewtils.errors import RequestForbidden
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +20,7 @@ class EventSocket(AuthMixin, WebSocketHandler):
     closing = False
     listeners = set()
 
-    def __init__(self, *args, **kwargs):
-        super(EventSocket, self).__init__(*args, **kwargs)
-
-        self.auth_providers.append(query_token_auth)
+    auth_providers = frozenset([query_token_auth])
 
     def check_origin(self, origin):
         return True


### PR DESCRIPTION
This PR fixes a tricky little issue that we've seen before. Adding a function to the `auth_providers` list in a handler `__init__` is a really bad idea since a new handler is constructed (and so another provider is added) for every request.

This means that, over time, each new request will be checked against a bunch of redundant functions for potential authorization.

We did this in the `BaseHandler` at one point and the slowdown eventually got so bad that the server would fall over :smile:

Doing this in a specific handler isn't *quite* as bad, but yeah. I've also made that a `frozenset` instead of a list so this hopefully doesn't happen again.