### PR TITLE
Removing extra css rule that made page too large

### DIFF
--- a/src/ui/src/styles/custom.css
+++ b/src/ui/src/styles/custom.css
@@ -73,9 +73,7 @@ html, body{
     height: 100%;
     background: inherit;
 }
-#page-wrapper{
-    min-height: 100%;
-}
+
 .icon-color{
     color: black !important;
 }


### PR DESCRIPTION
This is a tiny PR that fixes an annoying issue. Previously you could scroll down an amount equal to the width of the top navigation bar even if there was no content warrants it. This fixes that - you can no longer scroll down if there's nothing to scroll for.