### PR TITLE
Moved Menu Around

### DIFF
--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -26,7 +26,11 @@
       <ul class="nav navbar-nav navbar-top-links navbar-right">
 
         <li ng-show=!isUser(user)>
-          <a href="" ng-click="doLogin()">Login</a>
+
+          <a href="" ng-click="doLogin()">
+            <i class="fa fa-user"></i>
+            <span>Login</span>
+          </a>
         </li>
 
         <li ng-show="isUser(user)">
@@ -34,57 +38,14 @@
         </li>
 
         <li ng-show="isUser(user)">
-          <a ng-click="doLogout()" href="">Logout</a>
-        </li>
-
-        <li class="dropdown">
-          <a href="" class="dropdown-toggle" data-toggle="dropdown">
-            <span>Themes</span>
-            <span class="caret"></span>
+          <i class="fa fa-user"></i>
+          <a ng-click="doLogout()" href="">
+            <i class="fa fa-user"></i>
+            <span>Logout</span>
           </a>
-          <ul class="dropdown-menu">
-            <li ng-repeat="(style, enabled) in themes">
-              <div style="padding: 3px 15px; cursor: pointer;"
-                    ng-click="changeTheme(style, true)">
-                <span class="fa" ng-class="{'fa-check': enabled, 'fa-fw': !enabled}"></span>
-                <span>{{style}}</span>
-              </div>
-            </li>
-          </ul>
         </li>
 
-        <li>
-          <a ui-sref="base.about" ui-sref-active="active">About</a>
-        </li>
-      </ul>
-      <!-- Navbar Top End -->
-
-      <!-- Sidebar Start -->
-      <div class="navbar-default sidebar" role="navigation">
-        <div class="sidebar-nav navbar-collapse">
-          <ul class="nav" id="side-menu">
-
-            <li>
-              <a>
-                <i class="fa fa-cogs fa-fw"></i>
-                <span>Systems</span>
-                <span class="fa arrow"></span>
-              </a>
-
-              <ul class="nav nav-second-level">
-                <li ng-repeat="system in systems" ng-init="collapsed=false">
-                  <a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})"
-                     ui-sref-active="active">
-                    <i class="fa fa-cog"></i>
-                    <span>{{system.namespace}}</span>
-                    <span>{{system.display_name || system.name}}</span>
-                    <span>{{system.version}}</span>
-                  </a>
-                </li>
-              </ul>
-
-            </li>
-            <li ng-show="hasPermission(user, 'bg-command-read')">
+        <li ng-show="hasPermission(user, 'bg-command-read')">
               <a ui-sref="base.commands"
                  ng-class="{active: ($state.current.name.startsWith('command'))}">
                 <i class="fa fa-fw fa-send-o"></i>
@@ -105,14 +66,15 @@
                 <span>Scheduler</span>
               </a>
             </li>
-            <li>
-              <a ui-sref-active="active">
-                <i class="fa fa-wrench fa-fw"></i>
-                <span>Administration</span>
-                <span class="fa arrow"></span>
-              </a>
-              <ul class="nav nav-second-level" ng-cloak>
-                <li>
+
+        <li class="dropdown" ui-sref-active="active">
+          <a href="" class="dropdown-toggle" data-toggle="dropdown">
+            <i class="fa fa-wrench fa-fw"></i>
+            <span>Admin</span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu">
+             <li>
                   <a ui-sref="base.system_admin" ui-sref-active="active">
                     <i class="fa fa-power-off"></i>
                     <span>Systems Management</span>
@@ -140,6 +102,57 @@
                   <a ui-sref="base.garden_admin" ui-sref-active="active">
                     <i class="fa fa-leaf"></i>
                     <span>Garden Management</span>
+                  </a>
+                </li>
+          </ul>
+        </li>
+
+        <li class="dropdown">
+          <a href="" class="dropdown-toggle" data-toggle="dropdown">
+            <i class="fa fa-window-restore"></i>
+            <span>Themes</span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu">
+            <li ng-repeat="(style, enabled) in themes">
+              <div style="padding: 3px 15px; cursor: pointer;"
+                    ng-click="changeTheme(style, true)">
+                <span class="fa" ng-class="{'fa-check': enabled, 'fa-fw': !enabled}"></span>
+                <span>{{style}}</span>
+              </div>
+            </li>
+          </ul>
+        </li>
+
+        <li>
+
+          <a ui-sref="base.about" ui-sref-active="active">
+            <i class="fa fa-info"></i>
+            <span>About</span>
+          </a>
+        </li>
+      </ul>
+      <!-- Navbar Top End -->
+
+      <!-- Sidebar Start -->
+      <div class="navbar-default sidebar" role="navigation">
+        <div class="sidebar-nav navbar-collapse">
+          <ul class="nav" id="side-menu" >
+            <li ng-repeat="namespace in namespaces">
+              <a>
+                <i class="fa fa-cogs fa-fw"></i>
+                <span>{{namespace}}</span>
+                <span class="fa arrow"></span>
+              </a>
+              <ul class="nav nav-second-level">
+                <li ng-repeat="system in systems" >
+                  <a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})"
+                     ui-sref-active="active"
+                     ng-if="system.namespace == namespace">
+                    <i class="fa fa-cog"></i>
+                    <span>{{system.namespace}}</span>
+                    <span>{{system.display_name || system.name}}</span>
+                    <span>{{system.version}}</span>
                   </a>
                 </li>
               </ul>

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -19,11 +19,34 @@
     <nav class="navbar navbar-default navbar-static-top" role="navigation" style="margin-bottom:0">
 
       <!-- Navbar Top Start -->
-      <ul class="nav navbar-nav navbar-top-links navbar-left">
+      <a style="cursor:pointer" class="navbar-brand" ui-sref="base.systems">
+        <i ng-class="getIcon(config.iconDefault)"></i>
+        <span ng-cloak>{{config.applicationName}}</span>
+      </a>
+      <ul class="nav navbar-nav navbar-top-links navbar-right">
+
+        <li ng-show=!isUser(user)>
+          <a href="" ng-click="doLogin()">
+            <i class="fa fa-user"></i>
+            <span>Login</span>
+          </a>
+        </li>
+
+        <li ng-show="isUser(user)">
+          <a href="">Hello, {{user.username}}!</a>
+        </li>
+        <li ng-show="isUser(user)">
+          <i class="fa fa-user"></i>
+          <a ng-click="doLogout()" href="">
+            <i class="fa fa-user"></i>
+            <span>Logout</span>
+          </a>
+        </li>
         <li class="dropdown">
           <a href="" class="dropdown-toggle" data-toggle="dropdown">
-            <i ng-class="getIcon(config.iconDefault)"></i>
-            <span ng-cloak>{{config.applicationName}}</span>
+            <i class="fa fa-cog"></i>
+            <span>Systems</span>
+            <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
               <li>
@@ -44,32 +67,6 @@
                   </a>
             </li>
           </ul>
-        </li>
-      </ul>
-      <ul class="nav navbar-nav navbar-top-links navbar-right">
-
-        <li ng-show=!isUser(user)>
-          <a href="" ng-click="doLogin()">
-            <i class="fa fa-user"></i>
-            <span>Login</span>
-          </a>
-        </li>
-
-        <li ng-show="isUser(user)">
-          <a href="">Hello, {{user.username}}!</a>
-        </li>
-        <li ng-show="isUser(user)">
-          <i class="fa fa-user"></i>
-          <a ng-click="doLogout()" href="">
-            <i class="fa fa-user"></i>
-            <span>Logout</span>
-          </a>
-        </li>
-        <li >
-          <a ui-sref="base.systems">
-            <i class="fa fa-cog"></i>
-            <span>Systems</span>
-          </a>
         </li>
         <li ng-show="hasPermission(user, 'bg-command-read')">
           <a ui-sref="base.commands"

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -19,14 +19,36 @@
     <nav class="navbar navbar-default navbar-static-top" role="navigation" style="margin-bottom:0">
 
       <!-- Navbar Top Start -->
-      <a style="cursor:pointer" class="navbar-brand" ui-sref="base.systems">
-        <i ng-class="getIcon(config.iconDefault)"></i>
-        <span ng-cloak>{{config.applicationName}}</span>
-      </a>
+      <ul class="nav navbar-nav navbar-top-links navbar-left">
+        <li class="dropdown">
+          <a href="" class="dropdown-toggle" data-toggle="dropdown">
+            <i ng-class="getIcon(config.iconDefault)"></i>
+            <span ng-cloak>{{config.applicationName}}</span>
+          </a>
+          <ul class="dropdown-menu">
+              <li>
+                <a>
+                <i class="fa fa-search"></i>
+                <input ng-model="searchText">
+                  </a>
+              </li>
+                <li ng-repeat="system in systems | filter:searchText" >
+                  <a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})"
+                     ui-sref-active="active">
+                    <i class="fa fa-cog"></i>
+                    <span title="{{system.description}}">
+                    <span>{{system.namespace}}</span>
+                    <span>{{system.display_name || system.name}}</span>
+                    <span>{{system.version}}</span>
+                    </span>
+                  </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
       <ul class="nav navbar-nav navbar-top-links navbar-right">
 
         <li ng-show=!isUser(user)>
-
           <a href="" ng-click="doLogin()">
             <i class="fa fa-user"></i>
             <span>Login</span>
@@ -36,7 +58,6 @@
         <li ng-show="isUser(user)">
           <a href="">Hello, {{user.username}}!</a>
         </li>
-
         <li ng-show="isUser(user)">
           <i class="fa fa-user"></i>
           <a ng-click="doLogout()" href="">
@@ -44,28 +65,33 @@
             <span>Logout</span>
           </a>
         </li>
-
+        <li >
+          <a ui-sref="base.systems">
+            <i class="fa fa-cog"></i>
+            <span>Systems</span>
+          </a>
+        </li>
         <li ng-show="hasPermission(user, 'bg-command-read')">
-              <a ui-sref="base.commands"
-                 ng-class="{active: ($state.current.name.startsWith('command'))}">
-                <i class="fa fa-fw fa-send-o"></i>
-                <span>Commands</span>
-              </a>
-            </li>
-            <li ng-show="hasPermission(user, 'bg-request-read')">
-              <a ui-sref="base.requests"
-                 ng-class="{active: ($state.current.name.startsWith('request'))}">
-                <i class="fa fa-fw fa-tasks"></i>
-                <span>Requests</span>
-              </a>
-            </li>
-            <li ng-show="hasPermission(user, 'bg-job-read')">
-              <a ui-sref="base.jobs"
-                 ng-class="{active: ($state.current.name.startsWith('job'))}">
-                <i class="fa fa-fw fa-calendar"></i>
-                <span>Scheduler</span>
-              </a>
-            </li>
+          <a ui-sref="base.commands"
+             ng-class="{active: ($state.current.name.startsWith('command'))}">
+            <i class="fa fa-fw fa-send-o"></i>
+            <span>Commands</span>
+          </a>
+        </li>
+        <li ng-show="hasPermission(user, 'bg-request-read')">
+          <a ui-sref="base.requests"
+             ng-class="{active: ($state.current.name.startsWith('request'))}">
+            <i class="fa fa-fw fa-tasks"></i>
+            <span>Requests</span>
+          </a>
+        </li>
+        <li ng-show="hasPermission(user, 'bg-job-read')">
+          <a ui-sref="base.jobs"
+             ng-class="{active: ($state.current.name.startsWith('job'))}">
+            <i class="fa fa-fw fa-calendar"></i>
+            <span>Scheduler</span>
+          </a>
+        </li>
 
         <li class="dropdown" ui-sref-active="active">
           <a href="" class="dropdown-toggle" data-toggle="dropdown">
@@ -74,36 +100,36 @@
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
-             <li>
-                  <a ui-sref="base.system_admin" ui-sref-active="active">
-                    <i class="fa fa-power-off"></i>
-                    <span>Systems Management</span>
-                  </a>
-                </li>
-                <li ng-show="hasPermission(user, 'bg-queue-read')">
-                  <a ui-sref="base.queues" ui-sref-active="active">
-                    <i class="fa fa-database"></i>
-                    <span>Queue Management</span>
-                  </a>
-                </li>
-                <li ng-show="hasPermission(user, 'bg-user-read')">
-                  <a ui-sref="base.user_admin" ui-sref-active="active">
-                    <i class="fa fa-user"></i>
-                    <span>User Management</span>
-                  </a>
-                </li>
-                <li ng-show="hasPermission(user, 'bg-role-read')">
-                  <a ui-sref="base.role_admin" ui-sref-active="active">
-                    <i class="fa fa-tag"></i>
-                    <span>Role Management</span>
-                  </a>
-                </li>
-                <li ng-show="hasPermission(user, 'bg-role-read')">
-                  <a ui-sref="base.garden_admin" ui-sref-active="active">
-                    <i class="fa fa-leaf"></i>
-                    <span>Garden Management</span>
-                  </a>
-                </li>
+            <li>
+              <a ui-sref="base.system_admin" ui-sref-active="active">
+                <i class="fa fa-power-off"></i>
+                <span>Systems Management</span>
+              </a>
+            </li>
+            <li ng-show="hasPermission(user, 'bg-queue-read')">
+              <a ui-sref="base.queues" ui-sref-active="active">
+                <i class="fa fa-database"></i>
+                <span>Queue Management</span>
+              </a>
+            </li>
+            <li ng-show="hasPermission(user, 'bg-user-read')">
+              <a ui-sref="base.user_admin" ui-sref-active="active">
+                <i class="fa fa-user"></i>
+                <span>User Management</span>
+              </a>
+            </li>
+            <li ng-show="hasPermission(user, 'bg-role-read')">
+              <a ui-sref="base.role_admin" ui-sref-active="active">
+                <i class="fa fa-tag"></i>
+                <span>Role Management</span>
+              </a>
+            </li>
+            <li ng-show="hasPermission(user, 'bg-role-read')">
+              <a ui-sref="base.garden_admin" ui-sref-active="active">
+                <i class="fa fa-leaf"></i>
+                <span>Garden Management</span>
+              </a>
+            </li>
           </ul>
         </li>
 
@@ -133,35 +159,6 @@
         </li>
       </ul>
       <!-- Navbar Top End -->
-
-      <!-- Sidebar Start -->
-      <div class="navbar-default sidebar" role="navigation">
-        <div class="sidebar-nav navbar-collapse">
-          <ul class="nav" id="side-menu" >
-            <li ng-repeat="namespace in namespaces">
-              <a>
-                <i class="fa fa-cogs fa-fw"></i>
-                <span>{{namespace}}</span>
-                <span class="fa arrow"></span>
-              </a>
-              <ul class="nav nav-second-level">
-                <li ng-repeat="system in systems" >
-                  <a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})"
-                     ui-sref-active="active"
-                     ng-if="system.namespace == namespace">
-                    <i class="fa fa-cog"></i>
-                    <span>{{system.namespace}}</span>
-                    <span>{{system.display_name || system.name}}</span>
-                    <span>{{system.version}}</span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <!-- Sidebar End -->
-
     </nav>
     <!-- Navbar End -->
 

--- a/src/ui/src/styles/custom.css
+++ b/src/ui/src/styles/custom.css
@@ -75,6 +75,7 @@ html, body{
 }
 #page-wrapper{
     min-height: 100%;
+    margin: 0 auto;
 }
 .icon-color{
     color: black !important;


### PR DESCRIPTION

~~This changed the side menu to only have system information. Everything else is at the top.~~

~~Issue:~~
~~The Namespaces would not collapse for me. I don't know if this is because it is a dynamic list.~~

~~Another Note:~~
~~I just randomly put them in an order, if we want to re-arrange them we can.~~

This now moves everything to the top bar. Giving the user the entire width of their display. The logo in the top left is now a drop down menu to allow them to quickly navigate to a system. It searches all fields of the plugin, including description. Hoverover of the systems give the system description as well.
