### PR TITLE
FanoutProcessor no longer starts child processors before it starts

### DIFF
--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -249,7 +249,7 @@ class Application(StoppableThread):
         event_manager = FanoutProcessor()
 
         # Forward all events down into the entry points
-        event_manager.register(self.entry_manager, start=False)
+        event_manager.register(self.entry_manager, manage=False)
 
         # Register the callback processor
         event_manager.register(QueueListener(action=garden_callbacks))


### PR DESCRIPTION
This PR fixes an issue where the application wouldn't shut down cleanly if it could not connect to mongo.