### PR TITLE
Create sub menus

### DIFF
--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -105,7 +105,7 @@
                   <div style="padding: 3px 15px; cursor: pointer;"
                      ng-click="setMenuPage('main')">
                   <span class="fa fa-chevron-left"></span>
-                  <span>Themes</span>
+                  <span><b>Themes</b></span>
                 </div>
                 </form>
             <li>
@@ -131,7 +131,7 @@
                   <div style="padding: 3px 15px; cursor: pointer;"
                      ng-click="setMenuPage('main')">
                     <span class="fa fa-chevron-left"></span>
-                    <span>Admin</span>
+                    <span><b>Admin</b></span>
                 </div>
                 </form>
             <li>

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -80,40 +80,77 @@
              ng-class="{active: ($state.current.name.startsWith('job'))}">Scheduler</a>
         </li>
 
+        <!-- Menu Bar broken into three sections: main, themes, admin -->
+        <!-- Based on the current menu view selected will determine which elements are seen -->
         <li id="nav-extras" class="dropdown">
-          <a href="" class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></a>
+          <a href="" class="fa fa-bars dropdown-toggle" data-toggle="dropdown" ng-click="setMenuPage('main')"></a>
           <ul class="dropdown-menu">
-            <li><a ui-sref="base.about" ui-sref-active="active">About</a></li>
-            <hr>
-            <li ng-repeat="(style, enabled) in themes">
+            <li ng-show="!checkMenuPage('main')">
+              <form>
+                <div style="padding: 3px 15px; cursor: pointer;"
+                     ng-click="setMenuPage('main')">
+                  <span class="fa fa-chevron-left"></span>
+                  <span>Back</span>
+                </div>
+              </form>
+            </li>
+            <li ng-show="checkMenuPage('main')">
+              <a ui-sref="base.about" ui-sref-active="active">About</a>
+            </li>
+            <li ng-show="checkMenuPage('main')" role="separator" class="divider"></li>
+            <form>
+            <li ng-show="checkMenuPage('main')">
+              <form>
+                <div style="padding: 3px 15px; cursor: pointer;"
+                     ng-click="setMenuPage('theme')">
+                  <span>Themes</span>
+                  <span class="fa fa-chevron-right"></span>
+                </div>
+              </form>
+            </li>
+            </form>
+            <li ng-show="checkMenuPage('theme')"><h5>Themes</h5></li>
+            <li ng-repeat="(style, enabled) in themes" ng-show="checkMenuPage('theme')">
               <div style="padding: 3px 15px; cursor: pointer;"
                     ng-click="changeTheme(style, true)">
                 <span class="fa" ng-class="{'fa-check': enabled, 'fa-fw': !enabled}"></span>
                 <span>{{style}}</span>
               </div>
             </li>
-            <hr>
+            <li ng-show="(hasPermission(user, 'bg-queue-read') || hasPermission(user, 'bg-role-read')) && checkMenuPage('main')" role="separator" class="divider"><li>
+            <li ng-show="(hasPermission(user, 'bg-queue-read') || hasPermission(user, 'bg-role-read')) && checkMenuPage('main')" >
+                <form>
+                  <div style="padding: 3px 15px; cursor: pointer;"
+                       ng-click="setMenuPage('admin')">
+                    <span>Admin</span>
+                    <span class="fa fa-chevron-right"></span>
+                  </div>
+                </form>
             <li>
+            <li ng-show="checkMenuPage('admin')">
+              <span>Admin</span>
+            </li>
+            <li ng-show="checkMenuPage('admin')">
               <a ui-sref="base.system_admin" ui-sref-active="active">
                 <span>Systems</span>
               </a>
             </li>
-            <li ng-show="hasPermission(user, 'bg-queue-read')">
+            <li ng-show="hasPermission(user, 'bg-queue-read') && checkMenuPage('admin')">
               <a ui-sref="base.queues" ui-sref-active="active">
                 <span>Queues</span>
               </a>
             </li>
-            <li ng-show="hasPermission(user, 'bg-user-read')">
+            <li ng-show="hasPermission(user, 'bg-user-read') && checkMenuPage('admin')">
               <a ui-sref="base.user_admin" ui-sref-active="active">
                 <span>Users</span>
               </a>
             </li>
-            <li ng-show="hasPermission(user, 'bg-role-read')">
+            <li ng-show="hasPermission(user, 'bg-role-read') && checkMenuPage('admin')">
               <a ui-sref="base.role_admin" ui-sref-active="active">
                 <span>Roles</span>
               </a>
             </li>
-            <li ng-show="hasPermission(user, 'bg-role-read')">
+            <li ng-show="hasPermission(user, 'bg-role-read') && checkMenuPage('admin')">
               <a ui-sref="base.garden_admin" ui-sref-active="active">
                 <span>Gardens</span>
               </a>

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -85,19 +85,10 @@
         <li id="nav-extras" class="dropdown">
           <a href="" class="fa fa-bars dropdown-toggle" data-toggle="dropdown" ng-click="setMenuPage('main')"></a>
           <ul class="dropdown-menu">
-            <li ng-show="!checkMenuPage('main')">
-              <form>
-                <div style="padding: 3px 15px; cursor: pointer;"
-                     ng-click="setMenuPage('main')">
-                  <span class="fa fa-chevron-left"></span>
-                  <span>Back</span>
-                </div>
-              </form>
-            </li>
+
             <li ng-show="checkMenuPage('main')">
               <a ui-sref="base.about" ui-sref-active="active">About</a>
             </li>
-            <li ng-show="checkMenuPage('main')" role="separator" class="divider"></li>
             <form>
             <li ng-show="checkMenuPage('main')">
               <form>
@@ -109,7 +100,16 @@
               </form>
             </li>
             </form>
-            <li ng-show="checkMenuPage('theme')"><h5>Themes</h5></li>
+            <li ng-show="checkMenuPage('theme')" >
+                <form>
+                  <div style="padding: 3px 15px; cursor: pointer;"
+                     ng-click="setMenuPage('main')">
+                  <span class="fa fa-chevron-left"></span>
+                  <span>Themes</span>
+                </div>
+                </form>
+            <li>
+            <li ng-show="checkMenuPage('theme')" role="separator" class="divider"><li>
             <li ng-repeat="(style, enabled) in themes" ng-show="checkMenuPage('theme')">
               <div style="padding: 3px 15px; cursor: pointer;"
                     ng-click="changeTheme(style, true)">
@@ -117,7 +117,6 @@
                 <span>{{style}}</span>
               </div>
             </li>
-            <li ng-show="(hasPermission(user, 'bg-queue-read') || hasPermission(user, 'bg-role-read')) && checkMenuPage('main')" role="separator" class="divider"><li>
             <li ng-show="(hasPermission(user, 'bg-queue-read') || hasPermission(user, 'bg-role-read')) && checkMenuPage('main')" >
                 <form>
                   <div style="padding: 3px 15px; cursor: pointer;"
@@ -127,9 +126,16 @@
                   </div>
                 </form>
             <li>
-            <li ng-show="checkMenuPage('admin')">
-              <span>Admin</span>
-            </li>
+            <li ng-show="(hasPermission(user, 'bg-queue-read') || hasPermission(user, 'bg-role-read')) && checkMenuPage('admin')" >
+                <form>
+                  <div style="padding: 3px 15px; cursor: pointer;"
+                     ng-click="setMenuPage('main')">
+                    <span class="fa fa-chevron-left"></span>
+                    <span>Admin</span>
+                </div>
+                </form>
+            <li>
+            <li ng-show="checkMenuPage('admin')" role="separator" class="divider"><li>
             <li ng-show="checkMenuPage('admin')">
               <a ui-sref="base.system_admin" ui-sref-active="active">
                 <span>Systems</span>
@@ -154,6 +160,8 @@
               <a ui-sref="base.garden_admin" ui-sref-active="active">
                 <span>Gardens</span>
               </a>
+            </li>
+
             </li>
           </ul>
         </li>

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -71,6 +71,8 @@ export default function appRun(
     'slate': false,
   };
 
+  $rootScope.menu_page = "main"
+
   $rootScope.responseState = responseState;
 
   $rootScope.getIcon = UtilityService.getIcon;
@@ -150,6 +152,8 @@ export default function appRun(
     }
   };
 
+
+
   $rootScope.isUser = function(user) {
     return user && user.username !== 'anonymous';
   };
@@ -191,6 +195,14 @@ export default function appRun(
   $transitions.onSuccess({to: 'base'}, () => {
     $state.go('base.landing');
   });
+
+  $rootScope.setMenuPage = function(page){
+    $rootScope.menu_page = page
+  }
+
+  $rootScope.checkMenuPage = function(page) {
+    return $rootScope.menu_page == page
+  }
 
   function upsertSystem(system) {
     let index = _.findIndex($rootScope.systems, {id: system.id});


### PR DESCRIPTION
Trying to clean up how we have our drop down menu in the top right.

Previous the menu was as followed:
```
About
---------
default
slate
--------
Systems
Queues
Users
Roles
Gardens
```

Now the menus are broken out into three sections: Main, Themes, and Admin. When you click on the option it will open the sub-menu. Not sure if only Themes should be like this, but I went ahead and did the Admin actions the same way to see how it looks.