### PR TITLE
Return Local Garden Info

### DIFF
--- a/src/app/beer_garden/__init__.py
+++ b/src/app/beer_garden/__init__.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from beer_garden.__version__ import __version__
 
-__all__ = [
-    "__version__",
-    "application",
-]
+__all__ = ["__version__", "application"]
 
 # COMPONENTS #
 application = None

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -703,6 +703,12 @@ class Garden(MongoModel, Document):
         "indexes": [{"name": "unique_index", "fields": ["name"], "unique": True}],
     }
 
+    def deep_save(self):
+        for system in self.systems:
+            system.deep_save()
+
+        self.save()
+
 
 class SystemGardenMapping(MongoModel, Document):
     system = ReferenceField("System")

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -301,6 +301,7 @@ class Request(MongoModel, Document):
             {"name": "command_type_index", "fields": ["command_type"]},
             {"name": "system_index", "fields": ["system"]},
             {"name": "instance_name_index", "fields": ["instance_name"]},
+            {"name": "namespace_index", "fields": ["namespace"]},
             {"name": "status_index", "fields": ["status"]},
             {"name": "created_at_index", "fields": ["created_at"]},
             {"name": "updated_at_index", "fields": ["updated_at"]},

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -111,7 +111,6 @@ def create_garden(garden: Garden) -> Garden:
         The created Garden
 
     """
-    garden.status = "INITIALIZING"
     garden.status_info["heartbeat"] = datetime.utcnow()
 
     return db.create(garden)

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -168,9 +168,15 @@ def handle_event(event):
                 existing_garden = get_garden(event.payload.name)
 
                 if existing_garden is None:
+                    for system in event.payload.systems:
+                        system.local = False
+
                     create_garden(event.payload)
                 else:
                     for attr in ("status", "status_info", "namespaces", "systems"):
                         setattr(existing_garden, attr, getattr(event.payload, attr))
+
+                    for system in existing_garden.systems:
+                        system.local = False
 
                     update_garden(existing_garden)

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -9,6 +9,7 @@ from brewtils.models import Events, Garden, System
 import beer_garden.config as config
 import beer_garden.db.api as db
 from beer_garden.events import publish_event
+from beer_garden.systems import get_systems
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,8 @@ def get_garden(garden_name: str) -> Garden:
         The Garden
 
     """
+    if garden_name == config.get("garden.name"):
+        return get_local_garden()
     return db.query_unique(Garden, name=garden_name)
 
 
@@ -33,7 +36,34 @@ def get_gardens() -> List[Garden]:
         The Garden list
 
     """
-    return db.query(Garden)
+
+    query_results = db.query(Garden)
+    if query_results:
+        query_results.append(get_local_garden())
+        return query_results
+    return [get_local_garden()]
+
+
+def get_local_garden() -> Garden:
+    """Retrieved the local garden object
+
+    Returns:
+        Garden Object
+
+    """
+    local_garden = Garden(
+        name=config.get("garden.name"),
+        connection_type="LOCAL",
+        systems=get_systems(filter_params={"local": True}),
+        status="RUNNING",
+        status_info="This is your local Garden record, not persisted in the Database. "
+        "Changes will not be reflected",
+    )
+    for system in local_garden.systems:
+        if system.namespace not in local_garden.namespaces:
+            local_garden.namespaces.append(system.namespace)
+
+    return local_garden
 
 
 def update_garden_config(garden: Garden):

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -55,7 +55,7 @@ def get_local_garden() -> Garden:
         name=config.get("garden.name"),
         connection_type="LOCAL",
         systems=get_systems(filter_params={"local": True}),
-        status="RUNNING"
+        status="RUNNING",
     )
     for system in local_garden.systems:
         if system.namespace not in local_garden.namespaces:

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -55,9 +55,7 @@ def get_local_garden() -> Garden:
         name=config.get("garden.name"),
         connection_type="LOCAL",
         systems=get_systems(filter_params={"local": True}),
-        status="RUNNING",
-        status_info="This is your local Garden record, not persisted in the Database. "
-        "Changes will not be reflected",
+        status="RUNNING"
     )
     for system in local_garden.systems:
         if system.namespace not in local_garden.namespaces:

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -160,6 +160,9 @@ def handle_event(event):
                 existing_garden = get_garden(event.payload.name)
 
                 if existing_garden is None:
+                    event.payload.connection_type = None
+                    event.payload.connection_params = {}
+
                     for system in event.payload.systems:
                         system.local = False
 

--- a/src/app/beer_garden/local_plugins/runner.py
+++ b/src/app/beer_garden/local_plugins/runner.py
@@ -119,10 +119,10 @@ class ProcessRunner(Thread):
 
             # Reading process IO is blocking so needs to be in separate threads
             stdout_thread = Thread(
-                target=self._read_stream, args=(self.process.stdout, logging.INFO),
+                target=self._read_stream, args=(self.process.stdout, logging.INFO)
             )
             stderr_thread = Thread(
-                target=self._read_stream, args=(self.process.stderr, logging.ERROR),
+                target=self._read_stream, args=(self.process.stderr, logging.ERROR)
             )
             stdout_thread.start()
             stderr_thread.start()

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -221,10 +221,14 @@ def setup_routing():
 
 def handle_event(event):
     """Handle events"""
-    if event.name in (
-        Events.SYSTEM_CREATED.name,
-        Events.SYSTEM_UPDATED.name,
-        Events.SYSTEM_REMOVED.name,
+    if (
+        event.name
+        in (
+            Events.SYSTEM_CREATED.name,
+            Events.SYSTEM_UPDATED.name,
+            Events.SYSTEM_REMOVED.name,
+        )
+        and event.garden in gardens
     ):
         index = None
         for i, system in enumerate(gardens[event.garden].systems):

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -20,7 +20,7 @@ import beer_garden.scheduler
 import beer_garden.systems
 from beer_garden.errors import RoutingRequestException, UnknownGardenException
 from beer_garden.garden import get_gardens
-from beer_garden.garden import get_local_garden
+from beer_garden.garden import local_garden
 
 logger = logging.getLogger(__name__)
 
@@ -215,7 +215,7 @@ def setup_routing():
                 logger.warning(f"Garden with invalid connection info: {garden!r}")
 
     # Now add the "local" garden
-    gardens[local_garden_name] = get_local_garden()
+    gardens[local_garden_name] = local_garden()
     logger.debug("Routing setup complete")
 
 

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -20,7 +20,7 @@ import beer_garden.scheduler
 import beer_garden.systems
 from beer_garden.errors import RoutingRequestException, UnknownGardenException
 from beer_garden.garden import get_gardens
-from beer_garden.systems import get_systems
+from beer_garden.garden import get_local_garden
 
 logger = logging.getLogger(__name__)
 
@@ -215,12 +215,7 @@ def setup_routing():
                 logger.warning(f"Garden with invalid connection info: {garden!r}")
 
     # Now add the "local" garden
-    gardens[local_garden_name] = Garden(
-        name=local_garden_name,
-        connection_type="local",
-        systems=get_systems(filter_params={"local": True}),
-    )
-
+    gardens[local_garden_name] = get_local_garden()
     logger.debug("Routing setup complete")
 
 

--- a/src/app/test/router_test.py
+++ b/src/app/test/router_test.py
@@ -13,8 +13,6 @@ import beer_garden.router
 @pytest.fixture(autouse=True)
 def setup():
     beer_garden.router.gardens = {}
-    # beer_garden.router.garden_lookup = {}
-    # beer_garden.router.garden_connections = {}
 
     conf = Box(default_box=True)
     conf.garden.name = "parent"
@@ -53,12 +51,7 @@ def l_garden():
 
 @pytest.fixture
 def p_garden(p_sys_1, p_sys_2):
-    return Garden(
-        name="parent",
-        connection_type="local",
-        systems=[p_sys_1, p_sys_2]
-        # name="parent", connection_type="local", systems=[str(p_sys_1), str(p_sys_2)]
-    )
+    return Garden(name="parent", connection_type="local", systems=[p_sys_1, p_sys_2])
 
 
 @pytest.fixture

--- a/src/app/test/router_test.py
+++ b/src/app/test/router_test.py
@@ -69,7 +69,7 @@ def get_gardens_mock(monkeypatch):
 @pytest.fixture
 def get_local_garden_mock(monkeypatch):
     mock = Mock(return_value=[])
-    monkeypatch.setattr(beer_garden.router, "get_local_garden", mock)
+    monkeypatch.setattr(beer_garden.router, "local_garden", mock)
     return mock
 
 

--- a/src/app/test/router_test.py
+++ b/src/app/test/router_test.py
@@ -63,12 +63,7 @@ def p_garden(p_sys_1, p_sys_2):
 
 @pytest.fixture
 def c_garden(c_sys_1, c_sys_2):
-    return Garden(
-        name="child",
-        connection_type="http",
-        systems=[c_sys_1, c_sys_2]
-        # name="child", connection_type="http", systems=[str(c_sys_1), str(c_sys_2)]
-    )
+    return Garden(name="child", connection_type="http", systems=[c_sys_1, c_sys_2])
 
 
 @pytest.fixture

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -32,16 +32,21 @@ export default function adminGardenViewController(
     $scope.$broadcast('schemaFormRedraw');
   };
   $scope.successCallback = function(response) {
+
     $scope.response = response;
     $scope.data = response.data;
-    $scope.gardenModel = response.data;
-    generateGardenSF();
 
     if ($scope.data.id == null || $scope.data.connection_type == 'LOCAL'){
       $scope.alerts.push({
-        msg: 'This is marked as your local Garden record. This record is auto generated at startup. ' +
-             'So any changes to connection info will not persisted in the Database. ',
+        type: 'danger',
+        msg: 'This is marked as a local Garden record. The local Garden record is auto generated at startup. ' +
+             'So any changes to your local Garden record Connection Parameters will not persisted in the Database. ',
       });
+
+    $scope.gardenModel = response.data;
+    generateGardenSF();
+
+
     }
 
   };
@@ -80,8 +85,9 @@ export default function adminGardenViewController(
 
   loadAll();
 
-  };
-
   $scope.closeAlert = function(index) {
     $scope.alerts.splice(index, 1);
   };
+
+  };
+

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -3,7 +3,6 @@ import _ from 'lodash';
 adminGardenViewController.$inject = [
   '$scope',
   'GardenService',
-  'EventService',
   '$stateParams'
 ];
 
@@ -11,45 +10,46 @@ adminGardenViewController.$inject = [
  * adminGardenController - Garden management controller.
  * @param  {Object} $scope          Angular's $scope object.
  * @param  {Object} GardenService    Beer-Garden's garden service object.
- * @param  {Object} EventService    Beer-Garden's event service object.
  */
 export default function adminGardenViewController(
     $scope,
     GardenService,
-    EventService,
     $stateParams) {
   $scope.setWindowTitle('Configure Garden');
   $scope.alerts = [];
 
+  $scope.isLocal = false;
   $scope.gardenSchema = null;
   $scope.gardenForm = null;
   $scope.gardenModel = {};
+
+  $scope.closeAlert = function(index) {
+    $scope.alerts.splice(index, 1);
+  };
 
   let generateGardenSF = function() {
     $scope.gardenSchema = GardenService.SCHEMA;
     $scope.gardenForm = GardenService.FORM;
     $scope.gardenModel = GardenService.serverModelToForm($scope.data);
+
     $scope.$broadcast('schemaFormRedraw');
   };
-  $scope.successCallback = function(response) {
 
+  $scope.successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
 
     if ($scope.data.id == null || $scope.data.connection_type == 'LOCAL'){
+      $scope.isLocal = true;
       $scope.alerts.push({
-        type: 'danger',
-        msg: 'This is marked as a local Garden record. The local Garden record is auto generated at startup. ' +
-             'So any changes to your local Garden record Connection Parameters will not persisted in the Database. ',
+        type: 'info',
+        msg: "Since this is the local Garden it's not possible to modify connection information"
       });
-
-    $scope.gardenModel = response.data;
-    generateGardenSF();
-
-
     }
 
+    generateGardenSF();
   };
+
  $scope.failureCallback = function(response) {
     $scope.response = response;
     $scope.data = [];
@@ -73,9 +73,9 @@ export default function adminGardenViewController(
     $scope.$broadcast('schemaFormValidate');
 
     if (form.$valid){
-       var garden = GardenService.formToServerModel($scope.data, model);
-       GardenService.updateGardenConfig(garden);
+       let updated_garden = GardenService.formToServerModel($scope.data, model);
 
+       GardenService.updateGardenConfig(updated_garden);
      }
   };
 
@@ -85,9 +85,5 @@ export default function adminGardenViewController(
 
   loadAll();
 
-  $scope.closeAlert = function(index) {
-    $scope.alerts.splice(index, 1);
-  };
-
-  };
+};
 

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -19,6 +19,7 @@ export default function adminGardenViewController(
     EventService,
     $stateParams) {
   $scope.setWindowTitle('Configure Garden');
+  $scope.alerts = [];
 
   $scope.gardenSchema = null;
   $scope.gardenForm = null;
@@ -35,6 +36,13 @@ export default function adminGardenViewController(
     $scope.data = response.data;
     $scope.gardenModel = response.data;
     generateGardenSF();
+
+    if ($scope.data.id == null || $scope.data.connection_type == 'LOCAL'){
+      $scope.alerts.push({
+        msg: 'This is marked as your local Garden record. This record is auto generated at startup. ' +
+             'So any changes to connection info will not persisted in the Database. ',
+      });
+    }
 
   };
  $scope.failureCallback = function(response) {
@@ -72,4 +80,8 @@ export default function adminGardenViewController(
 
   loadAll();
 
+  };
+
+  $scope.closeAlert = function(index) {
+    $scope.alerts.splice(index, 1);
   };

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -34,7 +34,7 @@ export default function gardenService($http) {
 
     var values = {};
     values['connection_type'] = model['connection_type'];
-     if (model.hasOwnProperty('connection_params')) {
+     if (model.hasOwnProperty('connection_params') && model.connection_params != null) {
         for (var parameter of Object.keys(model['connection_params']) ) {
           values[parameter] = model['connection_params'][parameter];
         }

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -12,6 +12,8 @@
     <div class="panel-heading">
       <h3>
         <span>{{garden.name}}</span>
+        <span ng-show="garden.id == null || garden.connection_type == 'LOCAL'">(LOCAL)</span>
+        <span ng-show="garden.id != null && garden.connection_type != 'LOCAL'">(REMOTE)</span>
       </h3>
     </div>
     <div class="panel-body" style="padding-bottom: 0;">

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -4,6 +4,14 @@
 
 <fetch-data response="response"></fetch-data>
 
+<div uib-alert
+     ng-repeat="alert in alerts"
+     ng-class="'alert-' + alert.type"
+     close="closeAlert($index)">
+  {{alert.msg}}
+</div>
+
+
 <div id="garden-view-container"
      class="animate-if"
      ng-if="responseState(response) === 'success'">

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -1,53 +1,73 @@
 <h1 class='page-header'>
-  <span>Garden Editor</span>
+  <span>Garden View</span>
 </h1>
 
 <fetch-data response="response"></fetch-data>
 
-<div uib-alert
-     ng-repeat="alert in alerts"
-     ng-class="'alert-' + alert.type"
-     close="closeAlert($index)">
-  {{alert.msg}}
-</div>
-
-
 <div id="garden-view-container"
-     class="animate-if"
+     class="animate-if container-fluid"
      ng-if="responseState(response) === 'success'">
 
-  <h3 class='page-header'>
-    <span>Connected Systems</span>
-  </h3>
-
-  <table
-      datatable="ng"
-      dt-options="dtOptions"
-      class="table table-striped table-bordered"
-      style="width: 100%">
-    <thead>
-      <tr>
-        <th id="th_job_name">Namespace</th>
-        <th id="th_job_status">System</th>
-        <th id="th_system">Version</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr ng-repeat="system in data.systems">
-        <td><a ui-sref="base.systems({namespace: system.namespace})">{{system.namespace}}</a></span></td>
-        <td>{{system.name}}</td>
-        <td><a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})">{{system.version}}</a></span></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <h3 class='page-header'>
-    <span>Connection Parameters</span>
-  </h3>
-
-  <div class="container-fluid">
+  <div class="row">
+    <h4>Garden Info</h4>
     <div class="row">
-      <div class="col-md-8">
+      <div class="col-md-2">Name:</div>
+      <div class="col-md-2">{{data.name}}</div>
+    </div>
+    <div class="row">
+      <div class="col-md-2">Status:</div>
+      <div class="col-md-2">{{data.status}}</div>
+    </div>
+    <div class="row">
+      <div class="col-md-2">Known Namespaces:</div>
+      <div class="col-md-2">
+        <ul>
+          <li ng-repeat="ns in data.namespaces">{{ns}}</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-2">Connection Type:</div>
+      <div class="col-md-2">{{data.connection_type}}</div>
+    </div>
+  </div>
+
+  <div class="row">
+    <h4>Connected Systems</h4>
+    <table
+        datatable="ng"
+        dt-options="dtOptions"
+        class="table table-striped table-bordered"
+        style="width: 100%">
+      <thead>
+        <tr>
+          <th id="th_job_name">Namespace</th>
+          <th id="th_job_status">System</th>
+          <th id="th_system">Version</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="system in data.systems">
+          <td><a ui-sref="base.systems({namespace: system.namespace})">{{system.namespace}}</a></span></td>
+          <td>{{system.name}}</td>
+          <td><a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})">{{system.version}}</a></span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div uib-alert
+    ng-repeat="alert in alerts"
+    ng-class="'alert-' + alert.type"
+    close="closeAlert($index)">
+      {{alert.msg}}
+  </div>
+
+  <div ng-hide="isLocal">
+    <h4>Update Connection</h4>
+    <div class="container-fluid">
+      <div class="row">
         <form
             name="gardenform"
             sf-schema="gardenSchema"
@@ -57,4 +77,5 @@
       </div>
     </div>
   </div>
+
 </div>


### PR DESCRIPTION
When viewing the Gardens on the UI we couldn't see the local garden information. These changes will inject the Local Garden object when someone requests all of the Gardens. When someone attempts to make changes to the Garden it will not persist because it does not have an ID. When you restart with a new Garden name it will change that Garden info. If you select a Garden Name of a downstream Garden, you will see both in the UI but with different comments next to them (Local vs Remote). 