### PR TITLE
Provide PYTHONPATH in beer.conf

### DIFF
--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -41,6 +41,7 @@ class ConfigKeys(Enum):
     DISPLAY_NAME = 11
     METADATA = 12
     NAMESPACE = 13
+    PYTHONPATH = 14
 
 
 class PluginManager(StoppableThread):
@@ -318,7 +319,10 @@ class PluginManager(StoppableThread):
 
     @staticmethod
     def _process_args(plugin_config, instance_name):
-        process_args = [sys.executable]
+        if plugin_config.get("PYTHONPATH"):
+            process_args = [plugin_config.get("PYTHONPATH")]
+        else:
+            process_args = [sys.executable]
 
         if plugin_config.get("PLUGIN_ENTRY"):
             process_args += plugin_config["PLUGIN_ENTRY"].split(" ")

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -41,7 +41,7 @@ class ConfigKeys(Enum):
     DISPLAY_NAME = 11
     METADATA = 12
     NAMESPACE = 13
-    PYTHONPATH = 14
+    INTERPRETER_PATH = 14
 
 
 class PluginManager(StoppableThread):
@@ -319,8 +319,8 @@ class PluginManager(StoppableThread):
 
     @staticmethod
     def _process_args(plugin_config, instance_name):
-        if plugin_config.get("PYTHONPATH"):
-            process_args = [plugin_config.get("PYTHONPATH")]
+        if plugin_config.get("INTERPRETER_PATH"):
+            process_args = [plugin_config.get("INTERPRETER_PATH")]
         else:
             process_args = [sys.executable]
 


### PR DESCRIPTION
This change will allow developers to self manage the Python environment. If they do not provide a Python Path then it will default to path the Beer Garden is using.

Fixes #492 