### PR TITLE
Downloads

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -181,6 +181,7 @@ def _setup_tornado_app():
         (rf"{prefix}api/v1/commands/(\w+)/?", v1.command.CommandAPI),
         (rf"{prefix}api/v1/instances/(\w+)/?", v1.instance.InstanceAPI),
         (rf"{prefix}api/v1/requests/(\w+)/?", v1.request.RequestAPI),
+        (rf"{prefix}api/v1/requests/output/(\w+)/?", v1.request.RequestOutputAPI),
         (rf"{prefix}api/v1/systems/(\w+)/?", v1.system.SystemAPI),
         (rf"{prefix}api/v1/queues/([\w\.-]+)/?", v1.queue.QueueAPI),
         (rf"{prefix}api/v1/users/(\w+)/?", v1.user.UserAPI),

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -125,6 +125,47 @@ class RequestAPI(BaseHandler):
         self.write(response)
 
 
+class RequestOutputAPI(BaseHandler):
+    @authenticated(permissions=[Permissions.REQUEST_READ])
+    async def get(self, request_id):
+        """
+        ---
+        summary: Retrieve a specific Request output
+        parameters:
+          - name: request_id
+            in: path
+            required: true
+            description: The ID of the Request
+            type: string
+        responses:
+          200:
+            description: Request output for request with the given ID
+            type: String
+          404:
+            $ref: '#/definitions/404Error'
+          50x:
+            $ref: '#/definitions/50xError'
+        tags:
+          - Requests
+        """
+
+        response = await self.client(
+            Operation(operation_type="REQUEST_READ", args=[request_id]),
+            serialize_kwargs={"to_string": False},
+        )
+
+        if response["output"]:
+            content_types = {
+                "HTML": "text/html; charset=UTF-8",
+                "JSON": "application/json; charset=UTF-8",
+                "STRING": "text/plain; charset=UTF-8",
+            }
+            self.set_header("Content-Type", content_types[response["output_type"]])
+            self.write(response["output"])
+        else:
+            self.set_status(204)
+
+
 class RequestListAPI(BaseHandler):
     parser = SchemaParser()
 

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1818,8 +1818,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "batch": {
       "version": "0.6.1",
@@ -5166,8 +5165,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -6524,6 +6522,25 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object-sizeof": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.6.1.tgz",
+      "integrity": "sha512-gNKGcRnDRXwEpAdwUY3Ef+aVZIrcQVXozSaVzHz6Pv4JxysH8vf5F+nIgsqW5T/YNwZNveh0mIW7PEH1O2MrDw==",
+      "requires": {
+        "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
     },
     "object-visit": {
       "version": "1.0.1",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -36,6 +36,7 @@
     "moment": "^2.19.1",
     "moment-timezone": "^0.5.0",
     "object-assign": "^4.1.1",
+    "object-sizeof": "^1.6.1",
     "objectpath": "^2.0.0",
     "startbootstrap-sb-admin-2": "^3.3.7",
     "swagger-ui-dist": "^3.25.0",

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -155,10 +155,6 @@ angular.module('bgApp',
 .config(['localStorageServiceProvider', function(localStorageServiceProvider) {
   localStorageServiceProvider.setStorageType('sessionStorage');
 }])
-//Adds urls to whitelist to prevent undefined url for download link
-.config(['$compileProvider', function ($compileProvider) {
-  $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|data):/);
-}])
 .service('APIInterceptor', interceptorService)
 .service('authInterceptorService', authInterceptorService)
 .animation('.slide', slideAnimation)

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import sizeOf from 'object-sizeof';
 import {formatDate, formatJsonDisplay} from '../services/utility_service.js';
 
 requestViewController.$inject = [
@@ -40,7 +41,7 @@ export default function requestViewController(
   $scope.children = [];
   $scope.downloadHref = '';
   $scope.filename = '';
-  $scope.downloadVisible = true
+  $scope.downloadVisible = false;
   $scope.childrenDisplay = [];
   $scope.childrenCollapsed = false;
   $scope.rawOutput = undefined;
@@ -66,6 +67,8 @@ export default function requestViewController(
     'ERROR': 'The request encountered an error during processing and will ' +
              'not be reprocessed.',
   };
+
+  $scope.formatDate = formatDate;
 
   $scope.loadPreview = function(_editor) {
     formatJsonDisplay(_editor, true);
@@ -96,20 +99,14 @@ export default function requestViewController(
     $scope.showFormatted = false;
     $scope.formatErrorTitle = undefined;
     $scope.formatErrorMsg = undefined;
+
     let rawOutput = $scope.request.output;
-    let downloadHref = 'data:text/plain;charset=utf-8,' + encodeURIComponent($scope.request.output);
+
     try {
-      let raw_size = $scope.memorySizeOf(rawOutput)
       if (rawOutput === undefined || rawOutput == null) {
         rawOutput = 'null';
-        $scope.downloadVisible = false;
-      } else if (raw_size > 5){
-        $scope.formatErrorTitle = 'Output is too large';
-        $scope.formatErrorMsg = 'This output has a memory footprint of ' + raw_size  + ' MiB and ' +
-                                  'displaying it in the collapsible viewer would crash the ' +
-                                  'page. Depending on size, downloading file may take a few minutes for UI to prepare.';
-      } else if ($scope.request.output_type == 'HTML') {
-        $scope.filename = $scope.request.id+".html";
+      }
+      else if ($scope.request.output_type == 'HTML') {
         $scope.htmlOutput = rawOutput;
         $scope.formattedAvailable = true;
         $scope.showFormatted = true;
@@ -117,7 +114,6 @@ export default function requestViewController(
         try {
           let parsedOutput = JSON.parse(rawOutput);
           rawOutput = $scope.stringify(parsedOutput);
-          $scope.filename = $scope.request.id+".json";
           if ($scope.memorySizeOf($scope.formattedOutput) < 5) {
             $scope.jsonOutput = rawOutput;
             $scope.formattedAvailable = true;
@@ -136,20 +132,17 @@ export default function requestViewController(
         }
       } else if ($scope.request.output_type == 'STRING') {
         try {
-          $scope.filename = $scope.request.id+".txt";
           rawOutput = $scope.stringify(JSON.parse(rawOutput));
         } catch (err) { }
       }
     } finally {
-      $scope.downloadHref = downloadHref;
       $scope.rawOutput = rawOutput;
     }
   };
 
-  $scope.formatDate = formatDate;
-
   $scope.successCallback = function(request) {
     $scope.request = request;
+    $scope.filename = $scope.request.id;
 
     $scope.setWindowTitle(
       $scope.request.command,
@@ -160,7 +153,27 @@ export default function requestViewController(
     );
 
     if (RequestService.isComplete($scope.request)) {
-      $scope.formatOutput();
+
+      if (sizeOf(request) > 5000000) {
+        $scope.formatErrorTitle = 'Output is too large';
+        $scope.formatErrorMsg = 'The output for this request is too large to display, please download instead';
+      } else {
+        $scope.formatOutput();
+      }
+
+      if ($scope.request.output) {
+        $scope.downloadVisible = true;
+        $scope.downloadHref = `api/v1/requests/output/${$scope.request.id}`;
+
+        if ($scope.request.output_type == 'STRING') {
+          $scope.filename += ".txt";
+        } else if ($scope.request.output_type == 'HTML') {
+          $scope.filename += ".html";
+        } else if ($scope.request.output_type == 'JSON') {
+          $scope.filename += ".json";
+        }
+      }
+
       $scope.complete = true;
     }
 

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -39,7 +39,6 @@ export default function requestViewController(
   $scope.instanceStatus = undefined;
   $scope.timeoutRequest = undefined;
   $scope.children = [];
-  $scope.downloadHref = '';
   $scope.filename = '';
   $scope.downloadVisible = false;
   $scope.childrenDisplay = [];
@@ -163,7 +162,6 @@ export default function requestViewController(
 
       if ($scope.request.output) {
         $scope.downloadVisible = true;
-        $scope.downloadHref = `api/v1/requests/output/${$scope.request.id}`;
 
         if ($scope.request.output_type == 'STRING') {
           $scope.filename += ".txt";

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -114,7 +114,7 @@ export default function requestViewController(
         try {
           let parsedOutput = JSON.parse(rawOutput);
           rawOutput = $scope.stringify(parsedOutput);
-          if ($scope.memorySizeOf($scope.formattedOutput) < 5) {
+          if ($scope.countNodes($scope.formattedOutput) < 1000) {
             $scope.jsonOutput = rawOutput;
             $scope.formattedAvailable = true;
             $scope.showFormatted = true;
@@ -274,36 +274,17 @@ export default function requestViewController(
     return JSON.stringify(data, undefined, 2);
   };
 
-  $scope.memorySizeOf = function(obj) {
-    let bytes = 0;
+  $scope.countNodes = function(obj) {
+    // Arrays have type object too
+    if (typeof obj != 'object') {
+      return 1;
+    }
 
-    function sizeOf(obj) {
-        if(obj !== null && obj !== undefined) {
-            switch(typeof obj) {
-            case 'number':
-                bytes += 8;
-                break;
-            case 'string':
-                bytes += obj.length * 2;
-                break;
-            case 'boolean':
-                bytes += 4;
-                break;
-            case 'object':
-                var objClass = Object.prototype.toString.call(obj).slice(8, -1);
-                if(objClass === 'Object' || objClass === 'Array') {
-                    for(var key in obj) {
-                        if(!obj.hasOwnProperty(key)) continue;
-                        sizeOf(obj[key]);
-                    }
-                } else bytes += obj.toString().length * 2;
-                break;
-            }
-        }
-        return bytes;
-    };
-
-    return(sizeOf(obj) / 1048576).toFixed(3)
+    let total = 1;
+    for (const key of Object.keys(obj)) {
+      total += $scope.countNodes(object[key]);
+    }
+    return total;
   };
 
   function eventCallback(event) {

--- a/src/ui/src/partials/request_view.html
+++ b/src/ui/src/partials/request_view.html
@@ -106,7 +106,7 @@
                  ng-hide="!isMaximized"
                  style="font-size: 0.8em; margin-top: 11px; color: black"></a>
             <a class="fa fa-download pull-right" style="font-size: 0.8em; margin-top: 12px; color: black"
-                 ng-href="{{downloadHref}}" download="{{filename}}" ng-show="{{downloadVisible}}"></a>
+                 ng-href="api/v1/requests/output/{{request.id}}" download="{{filename}}" ng-show="downloadVisible"></a>
           </span>
           <span ng-show="formattedAvailable && format_error === undefined" style="margin-top: 9px" class="pull-right">
             <input bs-switch ng-model="showFormatted" switch-size="mini" type="checkbox" switch-label-width="0"


### PR DESCRIPTION
This PR adds an additional REST API path at `/api/v1/requests/output/<requestid>`. This enables us to provide the browser with an actual URL that will resolve to the output, which means we don't need to use data urls anymore.

It also reworks how we do the size checking on the frontend so there's no longer a delay between loading and rendering.

This fixes #505 and fixes #506.