### PR TITLE
Logging fix

### DIFF
--- a/src/app/beer_garden/log.py
+++ b/src/app/beer_garden/log.py
@@ -94,9 +94,20 @@ def process_record(record):
 
 def setup_entry_point_logging(queue):
     """Set up logging for an entry point process"""
-    root = logging.getLogger()
-    root.addHandler(logging.handlers.QueueHandler(queue))
-    root.setLevel(logging.DEBUG)
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "handlers": {
+                "entry_point": {
+                    "class": "logging.handlers.QueueHandler",
+                    "level": "DEBUG",
+                    "queue": queue,
+                }
+            },
+            "root": {"level": "DEBUG", "handlers": ["entry_point"]},
+        }
+    )
 
 
 def get_plugin_log_config(system_name=None):

--- a/src/app/beer_garden/log.py
+++ b/src/app/beer_garden/log.py
@@ -4,6 +4,7 @@ import logging
 import logging.config
 import logging.handlers
 
+import brewtils.log
 import six
 from brewtils.models import LoggingConfig
 from ruamel import yaml
@@ -12,8 +13,8 @@ from ruamel.yaml import YAML
 import beer_garden.config as config
 from beer_garden.errors import LoggingLoadingError
 
-plugin_logging_config = None
-_LOGGING_CONFIG = None
+_APP_LOGGING = None
+_PLUGIN_LOGGING = None
 
 
 def load(config: dict, force=False) -> None:
@@ -27,8 +28,8 @@ def load(config: dict, force=False) -> None:
         config: Subsection "log" of the loaded configuration
         force: Force a reload.
     """
-    global _LOGGING_CONFIG
-    if _LOGGING_CONFIG is not None and not force:
+    global _APP_LOGGING
+    if _APP_LOGGING is not None and not force:
         return
 
     logging_filename = config.get("config_file")
@@ -41,7 +42,7 @@ def load(config: dict, force=False) -> None:
 
     logging.config.dictConfig(logging_config)
 
-    _LOGGING_CONFIG = logging_config
+    _APP_LOGGING = logging_config
 
 
 def default_app_config(level, filename=None):
@@ -111,17 +112,18 @@ def setup_entry_point_logging(queue):
 
 
 def get_plugin_log_config(system_name=None):
-    return plugin_logging_config.get_plugin_log_config(system_name=system_name)
+    return _PLUGIN_LOGGING.get_plugin_log_config(system_name=system_name)
 
 
 def load_plugin_log_config():
-    global plugin_logging_config
+    global _PLUGIN_LOGGING
 
     plugin_config = config.get("plugin")
-    plugin_logging_config = PluginLoggingLoader.load(
+
+    _PLUGIN_LOGGING = PluginLoggingLoader.load(
         filename=plugin_config.logging.config_file,
         level=plugin_config.logging.level,
-        default_config=_LOGGING_CONFIG,
+        default_config=brewtils.log.default_config(level="INFO"),
     )
 
 

--- a/src/app/test/log_test.py
+++ b/src/app/test/log_test.py
@@ -24,7 +24,7 @@ class TestLoad(object):
 
         beer_garden.log.load({"level": level}, force=True)
 
-        assert beer_garden.log._LOGGING_CONFIG == default_app_config(level)
+        assert beer_garden.log._APP_LOGGING == default_app_config(level)
 
     def test_level_and_filename(self, tmpdir):
         level = "DEBUG"
@@ -32,7 +32,7 @@ class TestLoad(object):
 
         beer_garden.log.load({"level": level, "file": filename}, force=True)
 
-        assert beer_garden.log._LOGGING_CONFIG == default_app_config(
+        assert beer_garden.log._APP_LOGGING == default_app_config(
             level, filename=filename
         )
 
@@ -45,7 +45,7 @@ class TestLoad(object):
 
         beer_garden.log.load({"config_file": str(config_file)}, force=True)
 
-        assert beer_garden.log._LOGGING_CONFIG == logging_config
+        assert beer_garden.log._APP_LOGGING == logging_config
 
 
 class PluginLoggingLoaderTest(unittest.TestCase):


### PR DESCRIPTION
This PR fixes some issues with logging:

- If a plugin logging configuration file isn't specified the app will now just use brewtils' defaults instead of crashing the entry point.
- If something to crash the entry point *does* happen we now the logs back to the main process so we can see them in situations where we can't easily see the process stderr (e.g. systemd).