### PR TITLE
Application will now wait for all Entry Points to start

### DIFF
--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -16,19 +16,15 @@ logger = logging.getLogger(__name__)
 class BaseProcessor(StoppableThread):
     """Base Processor"""
 
-    def __init__(self, action=None, actions=None, **kwargs):
+    def __init__(self, action=None, **kwargs):
         super().__init__(**kwargs)
 
         self._action = action
-        self._actions = actions
 
     def process(self, item):
         try:
-            if self._action:
-                self._action(item)
-            if self._actions:
-                for action in self._actions:
-                    action(item)
+            self._action(item)
+
         except Exception as ex:
             logger.exception(f"Error processing: {ex}")
 

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -16,14 +16,19 @@ logger = logging.getLogger(__name__)
 class BaseProcessor(StoppableThread):
     """Base Processor"""
 
-    def __init__(self, action=None, **kwargs):
+    def __init__(self, action=None, actions=None, **kwargs):
         super().__init__(**kwargs)
 
         self._action = action
+        self._actions = actions
 
     def process(self, item):
         try:
-            self._action(item)
+            if self._action:
+                self._action(item)
+            if self._actions:
+                for action in self._actions:
+                    action(item)
         except Exception as ex:
             logger.exception(f"Error processing: {ex}")
 


### PR DESCRIPTION
When Beer Garden starts up, it will wait for all Entry Points to be in the RUNNING status before proceeding. This is done by providing each entry point two call back functions, first monitors events for START/STOP events to reflect in it's status. The second is the standard callback to provide events to the main process.

Fixes #518 