### PR TITLE
Added EventService implementations to both Garden Pages for Admins

### DIFF
--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -57,21 +57,21 @@ export default function adminGardenController(
     switch (event.name) {
       case 'GARDEN_CREATED':
         $scope.data.push(event.payload);
-        $apply();
+        break;
       case 'GARDEN_REMOVED':
-        let new_data = []
         for (var i = 0; i < $scope.data.length; i++) {
-            if ($scope.data[i].id != event.payload.id){
-                new_data.push($scope.data[i]);
+            if ($scope.data[i].id == event.payload.id){
+                $scope.data.splice(i, 1)
             }
         }
-        $scope.data = new_data
+        break;
       case 'GARDEN_UPDATED':
         for (var i = 0; i < $scope.data.length; i++) {
             if ($scope.data[i].id == event.payload.id){
                 $scope.data[i] = event.payload;
             }
         }
+        break;
     }
   });
 

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -75,6 +75,10 @@ export default function adminGardenController(
     }
   });
 
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('admin_garden');
+  });
+
   $scope.$on('userChange', function() {
     loadAll();
   });

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -53,12 +53,25 @@ export default function adminGardenController(
     loadGardens();
   };
 
-  EventService.addCallback('admin_system', (event) => {
+  EventService.addCallback('admin_garden', (event) => {
     switch (event.name) {
       case 'GARDEN_CREATED':
-        break;
+        $scope.data.push(event.payload);
+        $apply();
       case 'GARDEN_REMOVED':
-        break;
+        let new_data = []
+        for (var i = 0; i < $scope.data.length; i++) {
+            if ($scope.data[i].id != event.payload.id){
+                new_data.push($scope.data[i]);
+            }
+        }
+        $scope.data = new_data
+      case 'GARDEN_UPDATED':
+        for (var i = 0; i < $scope.data.length; i++) {
+            if ($scope.data[i].id == event.payload.id){
+                $scope.data[i] = event.payload;
+            }
+        }
     }
   });
 

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 adminGardenViewController.$inject = [
   '$scope',
   'GardenService',
+  'EventService',
   '$stateParams'
 ];
 
@@ -14,6 +15,7 @@ adminGardenViewController.$inject = [
 export default function adminGardenViewController(
     $scope,
     GardenService,
+    EventService,
     $stateParams) {
   $scope.setWindowTitle('Configure Garden');
   $scope.alerts = [];
@@ -78,6 +80,16 @@ export default function adminGardenViewController(
        GardenService.updateGardenConfig(updated_garden);
      }
   };
+
+  EventService.addCallback('admin_garden_view', (event) => {
+    switch (event.name) {
+      case 'GARDEN_UPDATED':
+        if ($scope.data.id == event.payload.id){
+            $scope.data = event.payload;
+
+        }
+    }
+  });
 
   $scope.$on('userChange', function() {
     loadAll();

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -86,8 +86,8 @@ export default function adminGardenViewController(
       case 'GARDEN_UPDATED':
         if ($scope.data.id == event.payload.id){
             $scope.data = event.payload;
-
         }
+        break
     }
   });
 

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -91,6 +91,10 @@ export default function adminGardenViewController(
     }
   });
 
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('admin_garden_view');
+  });
+
   $scope.$on('userChange', function() {
     loadAll();
   });


### PR DESCRIPTION
Admin pages for Gardens now listen for events for live updates.

Ways to test:
1. Deploy child garden to see if it appears
2. Shut down child garden to see if status changes
3. Delete the Garden through the API and see if it is removed. 

Fixes #517