### PR TITLE
Migrated from AMQ to MQ (Docker Compose)

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -37,11 +37,11 @@ services:
             BG_DB_NAME: beer_garden_v3
 
             # Point at the correct message broker
-            BG_AMQ_HOST: rabbitmq
-            BG_AMQ_CONNECTIONS_ADMIN_USER: beer_garden
-            BG_AMQ_CONNECTIONS_ADMIN_PASSWORD: password
-            BG_AMQ_CONNECTIONS_MESSAGE_USER: beer_garden
-            BG_AMQ_CONNECTIONS_MESSAGE_PASSWORD: password
+            BG_MQ_HOST: rabbitmq
+            BG_MQ_CONNECTIONS_ADMIN_USER: beer_garden
+            BG_MQ_CONNECTIONS_ADMIN_PASSWORD: password
+            BG_MQ_CONNECTIONS_MESSAGE_USER: beer_garden
+            BG_MQ_CONNECTIONS_MESSAGE_PASSWORD: password
 
             # Disable TLS
             BG_AUTH_ENABLED: "false"


### PR DESCRIPTION
Moving over the AMQ naming convention to the new MQ naming convention.