### PR TITLE
Using v3 tag for plugins docker image

### DIFF
--- a/docker/docker-compose/plugins/docker-compose.yml
+++ b/docker/docker-compose/plugins/docker-compose.yml
@@ -13,7 +13,7 @@ x-definitions: &complex-env
     DB_PASS: supersecret
 
 x-definitions: &plugin
-    image: bgio/example-plugins
+    image: bgio/example-plugins:v3
     network_mode: host
     volumes:
         - ../data/certs/ca_certificate.pem:/certs/ca_certificate.pem


### PR DESCRIPTION
This updates the docker image to use the `v3` tag.