### PR TITLE
Removed Bartender and Brew View from About page

### DIFF
--- a/src/ui/src/partials/about.html
+++ b/src/ui/src/partials/about.html
@@ -42,40 +42,22 @@
                 <th scope="col">Version</th>
               </tr>
               <tr>
-                <td>Bartender</td>
-                <td>{{ data.bartender_version }}</td>
-              </tr>
-              <tr>
-                <td>Brew View</td>
-                <td>{{ data.brew_view_version }}</td>
-              </tr>
-              <tr>
-                <td>Current API</td>
-                <td>{{ data.current_api_version }}</td>
-              </tr>
-              <tr>
-                <td>Supported API Versions</td>
-                <td>{{ data.supported_api_versions.join(', ') }}</td>
+                <td>Beer Garden</td>
+                <td>{{ data.beer_garden_version }}</td>
               </tr>
             </table>
           </div>
         </div>
         <div class="col-md-6">
           <div class="panel panel-default">
-            <div class="panel-heading">Component Version</div>
+            <div class="panel-heading">Component Status</div>
             <div class="panel-body">
               <p>Listed below is the current status of the components</p>
             </div>
             <table class="table table-hover">
               <tr>
-                <td>Brew View</td>
+                <td>Beer Garden</td>
                 <td><span class="label label-success">RUNNING</span></td>
-              </tr>
-              <tr>
-                <td>Bartender</td>
-                <td>
-                  <span class="label label-success">RUNNING</span>
-                </td>
               </tr>
             </table>
           </div>


### PR DESCRIPTION
Removed the Bartender and Brew View sections from the About Page. In a future PR, we should consider adding live statuses for the different components we have. It would also be nice to have indication for which version of the MongoDB and RabbitMQ we are connected to and their status. But this PR was only focused on the initial cleanup.

Part of #552 