### PR TITLE
Persist Themes (No Login Required)

### DIFF
--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -91,8 +91,11 @@ export default function appRun(
         // coalescePermissions [0] is roles, [1] is permissions
         user.permissions = RoleService.coalescePermissions(user.roles)[1];
 
-        let theme = _.get(user, 'preferences.theme', 'default');
-        $rootScope.changeTheme(theme);
+        // If user is logged in, change to their default theme selection
+        if (user.id != null){
+          let theme = _.get(user, 'preferences.theme', 'default');
+          $rootScope.changeTheme(theme);
+        }
 
         $rootScope.user = user;
       }, (response) => {
@@ -250,6 +253,12 @@ export default function appRun(
       updateInstance(event.payload);
     }
   });
+
+  // If a Theme is stored, switched to Theme in the session
+  let theme = localStorageService.get('currentTheme');
+  if (theme != null){
+    $rootScope.changeTheme(theme);
+  }
 
   $interval(function() {
     EventService.connect(TokenService.getToken());

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -92,10 +92,13 @@ export default function appRun(
         user.permissions = RoleService.coalescePermissions(user.roles)[1];
 
         // If user is logged in, change to their default theme selection
-        if (user.id != null){
-          let theme = _.get(user, 'preferences.theme', 'default');
-          $rootScope.changeTheme(theme);
+        let theme;
+        if (user.id) {
+          theme = _.get(user, 'preferences.theme', 'default');
+        } else {
+          theme = localStorageService.get('currentTheme') || 'default';
         }
+        $rootScope.changeTheme(theme, false);
 
         $rootScope.user = user;
       }, (response) => {
@@ -253,12 +256,6 @@ export default function appRun(
       updateInstance(event.payload);
     }
   });
-
-  // If a Theme is stored, switched to Theme in the session
-  let theme = localStorageService.get('currentTheme');
-  if (theme != null){
-    $rootScope.changeTheme(theme);
-  }
 
   $interval(function() {
     EventService.connect(TokenService.getToken());

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -130,6 +130,11 @@ export default function appRun(
     // Connect to the event socket
     EventService.connect(token);
 
+    // Load theme from local storage
+    // REMOVE THIS ONCE THE rootScope.loadUser CALL BELOW IS ENABLED
+    let theme = localStorageService.get('currentTheme') || 'default';
+    $rootScope.changeTheme(theme, false);
+
     // $rootScope.loadUser(token).catch(
     //   // This prevents the situation where the user needs to logout but the
     //   // logout button isn't displayed because there's no user loaded


### PR DESCRIPTION
Now when a user selects a Theme from the drop down menu the selection will persist when refreshing the page. This previously only worked for logged in users. Now any person who accesses BG can make this selection and it will persist that to local storage.

(ignore commit message)