### PR TITLE
Added auto-loader for plugin logger, including plugin updates

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -42,6 +42,7 @@ from beer_garden.api.http.authorization import anonymous_principal as load_anony
 from beer_garden.api.http.processors import EventManager, websocket_publish
 from beer_garden.events import publish
 from beer_garden.events.processors import QueueListener
+import beer_garden.log
 
 io_loop = None
 server = None
@@ -391,7 +392,7 @@ def _event_callback(event):
 
     # And also register handlers that the entry point needs to care about
     # As of now that's only the routing subsystem
-    for handler in [beer_garden.router.handle_event]:
+    for handler in [beer_garden.router.handle_event, beer_garden.log.handle_event]:
         try:
             handler(event)
         except Exception as ex:

--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -208,7 +208,9 @@ class Application(StoppableThread):
         self.logger.debug("Starting Plugin-logger Monitor")
         self.plugin_logger_observer = MonitorFile(
             config.get("plugin.logging.config_file"),
-            Event(name=Events.PLUGIN_LOGGER_FILE_CHANGE.name),
+            create_event=Event(name=Events.PLUGIN_LOGGER_FILE_CHANGE.name),
+            modified_event=Event(name=Events.PLUGIN_LOGGER_FILE_CHANGE.name),
+            moved_event=Event(name=Events.PLUGIN_LOGGER_FILE_CHANGE.name),
         )
 
         self.logger.info("All set! Let me know if you need anything else!")

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -10,6 +10,7 @@ import beer_garden.requests
 import beer_garden.router
 import beer_garden.systems
 import beer_garden.scheduler
+import beer_garden.log
 from beer_garden.local_plugins.manager import PluginManager
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ def garden_callbacks(event: Event) -> None:
         beer_garden.router.handle_event,
         beer_garden.systems.handle_event,
         beer_garden.scheduler.handle_event,
+        beer_garden.log.handle_event,
         PluginManager.handle_event,
     ]:
         try:

--- a/src/app/beer_garden/log.py
+++ b/src/app/beer_garden/log.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
+import os
 
 import brewtils.log
 import logging
@@ -9,6 +10,7 @@ from ruamel import yaml
 from ruamel.yaml import YAML
 
 import beer_garden.config as config
+from brewtils.models import Events
 
 _APP_LOGGING = None
 
@@ -169,7 +171,7 @@ class PluginLoggingManager(object):
         Returns:
             None
         """
-        if filename:
+        if filename and os.path.exists(filename):
             with open(filename) as log_config_file:
                 cls._PLUGIN_LOGGING = yaml.safe_load(log_config_file)
         else:
@@ -195,3 +197,10 @@ class PluginLoggingManager(object):
         log_config["level"] = level
 
         return log_config
+
+
+def handle_event(event):
+    # Only care about local garden
+    if event.garden == config.get("garden.name"):
+        if event.name == Events.PLUGIN_LOGGER_FILE_CHANGE.name:
+            load_plugin_log_config()

--- a/src/app/beer_garden/monitor.py
+++ b/src/app/beer_garden/monitor.py
@@ -74,9 +74,10 @@ class PluginStatusMonitor(StoppableThread):
 
 class MonitorFile:
     def __init__(self, path, publish_event):
-        self.observer = PollingObserver()
+
+        self.file = path
+
         if path:
-            self.file = path
             self.path = os.path.split(path)[0]
             self.publish_event = publish_event
 
@@ -89,9 +90,9 @@ class MonitorFile:
 
             # Using PollingObserver instead of Observer because Observer throws events at
             # each file transaction
-
+            self.observer = PollingObserver()
             self.observer.schedule(self.event_handler, self.path, recursive=False)
-        self.observer.start()
+            self.observer.start()
 
     def on_created(self, event):
         """ When a user VIM edits a file it DELETES, then CREATES the file, this captures that use case"""
@@ -102,5 +103,6 @@ class MonitorFile:
         publish(self.publish_event)
 
     def stop(self):
-        self.observer.stop()
-        self.observer.join()
+        if self.file:
+            self.observer.stop()
+            self.observer.join()

--- a/src/app/beer_garden/monitor.py
+++ b/src/app/beer_garden/monitor.py
@@ -73,13 +73,23 @@ class PluginStatusMonitor(StoppableThread):
 
 
 class MonitorFile:
-    def __init__(self, path, publish_event):
+    def __init__(
+        self,
+        path,
+        create_event=None,
+        modified_event=None,
+        moved_event=None,
+        deleted_event=None,
+    ):
 
         self.file = path
 
         if path:
             self.path = os.path.split(path)[0]
-            self.publish_event = publish_event
+            self.create_event = create_event
+            self.modified = modified_event
+            self.moved_event = moved_event
+            self.deleted_event = deleted_event
 
             self.event_handler = PatternMatchingEventHandler(
                 patterns=[self.file], ignore_patterns=[], ignore_directories=True
@@ -87,6 +97,8 @@ class MonitorFile:
 
             self.event_handler.on_created = self.on_created
             self.event_handler.on_modified = self.on_modified
+            self.event_handler.on_moved = self.on_moved
+            self.event_handler.on_deleted = self.on_deleted
 
             # Using PollingObserver instead of Observer because Observer throws events at
             # each file transaction
@@ -96,11 +108,23 @@ class MonitorFile:
 
     def on_created(self, event):
         """ When a user VIM edits a file it DELETES, then CREATES the file, this captures that use case"""
-        publish(self.publish_event)
+        if self.create_event:
+            publish(self.create_event)
 
     def on_modified(self, event):
         """ This captures all other modification events that occur against the file"""
-        publish(self.publish_event)
+        if self.modified_event:
+            publish(self.modified_event)
+
+    def on_moved(self, event):
+        """ This captures if the file is moved into or from the directory"""
+        if self.moved_event:
+            publish(self.moved_event)
+
+    def on_deleted(self, event):
+        """ This captures if the file was deleted (Be warned that VIM does this by default during write actions)"""
+        if self.deleted_event:
+            publish(self.deleted_event)
 
     def stop(self):
         if self.file:

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 start_request = RequestTemplate(command="_start", command_type="EPHEMERAL")
 stop_request = RequestTemplate(command="_stop", command_type="EPHEMERAL")
+initialize_logging_request = RequestTemplate(
+    command="_initialize_logging", command_type="EPHEMERAL"
+)
 read_logs_request = RequestTemplate(command="_read_log", command_type="ADMIN")
 
 
@@ -103,6 +106,36 @@ def stop(instance_id: str) -> Instance:
     requests.process_request(
         Request.from_template(
             stop_request,
+            namespace=system.namespace,
+            system=system.name,
+            system_version=system.version,
+            instance_name=instance.name,
+        ),
+        is_admin=True,
+        priority=1,
+        wait_timeout=0,
+    )
+
+    return instance
+
+
+def initialize_logging(instance_id: str) -> Instance:
+    """Initialize logging of Instance.
+
+    Args:
+        instance_id: The Instance ID
+
+    Returns:
+        The Instance
+    """
+    instance = db.query_unique(Instance, id=instance_id)
+    system = db.query_unique(System, instances__contains=instance)
+
+    logger.debug(f"Initializing logging for instance {system}[{instance}]")
+
+    requests.process_request(
+        Request.from_template(
+            initialize_logging_request,
             namespace=system.namespace,
             system=system.name,
             system_version=system.version,

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -262,12 +262,3 @@ def handle_event(event: Event) -> None:
 
         elif event.name == Events.SYSTEM_REMOVED.name:
             db.delete(event.payload)
-
-    else:
-        if event.name == Events.PLUGIN_LOGGER_FILE_CHANGE.name:
-            local_systems = get_systems(filter_params={"local": True})
-
-            for system in local_systems:
-                for instance in system.instances:
-                    if instance.status == "RUNNING":
-                        initialize_logging(instance.id)

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -11,7 +11,7 @@ import beer_garden.config as config
 import beer_garden.db.api as db
 import beer_garden.queue.api as queue
 from beer_garden.events import publish_event
-from beer_garden.plugin import stop
+from beer_garden.plugin import stop, initialize_logging
 
 REQUEST_FIELDS = set(SystemSchema.get_attribute_names())
 
@@ -262,3 +262,12 @@ def handle_event(event: Event) -> None:
 
         elif event.name == Events.SYSTEM_REMOVED.name:
             db.delete(event.payload)
+
+    else:
+        if event.name == Events.PLUGIN_LOGGER_FILE_CHANGE.name:
+            local_systems = get_systems(filter_params={"local": True})
+
+            for system in local_systems:
+                for instance in system.instances:
+                    if instance.status == "RUNNING":
+                        initialize_logging(instance.id)

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -11,7 +11,7 @@ import beer_garden.config as config
 import beer_garden.db.api as db
 import beer_garden.queue.api as queue
 from beer_garden.events import publish_event
-from beer_garden.plugin import stop, initialize_logging
+from beer_garden.plugin import stop
 
 REQUEST_FIELDS = set(SystemSchema.get_attribute_names())
 


### PR DESCRIPTION
Created a generic monitoring tool for files. Then set this to monitor the logging-config.yaml and spawn an event when it changes. This event is captured by the Log.py handler and reloads the file. It also spawns commands to local plugins to reload their logging if they are Running. That way the changes can be immediate.

Easiest way to test this is to add and remove the file logging option. If you change the file directory or name you will see that change happen semi-immediately. 

The cool thing is now the logging file doesn't have to exist at startup. They can create it later and then those configurations will be applied automatically. 

Depends on: https://github.com/beer-garden/brewtils/pull/230
Fixes https://github.com/beer-garden/beer-garden/issues/532