### PR TITLE
Bumping the mongo version in compose files to 4.2

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -80,7 +80,7 @@ services:
             - prometheus
 
     mongodb:
-        image: mongo:4.0
+        image: mongo:4.2
         restart: always
         networks:
             - bg-network

--- a/docker/docker-compose/tls/docker-compose.yml
+++ b/docker/docker-compose/tls/docker-compose.yml
@@ -71,7 +71,7 @@ services:
             - rabbitmq
 
     mongodb:
-        image: mongo:4.0
+        image: mongo:4.2
         networks:
             - bg-network
         volumes:


### PR DESCRIPTION
This bumps the mongo image version in the compose files to 4.2.