### PR TITLE
Dropped Menu button for Commands Page

### DIFF
--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -77,10 +77,6 @@
         <li ng-show="hasPermission(user, 'bg-system-read')">
           <a ui-sref="base.systems" ng-class="{active: ($state.current.name.startsWith('base.systems'))}">Systems</a>
         </li>
-        <li ng-show="hasPermission(user, 'bg-command-read')">
-          <a ui-sref="base.commands"
-             ng-class="{active: ($state.current.name.startsWith('base.command'))}">Commands</a>
-        </li>
         <li ng-show="hasPermission(user, 'bg-request-read')">
           <a ui-sref="base.requests"
              ng-class="{active: ($state.current.name.startsWith('request'))}">Requests</a>


### PR DESCRIPTION
This removes the Command Page button from the Top Menu. The page will still exist for navigating, but there is no need to have  a page to search all commands if you can use the search bar.

Fixes #559 