### PR TITLE
Changing default max instance to -1

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -437,7 +437,7 @@ class System(MongoModel, Document):
     description = StringField()
     version = StringField(required=True)
     namespace = StringField(required=True)
-    max_instances = IntField(default=1)
+    max_instances = IntField(default=-1)
     instances = ListField(ReferenceField(Instance, reverse_delete_rule=PULL))
     commands = ListField(ReferenceField(Command, reverse_delete_rule=PULL))
     icon_name = StringField()

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -460,7 +460,7 @@ class System(MongoModel, Document):
     def clean(self):
         """Validate before saving to the database"""
 
-        if len(self.instances) > self.max_instances:
+        if len(self.instances) > self.max_instances > -1:
             raise ModelValidationError(
                 "Can not save System %s: Number of instances (%s) "
                 "exceeds system limit (%s)"

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -465,7 +465,7 @@ class ConfigLoader(object):
             raise PluginValidationError("Invalid INSTANCES and PLUGIN_ARGS combination")
 
         if max_instances is None:
-            max_instances = len(instances)
+            max_instances = -1
 
         return {
             "INSTANCES": instances,

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -57,18 +57,19 @@ def create_system(system: System) -> System:
     """
     # Assign a default 'main' instance if there aren't any instances and there can
     # only be one
+
+    if not system.max_instances:
+        system.max_instances = -1
+
     if not system.instances or len(system.instances) == 0:
-        if system.max_instances is None or system.max_instances == 1:
+        if system.max_instances < 2:
             system.instances = [Instance(name="default")]
-            system.max_instances = 1
+
         else:
             raise ModelValidationError(
                 f"Could not create {system}: Systems with max_instances > 1 "
                 f"must also define their instances"
             )
-    else:
-        if not system.max_instances:
-            system.max_instances = len(system.instances)
 
     if system.namespace is None:
         system.namespace = config.get("garden.name")
@@ -122,7 +123,7 @@ def update_system(
         system = db.replace_commands(system, brew_commands)
 
     if add_instances:
-        if len(system.instances) + len(add_instances) > system.max_instances:
+        if -1 < system.max_instances < len(system.instances) + len(add_instances):
             raise ModelValidationError(
                 f"Unable to add instance(s) to {system} - would exceed "
                 f"the system instance limit of {system.max_instances}"

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -55,28 +55,10 @@ def create_system(system: System) -> System:
         The created System
 
     """
-    # Assign a default 'main' instance if there aren't any instances and there can
-    # only be one
-
-    if not system.max_instances:
-        system.max_instances = -1
-
-    if not system.instances or len(system.instances) == 0:
-        if system.max_instances < 2:
-            system.instances = [Instance(name="default")]
-
-        else:
-            raise ModelValidationError(
-                f"Could not create {system}: Systems with max_instances > 1 "
-                f"must also define their instances"
-            )
-
     if system.namespace is None:
         system.namespace = config.get("garden.name")
 
-    system = db.create(system)
-
-    return system
+    return db.create(system)
 
 
 @publish_event(Events.SYSTEM_UPDATED)

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -271,6 +271,7 @@ class TestSystem(object):
         default_system.clean()
 
     def test_clean_fail_max_instances(self, default_system):
+        default_system.max_instances = 1
         default_system.instances.append(Instance(name="default2"))
         with pytest.raises(ModelValidationError):
             default_system.clean()

--- a/src/app/test/local_plugins/manager_test.py
+++ b/src/app/test/local_plugins/manager_test.py
@@ -305,7 +305,7 @@ class TestLoadConfig(object):
         loaded_config = ConfigLoader.load(tmp_path / CONFIG_NAME)
         assert loaded_config["INSTANCES"] == ["instance1", "instance2"]
         assert loaded_config["PLUGIN_ARGS"] == {"instance1": None, "instance2": None}
-        assert loaded_config["MAX_INSTANCES"] == 2
+        assert loaded_config["MAX_INSTANCES"] == -1
 
     def test_plugin_args_list_no_instances(self, tmp_path):
         write_file(
@@ -324,7 +324,7 @@ class TestLoadConfig(object):
         loaded_config = ConfigLoader.load(tmp_path / CONFIG_NAME)
         assert loaded_config["INSTANCES"] == ["default"]
         assert loaded_config["PLUGIN_ARGS"] == {"default": ["arg1"]}
-        assert loaded_config["MAX_INSTANCES"] == 1
+        assert loaded_config["MAX_INSTANCES"] == -1
 
     def test_plugin_args_dict_no_instances(self, tmp_path):
         write_file(
@@ -343,7 +343,7 @@ class TestLoadConfig(object):
         loaded_config = ConfigLoader.load(tmp_path / CONFIG_NAME)
         assert sorted(loaded_config["INSTANCES"]) == sorted(["foo", "bar"])
         assert loaded_config["PLUGIN_ARGS"] == {"foo": ["arg1"], "bar": ["arg2"]}
-        assert loaded_config["MAX_INSTANCES"] == 2
+        assert loaded_config["MAX_INSTANCES"] == -1
 
     def test_instance_and_args_list(self, tmp_path):
         write_file(
@@ -362,7 +362,7 @@ class TestLoadConfig(object):
         loaded_config = ConfigLoader.load(tmp_path / CONFIG_NAME)
         assert sorted(loaded_config["INSTANCES"]) == sorted(["foo", "bar"])
         assert loaded_config["PLUGIN_ARGS"] == {"foo": ["arg1"], "bar": ["arg1"]}
-        assert loaded_config["MAX_INSTANCES"] == 2
+        assert loaded_config["MAX_INSTANCES"] == -1
 
     def test_explicit_max_instances(self, tmp_path):
         write_file(


### PR DESCRIPTION
Updated logic to change the default `system.max_instance` to -1. If set to -1 then there is no upper limit to the instances that can be deployed.

Fixes #569 