### PR TITLE
Enabling executable output on request view page

### DIFF
--- a/src/app/beer_garden/api/http/handlers/misc.py
+++ b/src/app/beer_garden/api/http/handlers/misc.py
@@ -15,15 +15,15 @@ class ConfigHandler(BaseHandler):
         auth_config = config.get("auth")
 
         configs = {
-            "allow_unsafe_templates": app_config.allow_unsafe_templates,
             "application_name": app_config.name,
+            "auth_enabled": auth_config.enabled,
             "icon_default": app_config.icon_default,
             "debug_mode": app_config.debug_mode,
-            "auth_enabled": auth_config.enabled,
-            "guest_login_enabled": auth_config.guest_login_enabled,
-            "url_prefix": config.get("entry.http.url_prefix"),
-            "metrics_url": config.get("metrics.prometheus.url"),
+            "execute_javascript": app_config.execute_javascript,
             "garden_name": config.get("garden.name"),
+            "guest_login_enabled": auth_config.guest_login_enabled,
+            "metrics_url": config.get("metrics.prometheus.url"),
+            "url_prefix": config.get("entry.http.url_prefix"),
         }
 
         self.write(configs)

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -511,7 +511,7 @@ _MQ_SPEC = {
     },
 }
 
-_APP_SPEC = {
+_APPLICATION_SPEC = {
     "type": "dict",
     "items": {
         "cors_enabled": {
@@ -526,11 +526,24 @@ _APP_SPEC = {
             "description": "Run the application in debug mode",
             "previous_names": ["debug_mode"],
         },
-        "name": {
-            "type": "str",
-            "default": "Beer Garden",
-            "description": "The title to display on the GUI",
-            "previous_names": ["application_name"],
+        "execute_javascript": {
+            "type": "bool",
+            "default": False,
+            "description": "Execute plugin-provided javascript",
+            "long_description": "This is dangerous!! Setting this to true will instruct "
+            "the browser to execute javascript provided by plugins. This means you "
+            "MUST have control over all plugins running in the environment, otherwise "
+            "this is a problem waiting to happen.",
+            "previous_names": [
+                "application_allow_unsafe_templates",
+                "allow_unsanitized_templates",
+                "allow_unsafe_templates",
+            ],
+            "alt_env_names": [
+                "APPLICATION_ALLOW_UNSAFE_TEMPLATES",
+                "ALLOW_UNSANITIZED_TEMPLATES",
+                "BG_ALLOW_UNSAFE_TEMPLATES",
+            ],
         },
         "icon_default": {
             "type": "str",
@@ -539,15 +552,11 @@ _APP_SPEC = {
             "previous_names": ["icon_default"],
             "alt_env_names": ["ICON_DEFAULT"],
         },
-        "allow_unsafe_templates": {
-            "type": "bool",
-            "default": False,
-            "description": "Allow unsafe templates to be loaded by the application",
-            "previous_names": ["ALLOW_UNSANITIZED_TEMPLATES", "allow_unsafe_templates"],
-            "alt_env_names": [
-                "ALLOW_UNSANITIZED_TEMPLATES",
-                "BG_ALLOW_UNSAFE_TEMPLATES",
-            ],
+        "name": {
+            "type": "str",
+            "default": "Beer Garden",
+            "description": "The title to display on the GUI",
+            "previous_names": ["application_name"],
         },
     },
 }
@@ -1155,7 +1164,7 @@ _SPECIFICATION = {
         "alt_env_names": ["AMQ_PUBLISH_HOST"],
     },
     "mq": _MQ_SPEC,
-    "application": _APP_SPEC,
+    "application": _APPLICATION_SPEC,
     "auth": _AUTH_SPEC,
     "configuration": _META_SPEC,
     "db": _DB_SPEC,

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -1,7 +1,7 @@
 application:
-  allow_unsafe_templates: false
   cors_enabled: true
   debug_mode: true
+  execute_javascript: false
   icon_default: fa-beer
   name: Beer Garden
 auth:

--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -202,7 +202,7 @@ export default function commandViewController(
     // If this command has a custom template then we're done!
     if ($scope.command.template) {
       // This is necessary for things like scripts and forms
-      if ($scope.config.allowUnsafeTemplates) {
+      if ($scope.config.executeJavascript) {
         $scope.template = $sce.trustAsHtml($scope.command.template);
       } else {
         $scope.template = $scope.command.template;

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -8,6 +8,7 @@ requestViewController.$inject = [
   '$stateParams',
   '$timeout',
   '$animate',
+  '$sce',
   'localStorageService',
   'RequestService',
   'SystemService',
@@ -21,6 +22,7 @@ requestViewController.$inject = [
  * @param  {$stateParams} $stateParams Angular's $stateParams object.
  * @param  {$timeout} $timeout         Angular's $timeout object.
  * @param  {$animate} $animate         Angular's $animate object.
+ * @param  {Object} $sce              Angular's $sce object.
  * @param  {Object} localStorageService  Storage service
  * @param  {Object} RequestService     Beer-Garden Request Service.
  * @param  {Object} SystemService      Beer-Garden's System Service.
@@ -32,6 +34,7 @@ export default function requestViewController(
     $stateParams,
     $timeout,
     $animate,
+    $sce,
     localStorageService,
     RequestService,
     SystemService,
@@ -124,9 +127,15 @@ export default function requestViewController(
         rawOutput = 'null';
       }
       else if ($scope.request.output_type == 'HTML') {
-        $scope.htmlOutput = rawOutput;
         $scope.formattedAvailable = true;
         $scope.showFormatted = true;
+
+        // This is necessary for things like scripts and forms
+        if ($scope.config.allowUnsafeTemplates) {
+          $scope.htmlOutput = $sce.trustAsHtml(rawOutput);
+        } else {
+          $scope.htmlOutput = rawOutput;
+        }
       } else if ($scope.request.output_type == 'JSON') {
         try {
           let parsedOutput = JSON.parse(rawOutput);

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -131,7 +131,7 @@ export default function requestViewController(
         $scope.showFormatted = true;
 
         // This is necessary for things like scripts and forms
-        if ($scope.config.allowUnsafeTemplates) {
+        if ($scope.config.executeJavascript) {
           $scope.htmlOutput = $sce.trustAsHtml(rawOutput);
         } else {
           $scope.htmlOutput = rawOutput;


### PR DESCRIPTION
This mostly fixes #360. That ticket is kind of a mess, but we can open a new issue for the parts not covered by this PR.

This PR implements the application-wide switch to control this. It changes the old, fairly unclear `allow_unsanitized_templates` config name to the much more direct `execute_javascript`. This config item will control whether the frontend will execute javascript anywhere. It doesn't really make any sense to have multiple flags - if javascript execution is allowed *anywhere* then you're completely trusting plugins, any half measures we could provide would just be security theater.