### PR TITLE
Fixing monitor attribute name

### DIFF
--- a/src/app/beer_garden/monitor.py
+++ b/src/app/beer_garden/monitor.py
@@ -87,7 +87,7 @@ class MonitorFile:
         if path:
             self.path = os.path.split(path)[0]
             self.create_event = create_event
-            self.modified = modified_event
+            self.modified_event = modified_event
             self.moved_event = moved_event
             self.deleted_event = deleted_event
 


### PR DESCRIPTION
Fixes a failure in the plugin logging config file monitor