### PR TITLE
Syncing buffer writes by making them asyncio

### DIFF
--- a/src/app/beer_garden/api/http/processors.py
+++ b/src/app/beer_garden/api/http/processors.py
@@ -16,7 +16,7 @@ class EventManager:
         self._conn = conn
 
     def put(self, event):
-        self._conn.send(event)
+        beer_garden.api.http.io_loop.add_callback(self._conn.send, event)
 
 
 def websocket_publish(item):


### PR DESCRIPTION
This should fix the issue with the broken pipe:

```
Exception in thread Thread-6:
Traceback (most recent call last):
  File "/home/mppatri/.pyenv/versions/3.7.4/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/home/mppatri/git/beergarden/beer-garden/src/app/beer_garden/events/processors.py", line 86, in run
    self.process(self._conn.recv())
  File "/home/mppatri/.pyenv/versions/3.7.4/lib/python3.7/multiprocessing/connection.py", line 251, in recv
    return _ForkingPickler.loads(buf.getbuffer())
_pickle.UnpicklingError: invalid load key, '\x00'.
```