### PR TITLE
Routing sync

### DIFF
--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -222,30 +222,26 @@ def setup_routing():
     logger.debug("Routing setup complete")
 
 
+def update_routing(garden_name=None, existing_id=None, update_system=None):
+    """Update the gardens used for routing"""
+    # Default to local garden name
+    garden_name = garden_name or config.get("garden.name")
+
+    index = None
+    for i, system in enumerate(gardens[garden_name].systems):
+        if system.id == existing_id:
+            index = i
+            break
+
+    if index is not None:
+        gardens[garden_name].systems.pop(index)
+
+    if update_system:
+        gardens[garden_name].systems.append(update_system)
+
+
 def handle_event(event):
     """Handle events"""
-    if (
-        event.name
-        in (
-            Events.SYSTEM_CREATED.name,
-            Events.SYSTEM_UPDATED.name,
-            Events.SYSTEM_REMOVED.name,
-        )
-        and event.garden in gardens
-        and not event.error
-    ):
-        index = None
-        for i, system in enumerate(gardens[event.garden].systems):
-            if system.id == event.payload.id:
-                index = i
-                break
-
-        if index is not None:
-            gardens[event.garden].systems.pop(index)
-
-        if event.name in (Events.SYSTEM_CREATED.name, Events.SYSTEM_UPDATED.name):
-            gardens[event.garden].systems.append(event.payload)
-
     # This is a little unintuitive. We want to let the garden module deal with handling
     # any downstream garden changes since handling those changes is nontrivial.
     # It's *those* events we want to act on here, not the "raw" downstream ones.

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+import threading
+
 import requests
 from brewtils.models import Events, Garden, Instance, Operation, Request, System
 from brewtils.schema_parser import SchemaParser
@@ -19,8 +21,7 @@ import beer_garden.requests
 import beer_garden.scheduler
 import beer_garden.systems
 from beer_garden.errors import RoutingRequestException, UnknownGardenException
-from beer_garden.garden import get_gardens
-from beer_garden.garden import local_garden
+from beer_garden.garden import get_gardens, local_garden
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ forward_processor = None
 
 # Dict of garden_name -> garden
 gardens: Dict[str, Garden] = {}
+gardens_lock = threading.Lock()
 
 route_functions = {
     "REQUEST_CREATE": beer_garden.requests.process_request,
@@ -227,17 +229,18 @@ def update_routing(garden_name=None, existing_id=None, update_system=None):
     # Default to local garden name
     garden_name = garden_name or config.get("garden.name")
 
-    index = None
-    for i, system in enumerate(gardens[garden_name].systems):
-        if system.id == existing_id:
-            index = i
-            break
+    with gardens_lock:
+        index = None
+        for i, system in enumerate(gardens[garden_name].systems):
+            if system.id == existing_id:
+                index = i
+                break
 
-    if index is not None:
-        gardens[garden_name].systems.pop(index)
+        if index is not None:
+            gardens[garden_name].systems.pop(index)
 
-    if update_system:
-        gardens[garden_name].systems.append(update_system)
+        if update_system:
+            gardens[garden_name].systems.append(update_system)
 
 
 def handle_event(event):
@@ -388,7 +391,8 @@ def _forward_http(operation: Operation, conn_info: dict):
 def _garden_name_lookup(system: Union[str, System]) -> str:
     system_name = str(system)
 
-    for garden in gardens.values():
-        for system in garden.systems:
-            if str(system) == system_name:
-                return garden.name
+    with gardens_lock:
+        for garden in gardens.values():
+            for system in garden.systems:
+                if str(system) == system_name:
+                    return garden.name


### PR DESCRIPTION
This PR changes routing updates to happen explicitly when system changes are executed locally rather than catching and handling the event that's generated when those changes happen.

It adds simple locking to help with concurrency issues in the HTTP entry point.