### PR TITLE
Child Gardens Back-Off

### DIFF
--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -24,9 +24,9 @@ from beer_garden.events import publish
 from beer_garden.events.handlers import garden_callbacks
 from beer_garden.events.processors import (
     FanoutProcessor,
-    HttpEventProcessor,
     QueueListener,
 )
+from beer_garden.events.parent_procesors import HttpParentUpdater
 from beer_garden.local_plugins.manager import PluginManager
 from beer_garden.log import load_plugin_log_config
 from beer_garden.metrics import PrometheusServer
@@ -278,7 +278,7 @@ class Application(StoppableThread):
                 self._publish_update(Events.GARDEN_STARTED)
 
             event_manager.register(
-                HttpEventProcessor(
+                HttpParentUpdater(
                     easy_client=easy_client,
                     black_list=skip_events,
                     reconnect_action=reconnect_action,

--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -273,8 +273,16 @@ class Application(StoppableThread):
                 ssl_enabled=http_event.ssl.enabled,
             )
             skip_events = config.get("parent.skip_events")
+
+            def reconnect_action():
+                self._publish_update(Events.GARDEN_STARTED)
+
             event_manager.register(
-                HttpEventProcessor(easy_client=easy_client, black_list=skip_events)
+                HttpEventProcessor(
+                    easy_client=easy_client,
+                    black_list=skip_events,
+                    reconnect_action=reconnect_action,
+                )
             )
 
         return event_manager

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -1,3 +1,5 @@
+import requests
+
 import beer_garden
 from beer_garden.events.processors import QueueListener
 from brewtils.models import Event
@@ -31,7 +33,7 @@ class HttpParentUpdater(QueueListener):
             if event.name not in self._black_list:
                 event.garden = beer_garden.config.get("garden.name")
                 self._ez_client.publish_event(event)
-        except:
+        except requests.exceptions.ConnectionError:
             self.reconnect()
 
     def reconnect(self):

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -1,0 +1,67 @@
+import beer_garden
+from beer_garden.events.processors import QueueListener
+from brewtils.models import Event
+
+
+class HttpParentUpdater(QueueListener):
+    """Publish events using an EasyClient"""
+
+    def __init__(
+        self, easy_client=None, black_list=None, reconnect_action=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        self._ez_client = easy_client
+        self._black_list = black_list or []
+        self._reconnect_action = reconnect_action
+        self._processing = True
+
+    def put(self, item):
+        """Put a new item on the queue to be processed
+
+        Args:
+            item: New item
+        """
+        if self._processing:
+            self._queue.put(item)
+
+    def process(self, event: Event):
+
+        try:
+            if event.name not in self._black_list:
+                event.garden = beer_garden.config.get("garden.name")
+                self._ez_client.publish_event(event)
+        except Exception as ex:
+            self.reconnect()
+
+    def reconnect(self):
+
+        self.logger.warning(
+            "Attempting to reconnect to Parent Garden"
+        )
+        # Mark not processing and stop accepting events
+        self._processing = False
+
+        # Purge the current Queue
+        while not self._queue.empty():
+            self._queue.get()
+
+        # Back-off connection from EZ Client
+        wait_time = 0.1
+        while not self.stopped() and not self._processing:
+            if self._ez_client.can_connect():
+                self._processing = True
+
+                self.logger.warning(
+                    "Successfully reconnected to Parent Garden"
+                )
+
+                if self._reconnect_action:
+                    self._reconnect_action()
+
+            else:
+                self.logger.debug(
+                    "Waiting %.1f seconds before next attempt", wait_time
+                )
+                self.wait(wait_time)
+                wait_time = min(wait_time * 2, 30)

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -31,7 +31,7 @@ class HttpParentUpdater(QueueListener):
             if event.name not in self._black_list:
                 event.garden = beer_garden.config.get("garden.name")
                 self._ez_client.publish_event(event)
-        except Exception as ex:
+        except:
             self.reconnect()
 
     def reconnect(self):

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -36,9 +36,7 @@ class HttpParentUpdater(QueueListener):
 
     def reconnect(self):
 
-        self.logger.warning(
-            "Attempting to reconnect to Parent Garden"
-        )
+        self.logger.warning("Attempting to reconnect to Parent Garden")
         # Mark not processing and stop accepting events
         self._processing = False
 
@@ -52,16 +50,12 @@ class HttpParentUpdater(QueueListener):
             if self._ez_client.can_connect():
                 self._processing = True
 
-                self.logger.warning(
-                    "Successfully reconnected to Parent Garden"
-                )
+                self.logger.warning("Successfully reconnected to Parent Garden")
 
                 if self._reconnect_action:
                     self._reconnect_action()
 
             else:
-                self.logger.debug(
-                    "Waiting %.1f seconds before next attempt", wait_time
-                )
+                self.logger.debug("Waiting %.1f seconds before next attempt", wait_time)
                 self.wait(wait_time)
                 wait_time = min(wait_time * 2, 30)

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -20,10 +20,12 @@ class BaseProcessor(StoppableThread):
         super().__init__(**kwargs)
 
         self._action = action
+        self._processing = True
 
     def process(self, item):
         try:
-            self._action(item)
+            if self._processing:
+                self._action(item)
         except Exception as ex:
             logger.exception(f"Error processing: {ex}")
 
@@ -42,7 +44,8 @@ class QueueListener(BaseProcessor):
         Args:
             item: New item
         """
-        self._queue.put(item)
+        if self._processing:
+            self._queue.put(item)
 
     def clear(self):
         """Empty the underlying queue without processing items"""
@@ -125,16 +128,47 @@ class FanoutProcessor(QueueListener):
 class HttpEventProcessor(QueueListener):
     """Publish events using an EasyClient"""
 
-    def __init__(self, easy_client=None, black_list=None, **kwargs):
+    def __init__(
+        self, easy_client=None, black_list=None, reconnect_action=None, **kwargs
+    ):
         super().__init__(**kwargs)
 
         self._ez_client = easy_client
         self._black_list = black_list or []
+        self._reconnect_action = reconnect_action
 
     def process(self, event: Event):
+
         try:
             if event.name not in self._black_list:
                 event.garden = beer_garden.config.get("garden.name")
                 self._ez_client.publish_event(event)
         except Exception as ex:
             logger.exception(f"Error publishing EasyClient event: {ex}")
+
+            self.reconnect()
+
+    def reconnect(self):
+
+        # Mark not processing and stop accepting events
+        self._processing = False
+
+        # Purge the current Queue
+        while not self._queue.empty():
+            self._queue.get()
+
+        # Back-off connection from EZ Client
+        wait_time = 0.1
+        while not self.stopped() and not self._processing:
+            if self._ez_client.can_connect():
+                self._processing = True
+
+                if self._reconnect_action:
+                    self._reconnect_action()
+
+            else:
+                self.logger.warning(
+                    "Waiting %.1f seconds before next attempt", wait_time
+                )
+                self.wait(wait_time)
+                wait_time = min(wait_time * 2, 30)

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -3,12 +3,7 @@ import logging
 from multiprocessing import Queue
 from queue import Empty
 
-from brewtils.models import Event
 from brewtils.stoppable_thread import StoppableThread
-
-import beer_garden.config
-import beer_garden.events
-import beer_garden.systems
 
 logger = logging.getLogger(__name__)
 

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -36,7 +36,6 @@ class QueueListener(BaseProcessor):
 
         self._queue = queue or Queue()
 
-
     def put(self, item):
         """Put a new item on the queue to be processed
 
@@ -121,6 +120,3 @@ class FanoutProcessor(QueueListener):
 
         if manage:
             self._managed_processors.append(processor)
-
-
-


### PR DESCRIPTION
When a child garden disconnects from the parent the child will go into a back-off state until it is reconnected. At the disconnect the queue is purged and no new events are accepted into the processor. Then once reconnected it runs any reconnect actions provided (Publish Garden Start Event) and begin accepting new events.

Fixes #607 
    
