### PR TITLE
Not using ThreadPoolExecutor for everything in HTTP package

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -42,6 +42,7 @@ import beer_garden.events
 import beer_garden.log
 import beer_garden.router
 from beer_garden.api.http.authorization import anonymous_principal as load_anonymous
+from beer_garden.api.http.client import SerializeHelper
 from beer_garden.api.http.processors import EventManager, websocket_publish
 from beer_garden.events import publish
 from beer_garden.events.processors import QueueListener
@@ -231,6 +232,7 @@ def _setup_tornado_app() -> Application:
         debug=app_config.debug_mode,
         cookie_secret=auth_config.token.secret,
         autoreload=False,
+        client=SerializeHelper(),
     )
 
 

--- a/src/app/beer_garden/api/http/base_handler.py
+++ b/src/app/beer_garden/api/http/base_handler.py
@@ -26,16 +26,15 @@ import beer_garden.config as config
 import beer_garden.db.mongo.models
 from beer_garden.api.http.authorization import (
     AuthMixin,
-    coalesce_permissions,
-    bearer_auth,
     basic_auth,
+    bearer_auth,
+    coalesce_permissions,
 )
-from beer_garden.api.http.client import ExecutorClient
 from beer_garden.api.http.metrics import http_api_latency_total
 from beer_garden.errors import (
+    EndpointRemovedException,
     NotFoundException,
     RoutingRequestException,
-    EndpointRemovedException,
 )
 
 
@@ -121,8 +120,9 @@ class BaseHandler(AuthMixin, RequestHandler):
             to_return = to_return.replace(mongo_id, "<ID>")
         return to_return
 
-    def initialize(self):
-        self.client = ExecutorClient()
+    @property
+    def client(self):
+        return self.settings["client"]
 
     def prepare(self):
         """Called before each verb handler"""

--- a/src/app/beer_garden/api/http/client.py
+++ b/src/app/beer_garden/api/http/client.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-import asyncio
 import json
-from concurrent.futures.thread import ThreadPoolExecutor
-from functools import partial
 
 import six
 from brewtils.models import BaseModel
@@ -12,14 +9,9 @@ import beer_garden.api
 import beer_garden.router
 
 
-class ExecutorClient(object):
-    parser = SchemaParser()
-    pool = ThreadPoolExecutor(50)
-
+class SerializeHelper(object):
     async def __call__(self, *args, serialize_kwargs=None, **kwargs):
-        result = await asyncio.get_event_loop().run_in_executor(
-            self.pool, partial(beer_garden.router.route, *args, **kwargs)
-        )
+        result = beer_garden.router.route(*args, **kwargs)
 
         # Handlers overwhelmingly just write the response so default to serializing
         serialize_kwargs = serialize_kwargs or {}


### PR DESCRIPTION
This depends on #620, and is part of #611 

This transforms the `ExecutorClient` into a `SerializeHelper`. It no longer executes the routing operation (and then the actual operation) inside of a `ThreadPoolExecutor`. The route operation is now just called directly and the client is used as a serialization helper.

Future work could be to either remove this class completely or pull it up to the entry point level (or the router) where it can be used by all entry points.