### PR TITLE
Monitor

### DIFF
--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -30,7 +30,8 @@ from beer_garden.events.parent_procesors import HttpParentUpdater
 from beer_garden.local_plugins.manager import PluginManager
 from beer_garden.log import load_plugin_log_config
 from beer_garden.metrics import PrometheusServer
-from beer_garden.monitor import PluginStatusMonitor, MonitorFile
+from beer_garden.monitor import MonitorFile
+from beer_garden.plugin import StatusMonitor
 
 
 class Application(StoppableThread):
@@ -64,7 +65,7 @@ class Application(StoppableThread):
         plugin_config = config.get("plugin")
         self.helper_threads = [
             HelperThread(
-                PluginStatusMonitor,
+                StatusMonitor,
                 timeout_seconds=plugin_config.status_timeout,
                 heartbeat_interval=plugin_config.status_heartbeat,
             )

--- a/src/app/beer_garden/monitor.py
+++ b/src/app/beer_garden/monitor.py
@@ -1,76 +1,10 @@
 # -*- coding: utf-8 -*-
-import logging
-from datetime import datetime, timedelta
 import os
 
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers.polling import PollingObserver
 
 from beer_garden.events import publish
-from brewtils.models import Request, System
-from brewtils.stoppable_thread import StoppableThread
-
-import beer_garden.db.api as db
-import beer_garden.queue.api as queue
-
-
-class PluginStatusMonitor(StoppableThread):
-    """Monitor plugin heartbeats and update plugin status"""
-
-    def __init__(self, heartbeat_interval=10, timeout_seconds=30):
-        self.logger = logging.getLogger(__name__)
-        self.display_name = "Plugin Status Monitor"
-        self.heartbeat_interval = heartbeat_interval
-        self.timeout = timedelta(seconds=timeout_seconds)
-        self.status_request = Request(command="_status", command_type="EPHEMERAL")
-
-        super(PluginStatusMonitor, self).__init__(
-            logger=self.logger, name="PluginStatusMonitor"
-        )
-
-    def run(self):
-        self.logger.info(self.display_name + " is started")
-
-        while not self.wait(self.heartbeat_interval):
-            self.request_status()
-            self.check_status()
-
-        self.logger.info(self.display_name + " is stopped")
-
-    def request_status(self):
-        try:
-            queue.put(
-                self.status_request,
-                routing_key="admin",
-                expiration=str(self.heartbeat_interval * 1000),
-            )
-        except Exception as ex:
-            self.logger.warning("Unable to publish status request: %s", str(ex))
-
-    def check_status(self):
-        """Update instance status if necessary"""
-
-        for system in db.query(System):
-            for instance in system.instances:
-                if self.stopped():
-                    break
-
-                last_heartbeat = instance.status_info["heartbeat"]
-
-                if last_heartbeat:
-                    if (
-                        instance.status == "RUNNING"
-                        and datetime.utcnow() - last_heartbeat >= self.timeout
-                    ):
-                        instance.status = "UNRESPONSIVE"
-                        db.update(system)
-                    elif (
-                        instance.status
-                        in ["UNRESPONSIVE", "STARTING", "INITIALIZING", "UNKNOWN"]
-                        and datetime.utcnow() - last_heartbeat < self.timeout
-                    ):
-                        instance.status = "RUNNING"
-                        db.update(system)
 
 
 class MonitorFile:

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -152,6 +152,7 @@ def update(
     system: System = None,
     new_status: str = None,
     metadata: dict = None,
+    update_heartbeat: bool = True,
     **_,
 ) -> Instance:
     """Update an Instance status.
@@ -164,6 +165,7 @@ def update(
         system: The System
         new_status: The new status
         metadata: New metadata
+        update_heartbeat: Set the heartbeat to the current time
 
     Returns:
         The updated Instance
@@ -178,6 +180,8 @@ def update(
 
     if new_status:
         updates["set__instances__S__status"] = new_status
+
+    if update_heartbeat:
         updates["set__instances__S__status_info__heartbeat"] = datetime.utcnow()
 
     if metadata:

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -398,7 +398,9 @@ class StatusMonitor(StoppableThread):
     def check_status(self):
         """Update instance status if necessary"""
 
-        for system in db.query(System):
+        for system in db.query(
+            System, filter_params={"local": True}, include_fields=["instances"]
+        ):
             for instance in system.instances:
                 if self.stopped():
                     break

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -412,12 +412,21 @@ class StatusMonitor(StoppableThread):
                         instance.status == "RUNNING"
                         and datetime.utcnow() - last_heartbeat >= self.timeout
                     ):
-                        instance.status = "UNRESPONSIVE"
-                        db.update(system)
+                        update(
+                            system=system,
+                            instance=instance,
+                            new_status="UNRESPONSIVE",
+                            update_heartbeat=False,
+                        )
+
                     elif (
                         instance.status
                         in ["UNRESPONSIVE", "STARTING", "INITIALIZING", "UNKNOWN"]
                         and datetime.utcnow() - last_heartbeat < self.timeout
                     ):
-                        instance.status = "RUNNING"
-                        db.update(system)
+                        update(
+                            system=system,
+                            instance=instance,
+                            new_status="RUNNING",
+                            update_heartbeat=False,
+                        )

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -4,10 +4,11 @@
 
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Tuple
 
 from brewtils.models import Event, Events, Instance, Request, RequestTemplate, System
+from brewtils.stoppable_thread import StoppableThread
 
 import beer_garden.config as config
 import beer_garden.db.api as db
@@ -355,3 +356,62 @@ def handle_event(event: Event) -> None:
                 )
             except Exception as ex:
                 logger.error(f"{event.name} error: {ex} ({event!r})")
+
+
+class StatusMonitor(StoppableThread):
+    """Monitor plugin heartbeats and update plugin status"""
+
+    def __init__(self, heartbeat_interval=10, timeout_seconds=30):
+        self.logger = logging.getLogger(__name__)
+        self.display_name = "Plugin Status Monitor"
+        self.heartbeat_interval = heartbeat_interval
+        self.timeout = timedelta(seconds=timeout_seconds)
+        self.status_request = Request(command="_status", command_type="EPHEMERAL")
+
+        super(StatusMonitor, self).__init__(
+            logger=self.logger, name="PluginStatusMonitor"
+        )
+
+    def run(self):
+        self.logger.info(self.display_name + " is started")
+
+        while not self.wait(self.heartbeat_interval):
+            self.request_status()
+            self.check_status()
+
+        self.logger.info(self.display_name + " is stopped")
+
+    def request_status(self):
+        try:
+            queue.put(
+                self.status_request,
+                routing_key="admin",
+                expiration=str(self.heartbeat_interval * 1000),
+            )
+        except Exception as ex:
+            self.logger.warning("Unable to publish status request: %s", str(ex))
+
+    def check_status(self):
+        """Update instance status if necessary"""
+
+        for system in db.query(System):
+            for instance in system.instances:
+                if self.stopped():
+                    break
+
+                last_heartbeat = instance.status_info["heartbeat"]
+
+                if last_heartbeat:
+                    if (
+                        instance.status == "RUNNING"
+                        and datetime.utcnow() - last_heartbeat >= self.timeout
+                    ):
+                        instance.status = "UNRESPONSIVE"
+                        db.update(system)
+                    elif (
+                        instance.status
+                        in ["UNRESPONSIVE", "STARTING", "INITIALIZING", "UNKNOWN"]
+                        and datetime.utcnow() - last_heartbeat < self.timeout
+                    ):
+                        instance.status = "RUNNING"
+                        db.update(system)

--- a/src/app/test/plugin_test.py
+++ b/src/app/test/plugin_test.py
@@ -3,23 +3,23 @@ import pytest
 from mock import Mock, patch
 
 import beer_garden.monitor
-from beer_garden.monitor import PluginStatusMonitor
+from beer_garden.plugin import StatusMonitor
 
 
 @pytest.fixture
 def queue_mock(monkeypatch):
     queue = Mock()
-    monkeypatch.setattr(beer_garden.monitor, "queue", queue)
+    monkeypatch.setattr(beer_garden.plugin, "queue", queue)
     return queue
 
 
 @pytest.fixture
 def monitor():
-    return PluginStatusMonitor()
+    return StatusMonitor()
 
 
 @patch("time.sleep", Mock())
-class TestPluginStatusMonitor(object):
+class TestStatusMonitor(object):
     def test_run_stopped(self, monkeypatch, monitor):
         check_mock = Mock()
         request_mock = Mock()
@@ -70,7 +70,7 @@ class TestPluginStatusMonitor(object):
         monkeypatch.setattr(monitor, "stopped", stopped_mock)
 
         monkeypatch.setattr(
-            beer_garden.monitor.db, "query", Mock(return_value=[bg_system])
+            beer_garden.plugin.db, "query", Mock(return_value=[bg_system])
         )
 
         monitor.check_status()
@@ -81,10 +81,10 @@ class TestPluginStatusMonitor(object):
         monkeypatch.setattr(monitor, "stopped", stopped_mock)
 
         update_mock = Mock()
-        monkeypatch.setattr(beer_garden.monitor.db, "update", update_mock)
+        monkeypatch.setattr(beer_garden.plugin.db, "update", update_mock)
 
         monkeypatch.setattr(
-            beer_garden.monitor.db, "query", Mock(return_value=[bg_system])
+            beer_garden.plugin.db, "query", Mock(return_value=[bg_system])
         )
 
         monitor.check_status()
@@ -96,15 +96,15 @@ class TestPluginStatusMonitor(object):
         monkeypatch.setattr(monitor, "stopped", stopped_mock)
 
         update_mock = Mock()
-        monkeypatch.setattr(beer_garden.monitor.db, "update", update_mock)
+        monkeypatch.setattr(beer_garden.plugin.db, "update", update_mock)
 
         bg_instance.status = "UNRESPONSIVE"
         monkeypatch.setattr(
-            beer_garden.monitor.db, "query", Mock(return_value=[bg_system])
+            beer_garden.plugin.db, "query", Mock(return_value=[bg_system])
         )
 
         monkeypatch.setattr(
-            beer_garden.monitor, "datetime", Mock(utcnow=Mock(return_value=ts_dt))
+            beer_garden.plugin, "datetime", Mock(utcnow=Mock(return_value=ts_dt))
         )
 
         monitor.check_status()

--- a/src/app/test/plugin_test.py
+++ b/src/app/test/plugin_test.py
@@ -81,14 +81,13 @@ class TestStatusMonitor(object):
         monkeypatch.setattr(monitor, "stopped", stopped_mock)
 
         update_mock = Mock()
-        monkeypatch.setattr(beer_garden.plugin.db, "update", update_mock)
+        monkeypatch.setattr(beer_garden.plugin, "update", update_mock)
 
         monkeypatch.setattr(
             beer_garden.plugin.db, "query", Mock(return_value=[bg_system])
         )
 
         monitor.check_status()
-        assert bg_instance.status == "UNRESPONSIVE"
         assert update_mock.called is True
 
     def test_mark_as_running(self, monkeypatch, monitor, bg_system, bg_instance, ts_dt):
@@ -96,7 +95,7 @@ class TestStatusMonitor(object):
         monkeypatch.setattr(monitor, "stopped", stopped_mock)
 
         update_mock = Mock()
-        monkeypatch.setattr(beer_garden.plugin.db, "update", update_mock)
+        monkeypatch.setattr(beer_garden.plugin, "update", update_mock)
 
         bg_instance.status = "UNRESPONSIVE"
         monkeypatch.setattr(
@@ -108,5 +107,4 @@ class TestStatusMonitor(object):
         )
 
         monitor.check_status()
-        assert bg_instance.status == "RUNNING"
         assert update_mock.called is True


### PR DESCRIPTION
Part of #611, follow-on to #622.

This moves the plugin status monitor into the plugin module and modifies it to only be concerned with systems that are associated with the local garden.