### PR TITLE
Issue/629

### DIFF
--- a/src/app/beer_garden/db/mongo/api.py
+++ b/src/app/beer_garden/db/mongo/api.py
@@ -4,7 +4,7 @@ import logging
 from box import Box
 from brewtils.models import BaseModel
 from brewtils.schema_parser import SchemaParser
-from mongoengine import connect, register_connection, DoesNotExist
+from mongoengine import NotUniqueError, connect, register_connection, DoesNotExist
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 from typing import List, Optional, Type, Union, Tuple
 
@@ -18,6 +18,7 @@ from beer_garden.db.mongo.util import (
     ensure_roles,
     ensure_users,
 )
+from beer_garden.errors import NotUniqueException
 
 logger = logging.getLogger(__name__)
 
@@ -316,10 +317,13 @@ def create(obj: ModelItem) -> ModelItem:
     """
     mongo_obj = from_brewtils(obj)
 
-    if hasattr(mongo_obj, "deep_save"):
-        mongo_obj.deep_save()
-    else:
-        mongo_obj.save(force_insert=True)
+    try:
+        if hasattr(mongo_obj, "deep_save"):
+            mongo_obj.deep_save()
+        else:
+            mongo_obj.save(force_insert=True)
+    except NotUniqueError as ex:
+        raise NotUniqueException from ex
 
     return to_brewtils(mongo_obj)
 

--- a/src/app/beer_garden/errors.py
+++ b/src/app/beer_garden/errors.py
@@ -56,3 +56,9 @@ class NotFoundException(Exception):
     """Something wasn't found"""
 
     pass
+
+
+class NotUniqueException(Exception):
+    """Something wasn't unique"""
+
+    pass

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -96,7 +96,7 @@ route_functions = {
     "JOB_PAUSE": beer_garden.scheduler.pause_job,
     "JOB_RESUME": beer_garden.scheduler.resume_job,
     "JOB_DELETE": beer_garden.scheduler.remove_job,
-    "SYSTEM_CREATE": beer_garden.systems.create_system,
+    "SYSTEM_CREATE": beer_garden.systems.upsert,
     "SYSTEM_READ": beer_garden.systems.get_system,
     "SYSTEM_READ_ALL": beer_garden.systems.get_systems,
     "SYSTEM_UPDATE": beer_garden.systems.update_system,


### PR DESCRIPTION
Fixes #629.

This PR makes system creation no longer fail if a system already exists - it turns the old "insert" operation into an "upsert".

I'm not excited about having to do this, but I don't see a better way at the moment. This is how things work in v2, and while I was hoping to improve on this for v3 it doesn't look like that's happening.

One thing that is different that v2: the HTTP response code is the same for both cases. In v2 we would return a 201 for a system that was actually created as a result of the POST and a 200 for a system that was just updated. In v3 we always return the same code. This doesn't *really* matter as the plugins don't care what the response code is as long as it's a success. It's just less REST-ideal.