### PR TITLE
Added Force Delete for Systems.

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/system.py
+++ b/src/app/beer_garden/api/http/handlers/v1/system.py
@@ -88,18 +88,15 @@ class SystemAPI(BaseHandler):
           - Systems
         """
 
-        if self.get_argument("force", default="").lower() == "true":
-            await self.client(
-                Operation(
-                    operation_type="SYSTEM_DELETE_FORCE",
-                    args=[system_id],
-                    kwargs={"force": True},
-                )
+        await self.client(
+            Operation(
+                operation_type="SYSTEM_DELETE",
+                args=[system_id],
+                kwargs={
+                    "force": self.get_argument("force", default="").lower() == "true"
+                },
             )
-        else:
-            await self.client(
-                Operation(operation_type="SYSTEM_DELETE", args=[system_id])
-            )
+        )
 
         self.set_status(204)
 

--- a/src/app/beer_garden/api/http/handlers/v1/system.py
+++ b/src/app/beer_garden/api/http/handlers/v1/system.py
@@ -71,6 +71,12 @@ class SystemAPI(BaseHandler):
             required: true
             description: The ID of the System
             type: string
+          - name: force
+            in: query
+            required: false
+            description: Flag indicating whether to force delete
+            type: boolean
+            default: false
         responses:
           204:
             description: System has been successfully deleted
@@ -82,7 +88,10 @@ class SystemAPI(BaseHandler):
           - Systems
         """
 
-        await self.client(Operation(operation_type="SYSTEM_DELETE", args=[system_id]))
+        if self.get_argument("force", default="").lower() == "true":
+            await self.client(Operation(operation_type="SYSTEM_DELETE_FORCE", args=[system_id]))
+        else:
+            await self.client(Operation(operation_type="SYSTEM_DELETE", args=[system_id]))
 
         self.set_status(204)
 

--- a/src/app/beer_garden/api/http/handlers/v1/system.py
+++ b/src/app/beer_garden/api/http/handlers/v1/system.py
@@ -89,9 +89,17 @@ class SystemAPI(BaseHandler):
         """
 
         if self.get_argument("force", default="").lower() == "true":
-            await self.client(Operation(operation_type="SYSTEM_DELETE_FORCE", args=[system_id]))
+            await self.client(
+                Operation(
+                    operation_type="SYSTEM_DELETE_FORCE",
+                    args=[system_id],
+                    kwargs={"force": True},
+                )
+            )
         else:
-            await self.client(Operation(operation_type="SYSTEM_DELETE", args=[system_id]))
+            await self.client(
+                Operation(operation_type="SYSTEM_DELETE", args=[system_id])
+            )
 
         self.set_status(204)
 

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -109,7 +109,7 @@ route_functions = {
     "SYSTEM_RELOAD": beer_garden.systems.reload_system,
     "SYSTEM_RESCAN": beer_garden.systems.rescan_system_directory,
     "SYSTEM_DELETE": beer_garden.systems.purge_system,
-    "SYSTEM_DELETE_FORCE": beer_garden.systems.remove_system,
+    "SYSTEM_DELETE_FORCE": beer_garden.systems.purge_system,
     "GARDEN_CREATE": beer_garden.garden.create_garden,
     "GARDEN_READ": beer_garden.garden.get_garden,
     "GARDEN_READ_ALL": beer_garden.garden.get_gardens,

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -109,6 +109,7 @@ route_functions = {
     "SYSTEM_RELOAD": beer_garden.systems.reload_system,
     "SYSTEM_RESCAN": beer_garden.systems.rescan_system_directory,
     "SYSTEM_DELETE": beer_garden.systems.purge_system,
+    "SYSTEM_DELETE_FORCE": beer_garden.systems.remove_system,
     "GARDEN_CREATE": beer_garden.garden.create_garden,
     "GARDEN_READ": beer_garden.garden.get_garden,
     "GARDEN_READ_ALL": beer_garden.garden.get_gardens,
@@ -418,6 +419,8 @@ def _determine_target_garden(operation: Operation) -> str:
         return _system_name_lookup(
             System(namespace=parts[0], name=parts[1], version=version)
         )
+    elif operation.operation_type == "SYSTEM_DELETE_FORCE":
+        return config.get("garden.name")
 
     raise Exception(f"Bad operation type {operation.operation_type}")
 

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -92,6 +92,7 @@ import aboutController from './js/controllers/about.js';
 import adminQueueController from './js/controllers/admin_queue.js';
 import adminSystemController from './js/controllers/admin_system.js';
 import adminSystemLogsController from './js/controllers/admin_system_logs.js';
+import adminSystemForceDeleteController from './js/controllers/admin_system_force_delete.js';
 import {adminUserController, newUserController} from './js/controllers/admin_user.js';
 import {adminRoleController, newRoleController} from './js/controllers/admin_role.js';
 import adminGardenController from './js/controllers/admin_garden.js';
@@ -181,6 +182,7 @@ angular.module('bgApp',
 
 .controller('AboutController', aboutController)
 .controller('AdminQueueController', adminQueueController)
+.controller('AdminSystemForceDeleteController', adminSystemForceDeleteController)
 .controller('AdminSystemController', adminSystemController)
 .controller('AdminSystemLogsController', adminSystemLogsController)
 .controller('AdminUserController', adminUserController)

--- a/src/ui/src/js/controllers/admin_system.js
+++ b/src/ui/src/js/controllers/admin_system.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import readLogs from '../../templates/read_logs.html';
 import adminQueue from '../../templates/admin_queue.html';
+import forceDelete from '../../templates/system_force_delete.html';
 
 adminSystemController.$inject = [
   '$scope',
@@ -60,7 +61,20 @@ export default function adminSystemController(
   };
 
   $scope.deleteSystem = function(system) {
-    SystemService.deleteSystem(system).then(_.noop, $scope.addErrorAlert);
+
+    $scope.deletedSystem = system;
+    SystemService.deleteSystem(system).then(_.noop, (response) => {
+        $uibModal.open({
+         template:forceDelete,
+        resolve: {
+           system: $scope.deletedSystem,
+           response: response,
+         },
+         controller: 'AdminSystemForceDeleteController',
+         windowClass: 'app-modal-window',
+      });
+    });
+
   };
 
   $scope.clearAllQueues = function() {

--- a/src/ui/src/js/controllers/admin_system_force_delete.js
+++ b/src/ui/src/js/controllers/admin_system_force_delete.js
@@ -1,0 +1,50 @@
+import angular from 'angular';
+
+adminSystemForceDeleteController.$inject = [
+  '$scope',
+  '$uibModalInstance',
+  'SystemService',
+  'system',
+  'response',
+];
+
+/**
+ * adminSystemForceDeleteController - Angular controller for force deleting systems.
+ * @param  {Object} $rootScope        Angular's $rootScope object.
+ * @param  {Object} SystemService     Beer-Garden's system service object.
+ */
+export default function adminSystemForceDeleteController(
+    $scope,
+    $uibModalInstance,
+    SystemService,
+    system,
+    response,
+) {
+
+  $scope.alerts = [];
+  $scope.system = system
+  $scope.error = response.data.message
+
+  $scope.forceDeleteSystem = function(system) {
+    SystemService.forceDeleteSystem(system).then(function(response) {
+    $uibModalInstance.close();
+
+    }, $scope.addErrorAlert);
+  };
+
+  $scope.closeAlert = function(index) {
+    $scope.alerts.splice(index, 1);
+  };
+
+  $scope.addErrorAlert = function(response) {
+    $scope.alerts.push({
+      type: 'danger',
+      msg: _.get(response, 'data.message', 'Please check the server logs'),
+    });
+  };
+
+  $scope.closeDialog = function() {
+    $uibModalInstance.close();
+  }
+
+};

--- a/src/ui/src/js/services/system_service.js
+++ b/src/ui/src/js/services/system_service.js
@@ -77,6 +77,10 @@ export default function systemService($rootScope, $http) {
     deleteSystem: (system) => {
       return $http.delete('api/v1/systems/' + system.id);
     },
+    forceDeleteSystem: (system) => {
+      return $http.delete('api/v1/systems/' + system.id,
+      {params: {force: true}});
+    },
     reloadSystem: (system) => {
       return $http.patch('api/v1/systems/' + system.id,
         {operation: 'reload', path: '', value: ''}

--- a/src/ui/src/templates/system_force_delete.html
+++ b/src/ui/src/templates/system_force_delete.html
@@ -1,0 +1,30 @@
+<div class="modal-header">
+  <h3 class="modal-title" id="modal-title">Error Deleting {{system.name}}</h3>
+</div>
+
+<div class="modal-body" id="modal-body">
+  <div uib-alert
+      ng-repeat="alert in alerts"
+      ng-class="'alert-{{alert.type}}'"
+      close="closeAlert($index)">
+    {{alert.msg}}
+  </div>
+  <div>
+      <div>If you would like to Force Delete {{system.name}}, please check with your system administrator before running
+          this command. This only deletes the record from the database and will not shutdown {{system.name}} or remove
+          RabbitMQ queues.</div>
+      <div>Please review the original error message before proceeding.</div>
+      <div uib-alert ng-class="'alert-danger'">{{error}}</div>
+      <button type="button"
+                      class="btn btn-danger"
+                      ng-click="forceDeleteSystem(system)"
+                      confirm="Are you sure you want to force delete {{system.name}} from your local database?">
+                    Force Delete
+      </button>
+  </div>
+
+</div>
+
+<div class="modal-footer">
+  <button class="btn btn-primary" type="button" ng-click="closeDialog()">Close</button>
+</div>

--- a/src/ui/src/templates/system_force_delete.html
+++ b/src/ui/src/templates/system_force_delete.html
@@ -10,15 +10,22 @@
     {{alert.msg}}
   </div>
   <div>
-      <div>If you would like to Force Delete {{system.name}}, please check with your system administrator before running
-          this command. This only deletes the record from the database and will not shutdown {{system.name}} or remove
-          RabbitMQ queues.</div>
+      <div ng-if="system.local">If you would like to Force Delete
+          {{system.namespace}}/{{system.name}}-{{system.version}}, please check with your system administrator before
+          running this command. This will follow the standard shutdown process for
+          {{system.namespace}}/{{system.name}}-{{system.version}}. If an error occurs,
+          {{system.namespace}}/{{system.name}}-{{system.version}} will still be deleted from the database.</div>
+      <div ng-if="!system.local">
+          If you would like to Force Delete {{system.namespace}}/{{system.name}}-{{system.version}}, please check with
+          your system administrator before running this command. {{system.namespace}}/{{system.name}}-{{system.version}}
+          is managed by another Garden, this request will only be executed locally. This only deletes
+          {{system.namespace}}/{{system.name}}-{{system.version}} from the database and will not shutdown
+          {{system.namespace}}/{{system.name}}-{{system.version}} or remove RabbitMQ queues.</div>
       <div>Please review the original error message before proceeding.</div>
       <div uib-alert ng-class="'alert-danger'">{{error}}</div>
       <button type="button"
                       class="btn btn-danger"
-                      ng-click="forceDeleteSystem(system)"
-                      confirm="Are you sure you want to force delete {{system.name}} from your local database?">
+                      ng-click="forceDeleteSystem(system)">
                     Force Delete
       </button>
   </div>


### PR DESCRIPTION
Added the functionality to force delete a System record from the database. This does not take into consideration RabbitMQ or shutting down the plugin. If the plugin is still operational it will throw errors, but this is the last resort to deleting systems if you get in a bad state. So we ask like 3 times if you are sure.

Fixes #526 