### PR TITLE
Changing tags in compose to 3.0.0a1

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -20,7 +20,7 @@ x-definitions: &env
 
 services:
     beer-garden:
-        image: bgio/beer-garden:unstable
+        image: bgio/beer-garden:3.0.0a1
         networks:
             - bg-network
         ports:
@@ -56,7 +56,7 @@ services:
             - rabbitmq
 
     ui:
-        image: bgio/ui:unstable
+        image: bgio/ui:3.0.0a1
         networks:
             - bg-network
         ports:


### PR DESCRIPTION
This would change the default tag in the non-TLS compose file to be the released tag instead of unstable.

I'm not sure if this something we want to do... thoughts?