### PR TITLE
Issue/590

### DIFF
--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -53,6 +53,24 @@ class QueueListener(BaseProcessor):
                 pass
 
 
+class LockListener(QueueListener):
+    """Listens for items on a multiprocessing.Queue"""
+
+    def __init__(self, lock=None, **kwargs):
+        super().__init__(**kwargs)
+
+        self._lock = lock
+
+    def run(self):
+        """Process events as they are received"""
+        while not self.stopped():
+            with self._lock:
+                try:
+                    self.process(self._queue.get(timeout=0.1))
+                except Empty:
+                    pass
+
+
 class DelayListener(QueueListener):
     """Listener that waits for an Event before running"""
 

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -4,6 +4,7 @@ import json
 import logging
 import string
 from concurrent.futures import ThreadPoolExecutor, wait
+from threading import Lock
 
 import sys
 from enum import Enum
@@ -309,6 +310,8 @@ class PluginManager(StoppableThread):
             return []
 
         new_runners = []
+        error_log_lock = Lock()
+
         for instance_name in plugin_config["INSTANCES"]:
             runner_id = "".join([choice(string.ascii_letters) for _ in range(10)])
             process_args = self._process_args(plugin_config, instance_name)
@@ -322,6 +325,7 @@ class PluginManager(StoppableThread):
                     process_args=process_args,
                     process_cwd=plugin_path,
                     process_env=process_env,
+                    error_log_lock=error_log_lock,
                 )
             )
 

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -20,7 +20,6 @@ from brewtils.stoppable_thread import StoppableThread
 
 import beer_garden
 import beer_garden.config as config
-import beer_garden.db.api as db
 from beer_garden.errors import PluginValidationError
 from beer_garden.local_plugins.env_help import expand_string
 from beer_garden.local_plugins.runner import ProcessRunner
@@ -136,10 +135,9 @@ class PluginManager(StoppableThread):
 
         if runner_id:
             instance = event.payload
-            system = db.query_unique(System, instances__contains=instance)
 
             runner = cls.from_runner_id(runner_id)
-            runner.associate(system=system, instance=instance)
+            runner.associate(instance=instance)
             runner.restart = True
 
     @classmethod

--- a/src/app/beer_garden/local_plugins/runner.py
+++ b/src/app/beer_garden/local_plugins/runner.py
@@ -89,7 +89,7 @@ class ProcessRunner(Thread):
     def __str__(self):
         return f"{self.runner_name}.{self.runner_id}"
 
-    def associate(self, system=None, instance=None):
+    def associate(self, instance=None):
         """Associate this runner with a specific instance ID"""
         self.instance_id = instance.id
 

--- a/src/app/test/local_plugins/runner_test.py
+++ b/src/app/test/local_plugins/runner_test.py
@@ -1,10 +1,11 @@
 import logging
 import string
 import subprocess
-import sys
 from random import choice
+from threading import Lock
 
 import pytest
+import sys
 from mock import Mock, call
 
 from beer_garden.local_plugins.runner import ProcessRunner
@@ -17,6 +18,7 @@ def runner(tmp_path):
         process_args=["python", "-m", "echo"],
         process_cwd=tmp_path,
         process_env={},
+        error_log_lock=Lock(),
     )
 
 


### PR DESCRIPTION
This helps with #590 but probably doesn't close it. This PR is ready to be reviewed, though.

This PR reworks how local plugin STDOUT and STDERR is handled when the Plugin inside the runner process fails to initialized. See the docstring for an in-depth discussion, but the short version is that all captured messages will be logged to both the application log and an plugin error file in the plugin working directory.