### PR TITLE
Grab the request object if the Job still exists for status

### DIFF
--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -59,9 +59,9 @@ def run_job(job_id, request_template):
     # Be a little careful here as the job could have been removed or paused
     job = beer_garden.application.scheduler.get_job(job_id)
     if (
-            job
-            and job.next_run_time is not None
-            and getattr(job.trigger, "reschedule_on_finish", False)
+        job
+        and job.next_run_time is not None
+        and getattr(job.trigger, "reschedule_on_finish", False)
     ):
         # This essentially resets the timer on this job, which has the effect of
         # making the wait time start whenever the job finishes

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -10,7 +10,7 @@ import beer_garden
 import beer_garden.config as config
 import beer_garden.db.api as db
 from beer_garden.events import publish_event
-from beer_garden.requests import process_request
+from beer_garden.requests import process_request, get_request
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,13 @@ def run_job(job_id, request_template):
     try:
         db_job = db.query_unique(Job, id=job_id)
         if db_job:
+            request = get_request(request.id)
+
             if request.status == "ERROR":
                 db_job.error_count += 1
             elif request.status == "SUCCESS":
                 db_job.success_count += 1
+
             db.update(db_job)
         else:
             # If the job is not in the database, don't proceed to update scheduler
@@ -56,9 +59,9 @@ def run_job(job_id, request_template):
     # Be a little careful here as the job could have been removed or paused
     job = beer_garden.application.scheduler.get_job(job_id)
     if (
-        job
-        and job.next_run_time is not None
-        and getattr(job.trigger, "reschedule_on_finish", False)
+            job
+            and job.next_run_time is not None
+            and getattr(job.trigger, "reschedule_on_finish", False)
     ):
         # This essentially resets the timer on this job, which has the effect of
         # making the wait time start whenever the job finishes


### PR DESCRIPTION
The scheduled was not getting the latest status from the request after our recent refactoring. This will grab the request object if it is required.

Fixes #665 