### PR TITLE
Translating empty string to garden name for SYSTEM_READ_ALL

### DIFF
--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -365,6 +365,10 @@ def _pre_route(operation: Operation) -> Operation:
         if operation.model.namespace is None:
             operation.model.namespace = config.get("garden.name")
 
+    elif operation.operation_type == "SYSTEM_READ_ALL":
+        if operation.kwargs.get("filter_params", {}).get("namespace") == "":
+            operation.kwargs["filter_params"]["namespace"] = config.get("garden.name")
+
     return operation
 
 


### PR DESCRIPTION
This fixes #673. It translate an empty string namespace filter param for the SYSTEM_READ_ALL operation to the local garden name.