### PR TITLE
Issue/590

### DIFF
--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1032,6 +1032,17 @@ _PLUGIN_SPEC = {
                     "previous_names": ["plugins_directory", "plugin_directory"],
                     "alt_env_names": ["PLUGINS_DIRECTORY", "BG_PLUGIN_DIRECTORY"],
                 },
+                "logging": {
+                    "type": "dict",
+                    "items": {
+                        "stream_files": {
+                            "type": "bool",
+                            "description": "Write plugin STDOUT to plugin.out and "
+                            "plugin STDERR to plugin.err",
+                            "default": False,
+                        },
+                    },
+                },
                 "timeout": {
                     "type": "dict",
                     "items": {

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -53,24 +53,6 @@ class QueueListener(BaseProcessor):
                 pass
 
 
-class LockListener(QueueListener):
-    """Listens for items on a multiprocessing.Queue"""
-
-    def __init__(self, lock=None, **kwargs):
-        super().__init__(**kwargs)
-
-        self._lock = lock
-
-    def run(self):
-        """Process events as they are received"""
-        while not self.stopped():
-            with self._lock:
-                try:
-                    self.process(self._queue.get(timeout=0.1))
-                except Empty:
-                    pass
-
-
 class DelayListener(QueueListener):
     """Listener that waits for an Event before running"""
 

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -1,23 +1,21 @@
 # -*- coding: utf-8 -*-
 
-import json
-import logging
 import string
 from concurrent.futures import ThreadPoolExecutor, wait
-from threading import Lock
-
-import sys
 from enum import Enum
+
+import json
+import logging
+import sys
+from brewtils.models import Event, Events, System
+from brewtils.specification import _SYSTEM_SPEC
+from brewtils.stoppable_thread import StoppableThread
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path, PosixPath
 from random import choice
 from types import ModuleType
 from typing import Any, Dict, List, Optional
-
-from brewtils.models import Event, Events, System
-from brewtils.specification import _SYSTEM_SPEC
-from brewtils.stoppable_thread import StoppableThread
 
 import beer_garden
 import beer_garden.config as config
@@ -310,7 +308,6 @@ class PluginManager(StoppableThread):
             return []
 
         new_runners = []
-        error_log_lock = Lock()
 
         for instance_name in plugin_config["INSTANCES"]:
             runner_id = "".join([choice(string.ascii_letters) for _ in range(10)])
@@ -325,7 +322,6 @@ class PluginManager(StoppableThread):
                     process_args=process_args,
                     process_cwd=plugin_path,
                     process_env=process_env,
-                    error_log_lock=error_log_lock,
                 )
             )
 

--- a/src/app/beer_garden/local_plugins/runner.py
+++ b/src/app/beer_garden/local_plugins/runner.py
@@ -3,13 +3,9 @@
 import logging
 import subprocess
 from pathlib import Path
-from queue import Queue
-from threading import Lock, Thread
-from typing import Sequence
-
+from threading import Thread
 from time import sleep
-
-from beer_garden.events.processors import LockListener
+from typing import Sequence
 
 log_levels = [n for n in getattr(logging, "_nameToLevel").keys()]
 
@@ -54,7 +50,6 @@ class ProcessRunner(Thread):
         process_args: Sequence[str],
         process_cwd: Path,
         process_env: dict,
-        error_log_lock: Lock,
     ):
         self.process = None
         self.restart = False
@@ -69,27 +64,30 @@ class ProcessRunner(Thread):
         self.process_env = process_env
         self.runner_name = process_cwd.name
 
-        self.log_queue = Queue()
-        self.error_log_lock = error_log_lock
-        self.log_reader = LockListener(
-            lock=self.error_log_lock,
-            queue=self.log_queue,
-            action=self._process_logs,
-            name=f"{self} Log Processor",
+        self.stdout_log = self.process_cwd / "plugin.out"
+        self.stdout_handler = logging.FileHandler(self.stdout_log)
+        self.stdout_handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
 
-        self.error_log = self.process_cwd / "plugin.err"
-        self.error_handler = logging.FileHandler(self.error_log)
-        self.error_handler.setFormatter(
+        self.stderr_log = self.process_cwd / "plugin.err"
+        self.stderr_handler = logging.FileHandler(self.stderr_log)
+        self.stderr_handler.setFormatter(
             logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
 
         # Logger that will be used by the actual ProcessRunner
         self.logger = logging.getLogger(f"{__name__}.{self}")
 
-        # Logger that will be used for captured STDOUT / STDERR
-        self.capture_logger = logging.getLogger(f"runner.{self}")
-        self.capture_logger.setLevel("DEBUG")
+        # Loggers that will be used for captured STDOUT / STDERR
+        self.stdout_logger = logging.getLogger(f"runner.{self}.stdout")
+        self.stdout_logger.setLevel("DEBUG")
+        self.stderr_logger = logging.getLogger(f"runner.{self}.stderr")
+        self.stderr_logger.setLevel("DEBUG")
+
+        if True:
+            self.stdout_logger.addHandler(self.stdout_handler)
+            self.stderr_logger.addHandler(self.stderr_handler)
 
         Thread.__init__(self, name=self.runner_name)
 
@@ -99,10 +97,6 @@ class ProcessRunner(Thread):
     def associate(self, instance=None):
         """Associate this runner with a specific instance ID"""
         self.instance_id = instance.id
-
-        # At this point we're satisfied that we won't need to write captured STDOUT /
-        # STDERR to the error file so allow messages to be processed
-        self.log_reader.start()
 
     def kill(self):
         """Kill the underlying plugin process with SIGKILL"""
@@ -132,14 +126,14 @@ class ProcessRunner(Thread):
 
             # Reading process IO is blocking so needs to be in separate threads
             stdout_thread = Thread(
-                target=self._read_stream,
-                args=(self.process.stdout, logging.INFO),
                 name=f"{self} STDOUT Reader",
+                target=self._read_stream,
+                args=(self.process.stdout, logging.INFO, self.stdout_logger),
             )
             stderr_thread = Thread(
-                target=self._read_stream,
-                args=(self.process.stderr, logging.ERROR),
                 name=f"{self} STDERR Reader",
+                target=self._read_stream,
+                args=(self.process.stderr, logging.ERROR, self.stderr_logger),
             )
             stdout_thread.start()
             stderr_thread.start()
@@ -152,34 +146,17 @@ class ProcessRunner(Thread):
             stdout_thread.join()
             stderr_thread.join()
 
-            # Ensure logs are sent SOMEWHERE in the event they were never configured
-            # TODO - This is broken: QueueListener doesn't exhaust queue before dying
-            if not self.log_reader.is_alive():
+            if not self.instance_id:
                 self.logger.warning(
-                    f"Plugin {self} terminated before successfully initializing. All "
-                    f"captured messages will be written to {self.error_log} and the "
-                    f"application logs."
+                    f"Plugin {self} terminated before successfully initializing."
                 )
-
-                # This is what enables logging to the error file
-                self.capture_logger.addHandler(self.error_handler)
-
-                self.log_reader.start()
-
-                # Need to give the log_reader time to start, otherwise the stopped
-                # check will happen before we start processing
-                sleep(0.1)
-
-            self.logger.debug("About to stop and join log processing thread")
-            self.log_reader.stop()
-            self.log_reader.join()
 
             self.logger.info("Plugin is officially stopped")
 
         except Exception as ex:
             self.logger.exception(f"Plugin died: {ex}")
 
-    def _read_stream(self, stream, default_level):
+    def _read_stream(self, stream, default_level, logger):
         """Helper function thread target to read IO from the plugin's subprocess
 
         This will read line by line from STDOUT or STDERR. If the line includes one of
@@ -203,9 +180,4 @@ class ProcessRunner(Thread):
                         level_to_log = getattr(logging, level)
                         break
 
-                # TODO - timestamps are broken if we have to log everything at the end
-                self.log_queue.put((level_to_log, line))
-
-    def _process_logs(self, record):
-        """Read messages off the logging queue and deal with them"""
-        self.capture_logger.log(record[0], record[1])
+                logger.log(level_to_log, line)

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -104,6 +104,8 @@ plugin:
       password: password
       username: admin
     directory: ./plugins
+    logging:
+      stream_files: false
     timeout:
       shutdown: 10
       startup: 2

--- a/src/app/test/local_plugins/runner_test.py
+++ b/src/app/test/local_plugins/runner_test.py
@@ -2,7 +2,6 @@ import logging
 import string
 import subprocess
 from random import choice
-from threading import Lock
 
 import pytest
 import sys
@@ -18,7 +17,6 @@ def runner(tmp_path):
         process_args=["python", "-m", "echo"],
         process_cwd=tmp_path,
         process_env={},
-        error_log_lock=Lock(),
     )
 
 


### PR DESCRIPTION
I believe this fixes #590. It adds a config option that will allow for persisting plugins' STDOUT and STDERR to files in the plugin's working directory.

There are two issues still [outstanding](https://github.com/beer-garden/beer-garden/issues/590#issuecomment-706450395):
- The first is now OBE as the `LockListener` is removed entirely
- The second is addressed as we're no longer delaying logging at all - every messaged is logged as soon as it's received