### PR TITLE
Storing request index length in local storage

### DIFF
--- a/src/ui/src/js/controllers/command_index.js
+++ b/src/ui/src/js/controllers/command_index.js
@@ -2,29 +2,40 @@ commandIndexController.$inject = [
   '$rootScope',
   '$scope',
   '$stateParams',
+  'localStorageService',
   'DTOptionsBuilder',
-  'DTColumnBuilder',
 ];
 
 /**
  * commandIndexController - Angular controller for all commands page.
- * @param  {$rootScope} $rootScope   Angular's $rootScope object.
- * @param  {$scope} $scope           Angular's $scope object.
+ * @param  {Object} $rootScope       Angular's $rootScope object.
+ * @param  {Object} $scope           Angular's $scope object.
+ * @param  {Object} localStorageService  Storage service
  * @param  {Object} DTOptionsBuilder Data-tables' builder for options.
  */
 export default function commandIndexController(
     $rootScope,
     $scope,
     $stateParams,
+    localStorageService,
     DTOptionsBuilder) {
   $scope.setWindowTitle('commands');
   $scope.filterHidden = false;
   $scope.dtInstance = {};
   $scope.dtOptions = DTOptionsBuilder.newOptions()
     .withOption('autoWidth', false)
+    .withOption('pageLength', localStorageService.get('_command_index_length') || 10)
     .withOption('hiddenContainer', true)
     .withOption('order', [[0, 'asc'], [1, 'asc'], [2, 'asc'], [3, 'asc']])
     .withBootstrap();
+
+  $scope.instanceCreated = function(_instance) {
+    $scope.dtInstance = _instance;
+
+    $('#commandIndexTable').on('length.dt', (event, settings, len) => {
+      localStorageService.set('_command_index_length', len);
+    });
+  };
 
   $scope.hiddenComparator = function(hidden, checkbox){
     return checkbox || !hidden;

--- a/src/ui/src/js/controllers/request_index.js
+++ b/src/ui/src/js/controllers/request_index.js
@@ -3,6 +3,7 @@ import {formatDate} from '../services/utility_service.js';
 requestIndexController.$inject = [
   '$scope',
   '$compile',
+  'localStorageService',
   'DTOptionsBuilder',
   'DTColumnBuilder',
   'RequestService',
@@ -13,6 +14,7 @@ requestIndexController.$inject = [
  * requestIndexController - Angular controller for viewing all requests.
  * @param  {Object} $scope            Angular's $scope object.
  * @param  {Object} $compile          Angular's $compile object.
+ * @param  {Object} localStorageService  Storage service
  * @param  {Object} DTOptionsBuilder  Data-tables' options builder object.
  * @param  {Object} DTColumnBuilder   Data-tables' column builder object.
  * @param  {Object} RequestService    Beer-Garden Request Service.
@@ -21,6 +23,7 @@ requestIndexController.$inject = [
 export default function requestIndexController(
     $scope,
     $compile,
+    localStorageService,
     DTOptionsBuilder,
     DTColumnBuilder,
     RequestService,
@@ -31,6 +34,7 @@ export default function requestIndexController(
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
     .withOption('autoWidth', false)
+    .withOption('pageLength', localStorageService.get('_request_index_length') || 10)
     .withOption('ajax', function(data, callback, settings) {
       // Need to also request ID for the href
       data.columns.push({'data': 'id'});
@@ -193,6 +197,10 @@ export default function requestIndexController(
 
   $scope.instanceCreated = function(_instance) {
     $scope.dtInstance = _instance;
+
+    $('#requestIndexTable').on('length.dt', (event, settings, len) => {
+      localStorageService.set('_request_index_length', len);
+    });
   };
 
   EventService.addCallback('request_index', (event) => {

--- a/src/ui/src/js/controllers/system_index.js
+++ b/src/ui/src/js/controllers/system_index.js
@@ -2,6 +2,7 @@
 systemIndexController.$inject = [
   '$scope',
   '$rootScope',
+  'localStorageService',
   'UtilityService',
   'DTOptionsBuilder',
 ];
@@ -10,11 +11,13 @@ systemIndexController.$inject = [
  * systemIndexController - Controller for the system index page.
  * @param  {Object} $scope         Angular's $scope object.
  * @param  {Object} $rootScope     Angular's $rootScope object.
+ * @param  {Object} localStorageService  Storage service
  * @param  {Object} UtilityService Beer-Garden's utility service.
  */
 export default function systemIndexController(
     $scope,
     $rootScope,
+    localStorageService,
     UtilityService,
     DTOptionsBuilder
     ) {
@@ -24,6 +27,7 @@ export default function systemIndexController(
 
   $scope.dtOptions = DTOptionsBuilder.newOptions()
     .withOption('autoWidth', false)
+    .withOption('pageLength', localStorageService.get('_system_index_length') || 10)
     .withOption('order', [[0, 'asc'], [1, 'asc'], [2, 'asc'], [3, 'asc']])
     .withLightColumnFilter({
       0: {html: 'input', type: 'text', attr: {class: 'form-inline form-control', title: 'Namespace Filter'}},
@@ -34,6 +38,14 @@ export default function systemIndexController(
       5: {html: 'input', type: 'number', attr: {class: 'form-inline form-control', title: 'Instances Filter'}},
     })
     .withBootstrap();
+
+  $scope.instanceCreated = function(_instance) {
+    $scope.dtInstance = _instance;
+
+    $('#systemIndexTable').on('length.dt', (event, settings, len) => {
+      localStorageService.set('_system_index_length', len);
+    });
+  };
 
   $scope.successCallback = function(response) {
     $scope.response = response;

--- a/src/ui/src/partials/command_index.html
+++ b/src/ui/src/partials/command_index.html
@@ -17,9 +17,10 @@
   <div>
 
     <table
+        id="commandIndexTable"
         datatable="ng"
         dt-options="dtOptions"
-        dt-instance="dtInstance"
+        dt-instance="instanceCreated"
         class="table table-striped table-bordered"
         style="width: 100%">
       <thead>

--- a/src/ui/src/partials/system_index.html
+++ b/src/ui/src/partials/system_index.html
@@ -6,8 +6,10 @@
 
   <div class="container-fluid animate-if">
     <table
+        id="systemIndexTable"
         datatable="ng"
         dt-options="dtOptions"
+        dt-instance="instanceCreated"
         class="table table-striped table-bordered"
         style="width: 100%">
       <thead>


### PR DESCRIPTION
This starts addressing #560. Only the request index page is done, but the solution should be easy to expand to the other tables.