### PR TITLE
Dt selection

### DIFF
--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -150,9 +150,6 @@ angular.module('bgApp',
 .run(runDTRenderer)
 .config(routeConfig)
 .config(interceptorConfig)
-.config(['localStorageServiceProvider', function(localStorageServiceProvider) {
-  localStorageServiceProvider.setStorageType('sessionStorage');
-}])
 .service('APIInterceptor', interceptorService)
 .service('authInterceptorService', authInterceptorService)
 .animation('.slide', slideAnimation)

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -116,7 +116,7 @@ export default function appRun(
 
   $rootScope.initialLoad = function() {
     // Very first thing is to load up a token if one exists
-    let token = localStorageService.get('token');
+    let token = localStorageService.get('token', 'sessionStorage');
     if (token) {
       TokenService.handleToken(token);
     }

--- a/src/ui/src/js/services/token_service.js
+++ b/src/ui/src/js/services/token_service.js
@@ -1,46 +1,39 @@
 import _ from 'lodash';
 
-tokenService.$inject = [
-  '$rootScope',
-  '$http',
-  'localStorageService',
-];
+tokenService.$inject = ['$http', 'localStorageService'];
 
 /**
  * tokenService - Service for interacting with the token API.
- * @param  {Object} $rootScope          Angular's $rootScope Object.
  * @param  {Object} $http               Angular's $http Object.
  * @param  {Object} localStorageService Storage service
  * @return {Object}       Service for interacting with the token API.
  */
-export default function tokenService(
-    $rootScope,
-    $http,
-    localStorageService) {
+export default function tokenService($http, localStorageService) {
+
   let service = {
     getToken: () => {
-      return localStorageService.get('token');
+      return localStorageService.get('token', 'sessionStorage');
     },
     handleToken: (token) => {
-      localStorageService.set('token', token);
+      localStorageService.set('token', token, 'sessionStorage');
       $http.defaults.headers.common.Authorization = 'Bearer ' + token;
     },
     clearToken: () => {
-      localStorageService.remove('token');
+      localStorageService.remove('token', 'sessionStorage');
       $http.defaults.headers.common.Authorization = undefined;
     },
     getRefresh: () => {
-      return localStorageService.get('refresh');
+      return localStorageService.get('refresh', 'sessionStorage');
     },
     handleRefresh: (refreshToken) => {
-      localStorageService.set('refresh', refreshToken);
+      localStorageService.set('refresh', refreshToken, 'sessionStorage');
     },
     clearRefresh: () => {
-      let refreshToken = localStorageService.get('refresh');
+      let refreshToken = localStorageService.get('refresh', 'sessionStorage');
       if (refreshToken) {
         // It's possible the refresh token was already removed from the database
         // We usually don't care if that's the case, so set a noop error handler
-        localStorageService.remove('refresh');
+        localStorageService.remove('refresh', 'sessionStorage');
         return $http.delete('api/v1/tokens/' + refreshToken).catch(() => {});
       }
     },


### PR DESCRIPTION
This changes the default frontend storage to `localStorage` and explicitly uses `sessionStorage` for all token-related things. Since we don't actually support the login capability on the frontend yet that isn't strictly necessary, but I think it's what we'll want to do when we re-add that functionality.