### PR TITLE
Temporary workaround to fix travis version conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
 
   - stage: pypi deploy
     if: tag IS present
+    install: pip install keyring==21.4.0
     before_script: cd src/app
     script: skip
     after_success: true


### PR DESCRIPTION
This is a temporary band-aid for #742. It looks like Travis has a PR for a fix to their deployment utility that should allow us to revert this once it's in use.