### PR TITLE
Resolves Issue #753

### DIFF
--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -44,6 +44,10 @@ class QueueListener(BaseProcessor):
         while not self._queue.empty():
             self._queue.get()
 
+    def stop(self):
+        super().stop()
+        self.clear()
+
     def run(self):
         """Process events as they are received"""
         while not self.stopped():


### PR DESCRIPTION
Clears queue in `QueueListener` to resolve error during shutdown described in issue #753

Fixes #753 