### PR TITLE
Issue/752

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,21 @@ jobs:
     script: make publish-docker VERSION=$TRAVIS_TAG
     after_success: skip
 
+  - stage: github release / rpm deploy
+    if: tag IS present
+    install: make -C src/ui deps
+    before_script: make docker-login
+    script: make rpm-build VERSION=$TRAVIS_TAG
+    deploy:
+      provider: releases
+      on:
+        tags: true
+      file: rpm/dist/beer-garden-$TRAVIS_TAG-1.el7.x86_64.rpm
+      skip_cleanup: true
+      api_key:
+        secure: Eg3oMUS7bBcFUffE5Mj89DiaLAxy3ls5BJ7NaAmAuZL7xzeuk/4BYgYneyWZUNYFYHKJ7tUk3GsLx2eQYciFmLNKsdp3rOy/4qKGMqWJU41TJmZC9A2mi6WenNCevRyuXwfT0uM0/qDE3G1D9zT4XWn+dRPZyBk2n/togm1nrsZ+U+rdU/lgvImBNB6QJJXWOzyPN8c6v1udI5O0w0N24291PDu7eIDDtpdQXuGTRueGrBLXbzZzGjzN7JXWVePUOe0+BrN8r/b7fQs45LIIqwzIH4yq30dXPaVWTsG7qhvncixC78MKd+IGY7do7ShEAweOU0dJ6MFAIhphRhj+tqxTJBVMRKu0sFVVLQOdmi/NWuXH1XJULSZXiK8dxBL3wS9X82JqGwbXxruoj/IojXb9z7T5kDNxVivw0738fXP4iBjqSkUKR+rSfoq57dBYuVF07p0ASzJSFDN+aUPJMR2GCGkxSjRY7U7aTfbLTMqPSJrGbsXQo1sBvwLSh0iRj4ZGaOSQv63kSgnNP1kTJ1JhGYjoeuotT6Cjg43BoIK3nHEPxhvFxUJjMXmHqLdw8suBuSA/hlRwnIhSvnruxXQQP/FZQ/akRZ/42zVH5G/93t2OsZNF9GtqUU2LRfWms4VaRC4ovudNxY7ZwbTgkCSWLKJLTC/FHNp9C+69fgw=
+
+
 
 # Integration tests
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ help:
 
 
 # RPM
-rpm-build-local:  ## build a local rpm
+rpm-build:  ## build rpm
+	$(PYTHON) rpm/bin/build.py rpm $(VERSION)
+
+rpm-build-local:  ## build local rpm
 	$(PYTHON) rpm/bin/build.py rpm --local $(VERSION)
 
 

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,6 @@ publish-docker: ## push the docker image
 publish-docker-unstable: ## push the unstable docker image
 	$(MAKE) -C $(APP_DIR) publish-docker-unstable
 	$(MAKE) -C $(UI_DIR) deps publish-docker-unstable
+
+publish-rpm: ## publish the rpm
+	rpm/bin/upload.sh $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,14 @@ docker-build-unstable: ## build unstable docker images
 	$(MAKE) -C $(UI_DIR) docker-build-unstable
 
 
+# GitHub
+github-release: ## create a github release
+	http --session=github \
+	  https://api.github.com/repos/beer-garden/beer-garden/releases \
+	  tag_name=$(VERSION) \
+	  name=$(VERSION)
+
+
 # Publishing
 publish-docker: ## push the docker image
 	$(MAKE) -C $(APP_DIR) publish-docker

--- a/rpm/bin/upload.sh
+++ b/rpm/bin/upload.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This requires you to have httpie (https://httpie.io/) installed
+# You'll also need a GitHub Personal Access Token (https://github.com/settings/tokens)
+# with the correct permissions to let you upload release artfacts
+# Finally, you'll need an httpie session named "github" for both api.github.com
+# and uploads.github.com that uses that token (https://httpie.io/docs#named-sessions)
+
+VERSION=$1
+DIST_DIR="$(dirname $0)/../dist"
+
+RAW_UPLOAD_URL=$(http -p b --session=github https://api.github.com/repos/beer-garden/beer-garden/releases/tags/${VERSION} | jq .upload_url)
+# Because Github is SUPER ANNOYING this is horribly mangled:
+# "https://uploads.github.com/repos/beer-garden/beer-garden/releases/34244733/assets{?name,label}"
+# Seriously, that is crazypants
+UNQUOTED=$(echo ${RAW_UPLOAD_URL} | cut -d '"' -f 2)
+UPLOAD_URL=${UNQUOTED%\{*\}}
+
+# OK, upload the thing
+http --session=github "${UPLOAD_URL}" "name==beer-garden-${VERSION}-1.el7.x86_64.rpm" < "${DIST_DIR}/beer-garden-${VERSION}-1.el7.x86_64.rpm"
+


### PR DESCRIPTION
This fixes #752. Tags will now automatically create Github Releases and attach the rpm. It also adds some scripts / make targets to do the same thing manually.