### PR TITLE
Fixes delete of Remote Systems

### DIFF
--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -44,6 +44,10 @@ def update(*args, **kwargs):
     return lpm_proxy.update(*args, **kwargs)
 
 
+def has_instance_id(*args, **kwargs):
+    return lpm_proxy.has_instance_id(*args, **kwargs)
+
+
 @publish_event(Events.RUNNER_STARTED)
 def start(*args, **kwargs):
     return lpm_proxy.restart(*args, **kwargs)

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -266,9 +266,10 @@ def purge_system(
     # Publish stop message to all instances of this system
     publish_stop(system)
 
-    # If local, wait for the runners to stop
+    # If lpm is managing the runner, wait for the runners to stop
     for inst in system.instances:
-        lpm.remove(instance_id=inst.id)
+        if lpm.has_instance_id(inst.id):
+            lpm.remove(instance_id=inst.id)
 
     system = db.reload(system)
 


### PR DESCRIPTION
Had two options to check, one was check the LPM or check the Metadata. Opted to check the LPM just in case another Beer-Garden is managing the Runner and populated the Metadata field.

Fixes: #794 