### PR TITLE
Handle Force Deletes for Child Systems

### DIFF
--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -62,9 +62,6 @@ routable_operations = [
     "GARDENS_SYNC",
 ]
 
-# Processor that will be used for forwarding
-forward_processor: Optional[QueueListener] = None
-
 # Executor used to run REQUEST_CREATE operations in an async context
 t_pool = ThreadPoolExecutor()
 
@@ -280,7 +277,8 @@ def initiate_forward(operation: Operation):
 
         raise
 
-    if response and operation.operation_type == "REQUEST_CREATE":
+    # If None is returned and this is a Request Create, return locally created Request
+    if not response and operation.operation_type == "REQUEST_CREATE":
         return operation.model
 
     return response

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -311,34 +311,30 @@ def forward(operation: Operation):
             f"Unknown child garden {operation.target_garden_name}"
         )
 
-    try:
-        connection_type = target_garden.connection_type
+    connection_type = target_garden.connection_type
 
-        if connection_type is None:
-            _publish_failed_forward(
-                operation=operation,
-                event_name=Events.GARDEN_NOT_CONFIGURED.name,
-                error_message=f"Attempted to forward operation to garden "
-                f"'{operation.target_garden_name}' but the connection type was None. "
-                f"This probably means that the connection to the child garden has not "
-                f"been configured, please talk to your system administrator.",
-            )
+    if connection_type is None:
+        _publish_failed_forward(
+            operation=operation,
+            event_name=Events.GARDEN_NOT_CONFIGURED.name,
+            error_message=f"Attempted to forward operation to garden "
+            f"'{operation.target_garden_name}' but the connection type was None. "
+            f"This probably means that the connection to the child garden has not "
+            f"been configured, please talk to your system administrator.",
+        )
 
-            raise RoutingRequestException(
-                f"Attempted to forward operation to garden "
-                f"'{operation.target_garden_name}' but the connection type was None. "
-                f"This probably means that the connection to the child garden has not "
-                f"been configured, please talk to your system administrator."
-            )
-        elif connection_type.casefold() == "http":
-            return _forward_http(operation, target_garden)
-        elif connection_type.casefold() == "stomp":
-            return _forward_stomp(operation, target_garden)
-        else:
-            raise RoutingRequestException(f"Unknown connection type {connection_type}")
-    except Exception as ex:
-        logger.exception(f"Error forwarding operation:{ex}")
-        raise
+        raise RoutingRequestException(
+            f"Attempted to forward operation to garden "
+            f"'{operation.target_garden_name}' but the connection type was None. "
+            f"This probably means that the connection to the child garden has not "
+            f"been configured, please talk to your system administrator."
+        )
+    elif connection_type.casefold() == "http":
+        return _forward_http(operation, target_garden)
+    elif connection_type.casefold() == "stomp":
+        return _forward_stomp(operation, target_garden)
+    else:
+        raise RoutingRequestException(f"Unknown connection type {connection_type}")
 
 
 def setup_stomp(garden):

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -19,7 +19,7 @@ import logging
 import threading
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import requests
 import stomp
@@ -47,7 +47,6 @@ import beer_garden.systems
 import beer_garden.files
 from beer_garden.errors import RoutingRequestException, UnknownGardenException
 from beer_garden.events import publish
-from beer_garden.events.processors import QueueListener
 from beer_garden.garden import get_garden, get_gardens
 from beer_garden.requests import complete_request
 

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -267,7 +267,7 @@ def purge_system(
 
     if force and not system.local:
         return remove_system(system=system)
-    
+
     for instance in system.instances:
         if instance.status not in ("STOPPED", "DEAD"):
             if lpm.has_instance_id(instance.id):

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -260,9 +260,6 @@ def purge_system(
     """
     system = system or db.query_unique(System, id=system_id)
 
-    if force and not system.local:
-        return remove_system(system=system)
-
     # Publish stop message to all instances of this system
     publish_stop(system)
 


### PR DESCRIPTION
Beer Garden will now wait on the response from Child Gardens. When we migrate to ASyncio this will improve performance. 

If we capture a router error during the forward of a Forced System Delete, then we will process it locally. That way at a minimum the System Admin can delete the record out of their database. 

fixes: #749