### PR TITLE
Allow tagging to existing PyPi releases for deployments

### DIFF
--- a/.github/workflows/tag-actions.yml
+++ b/.github/workflows/tag-actions.yml
@@ -42,6 +42,7 @@ jobs:
           pip install setuptools wheel twine
 
       - name: Build and publish
+        continue-on-error: true
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -83,7 +84,7 @@ jobs:
         run: make publish-docker VERSION=${GITHUB_REF#refs/tags/}
 
   RPM:
-    needs: Docker
+    needs: Verify-PyPi
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python-version }} RPM Builder
     strategy:
@@ -116,8 +117,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
-          tag_name: ${GITHUB_REF#refs/tags/}
-          release_name: Release ${GITHUB_REF#refs/tags/}
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
 


### PR DESCRIPTION
If PyPI is already deployed, this allows the actions to run off that existing release. Allowing for debugging of downstream actions.