### PR TITLE
Added Proxy Authentication

### DIFF
--- a/src/app/beer_garden/api/http/authorization.py
+++ b/src/app/beer_garden/api/http/authorization.py
@@ -262,8 +262,8 @@ def proxy_auth(request):
                             description="Generated from Headers",
                             permissions=[
                                 Permission(
-                                    garden=split_role[0],
-                                    namespace=split_role[1],
+                                    garden=split_role[0] if split_role[0] != "" else None,
+                                    namespace=split_role[1] if split_role[1] != "" else None,
                                     access=split_role[2].upper(),
                                 )
                             ],

--- a/src/app/beer_garden/api/http/authorization.py
+++ b/src/app/beer_garden/api/http/authorization.py
@@ -262,8 +262,12 @@ def proxy_auth(request):
                             description="Generated from Headers",
                             permissions=[
                                 Permission(
-                                    garden=split_role[0] if split_role[0] != "" else None,
-                                    namespace=split_role[1] if split_role[1] != "" else None,
+                                    garden=split_role[0]
+                                    if split_role[0] != ""
+                                    else None,
+                                    namespace=split_role[1]
+                                    if split_role[1] != ""
+                                    else None,
                                     access=split_role[2].upper(),
                                 )
                             ],

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -660,6 +660,12 @@ _AUTH_SPEC = {
                     "description": "Header filed to find list of Roles",
                     "default": None,
                 },
+                "roles_delimiter": {
+                    "type": "str",
+                    "required": False,
+                    "description": "Delimiter to use for generate Role based off headers",
+                    "default": "_",
+                },
             },
         },
     },

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -627,6 +627,41 @@ _AUTH_SPEC = {
                 },
             },
         },
+        "proxy": {
+            "type": "dict",
+            "items": {
+                "enabled": {
+                    "type": "bool",
+                    "default": False,
+                    "description": "Only applicable if auth is enabled. If set to "
+                    "true, guests can login through proxy service",
+                },
+                "secret": {
+                    "type": "str",
+                    "required": False,
+                    "description": "Secret to use proxy sends headers",
+                    "default": None,
+                },
+                "secret_header": {
+                    "type": "str",
+                    "required": False,
+                    "description": "Header field to find shared secret",
+                    "default": None,
+                },
+                "username_header": {
+                    "type": "str",
+                    "required": False,
+                    "description": "Header field to find User Name",
+                    "default": None,
+                },
+                "roles_header": {
+                    "type": "str",
+                    "required": False,
+                    "description": "Header filed to find list of Roles",
+                    "default": None,
+                },
+            },
+        },
     },
 }
 

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -5,6 +5,12 @@ auth:
     algorithm: HS256
     lifetime: 1200
     secret: IAMSUPERSECRET
+  proxy:
+    enabled: false
+    secret: IAMSUPERSECRET
+    secret_header: X-Secret
+    username_header: X-Username
+    roles_header: X-Roles
 db:
   connection:
     host: localhost

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -11,6 +11,7 @@ auth:
     secret_header: X-Secret
     username_header: X-Username
     roles_header: X-Roles
+    roles_delimiter: _
 db:
   connection:
     host: localhost

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -120,18 +120,24 @@ export default function appRun(
     if (token) {
       TokenService.handleToken(token);
     }
+    else {
+        // Attempt login through OAuth/Proxy Service
+        TokenService.doLogin(null, null);
+        let token = localStorageService.get('token');
+        $state.reload();
+    }
 
     // Connect to the event socket
     EventService.connect(token);
 
-    // $rootScope.loadUser(token).catch(
-    //   // This prevents the situation where the user needs to logout but the
-    //   // logout button isn't displayed because there's no user loaded
-    //   // (happens if the server secret changes)
-    //   (response) => {
-    //     $rootScope.doLogout();
-    //   }
-    // );
+    $rootScope.loadUser(token).catch(
+       // This prevents the situation where the user needs to logout but the
+       // logout button isn't displayed because there's no user loaded
+       // (happens if the server secret changes)
+       (response) => {
+         $rootScope.doLogout();
+       }
+    );
   };
 
   $rootScope.hasPermission = function(user, permissions) {

--- a/src/ui/webpack.dev.js
+++ b/src/ui/webpack.dev.js
@@ -29,9 +29,9 @@ module.exports = merge(common, {
 
     // Uncomment below for SSL
 //    https: true,
-//    key: fs.readFileSync('../../docker/docker-compose/data/certs/server_key.pem'),
-//    cert: fs.readFileSync('../../docker/docker-compose/data/certs/server_certificate.pem'),
-//    ca: fs.readFileSync('../../docker/docker-compose/data/certs/ca_certificate.pem'),
+//    key: fs.readFileSync('/home/gnburch/PycharmProjects/nginx-casport/localhost-key.pem'),
+//    cert: fs.readFileSync('/home/gnburch/PycharmProjects/nginx-casport/localhost-crt.pem'),
+//    ca: fs.readFileSync('/home/gnburch/PycharmProjects/nginx-casport/AllTrustedPartners.ca-bundle'),
 
     proxy: [
 // Switch comment lines for target to enable SSL
@@ -42,6 +42,11 @@ module.exports = merge(common, {
         //Secure is set to false if using self signed certs
 //        target: `https://${proxyHost}:${proxyPort}/`,
 //        secure: false
+        // Uncomment for simulated proxy headers
+//        headers: {
+//            'X-Username': 'admin',
+//            'X-Secret': 'IAMSUPERSECRET'
+//        },
       },
       {
         context: ['/api/v1/socket/events'],
@@ -51,6 +56,12 @@ module.exports = merge(common, {
         //Secure is set to false if using self signed certs
 //        target: `wss://${proxyHost}:${proxyPort}/`,
 //        secure: false
+
+        // Uncomment for simulated proxy headers
+//        headers: {
+//            'X-Username': 'admin',
+//            'X-Secret': 'IAMSUPERSECRET'
+//        },
       },
     ],
   },


### PR DESCRIPTION
If an person wants to place an OAuth service in front of Beer Garden, we have to be able to accept/trust the headers they are forwarding. Following NGINX example (https://www.nginx.com/blog/validating-oauth-2-0-access-tokens-nginx/), we can now use a header field for the user to log in.

Extra stuff outside of NGINX example:
- We can accept both Username and Roles
- If the user doesn't exist, then we generate a "proxied" user that has no database backing
- If roles as passed forward and the user doesn't have those roles, they are automatically applied
- To ensure only the proxy can forward results, a secret can be added to both deployments in the headers

If you want to run this without a proxy setup, you need to set those headers in Webpack. There is an example in there on how to set that up. You also need to uncomment out the login stuff on the index.html.

This will require https://github.com/beer-garden/beer-garden/pull/790 be merged in because it has some changes required for authentication.