### PR TITLE
changed STOMP default to false

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -44,7 +44,7 @@ services:
             BG_MQ_CONNECTIONS_MESSAGE_PASSWORD: password
 
             # Enable stomp and point at the correct broker
-            BG_ENTRY_STOMP_ENABLED: "true"
+            BG_ENTRY_STOMP_ENABLED: "false"
             BG_ENTRY_STOMP_HOST: activemq
 
             # We expose grafana for you, but you can change this to an


### PR DESCRIPTION
Set default value for `BG_ENTRY_STOMP_ENABLED` in docker to be false, so STOMP connection is not enabled by default.