### PR TITLE
Adding % to garden url regex so encoded unicode will match

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -207,7 +207,7 @@ def _setup_tornado_app() -> Application:
         (rf"{prefix}api/v1/tokens/(\w+)/?", v1.token.TokenAPI),
         (rf"{prefix}api/v1/jobs/(\w+)/?", v1.job.JobAPI),
         (rf"{prefix}api/v1/logging/?", v1.logging.LoggingAPI),
-        (rf"{prefix}api/v1/gardens/(\w+)/?", v1.garden.GardenAPI),
+        (rf"{prefix}api/v1/gardens/([\w%]+)/?", v1.garden.GardenAPI),
         (rf"{prefix}api/v1/files/?", v1.file.FileAPI),
         (rf"{prefix}api/v1/files/id/?", v1.file.FileNameAPI),
         # Beta


### PR DESCRIPTION
Fixes #875, add support for unicode garden names

@TheBurchLog you may want to do the same thing for the Users api?