### PR TITLE
Updated Client function to find serialization malforms

### DIFF
--- a/src/app/beer_garden/api/http/client.py
+++ b/src/app/beer_garden/api/http/client.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class SerializeHelper(object):
-    async def __call__(self, operation: Operation, serialize_kwargs=None, **kwargs):
-        result = beer_garden.router.route(operation, **kwargs)
+    async def __call__(self, operation: Operation, serialize_kwargs=None):
+        result = beer_garden.router.route(operation)
 
         # Await any coroutines
         if isawaitable(result):

--- a/src/app/beer_garden/api/http/client.py
+++ b/src/app/beer_garden/api/http/client.py
@@ -1,18 +1,21 @@
 # -*- coding: utf-8 -*-
 import json
+import logging
 from inspect import isawaitable
 
 import six
-from brewtils.models import BaseModel
+from brewtils.models import BaseModel, Operation
 from brewtils.schema_parser import SchemaParser
 
 import beer_garden.api
 import beer_garden.router
 
+logger = logging.getLogger(__name__)
+
 
 class SerializeHelper(object):
-    async def __call__(self, *args, serialize_kwargs=None, **kwargs):
-        result = beer_garden.router.route(*args, **kwargs)
+    async def __call__(self, operation: Operation, serialize_kwargs=None, **kwargs):
+        result = beer_garden.router.route(operation, **kwargs)
 
         # Await any coroutines
         if isawaitable(result):

--- a/src/app/beer_garden/api/http/handlers/v1/system.py
+++ b/src/app/beer_garden/api/http/handlers/v1/system.py
@@ -310,14 +310,14 @@ class SystemListAPI(BaseHandler):
             Operation(
                 operation_type="SYSTEM_READ_ALL",
                 kwargs={
-                    "serialize_kwargs": serialize_kwargs,
                     "filter_params": filter_params,
                     "order_by": order_by,
                     "include_fields": include_fields,
                     "exclude_fields": exclude_fields,
                     "dereference_nested": dereference_nested,
                 },
-            )
+            ),
+            serialize_kwargs=serialize_kwargs,
         )
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")


### PR DESCRIPTION
Updated the Client function for the HTTP API. Now it expected a single argument for input and if the serialization is passed through the Operation Kwargs it is utilized, but first it throws an something into the Logger for us to go back and address that malform request.

fixes: #888 