### PR TITLE
Remove Local Garden Connection Type

### DIFF
--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -81,7 +81,7 @@ export default function gardenService($http) {
     return model;
   }
 
-  GardenService.CONNECTION_TYPES = ['HTTP','STOMP','LOCAL'];
+  GardenService.CONNECTION_TYPES = ['HTTP','STOMP'];
 
 //  GardenService.stomp_header_array_to_dict = function(key, value){
 //    GardenService.


### PR DESCRIPTION
Removed the drop down for Local Connection Type on the Garden Edit page. This will prevent Admin's from accidentally bricking their Garden editor.

Fixes: #906 