### PR TITLE
Fixed Bad Config Preventing Startup

### DIFF
--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -156,8 +156,8 @@ class Connection:
                             logger.info("Stomp successfully " + connected_message)
 
                     except Exception as e:
-                        logger.warning(str(e))
                         logger.warning(
+                            f"Error connecting: {type(e).__name__}. "
                             f"Affected gardens are {[garden.get('name') for garden in gardens]}"
                         )
                         logger.warning(

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -107,7 +107,7 @@ class Connection:
         username=None,
         password=None,
     ):
-        self.host_and_port = host_and_ports
+        self.host_and_ports = host_and_ports
         self.username = username
         self.password = password
         self.subscribe_destination = subscribe_destination
@@ -129,8 +129,8 @@ class Connection:
     def connect(self, connected_message=None, gardens=None):
         wait_time = 0.1
         if (
-            self.host_and_port[0][0]
-            and self.host_and_port[0][1]
+            self.host_and_ports[0][0]
+            and self.host_and_ports[0][1]
             and self.subscribe_destination
         ):
             while not self.conn.is_connected() and self.bg_active:

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -128,7 +128,11 @@ class Connection:
 
     def connect(self, connected_message=None, gardens=None):
         wait_time = 0.1
-        if self.host_and_port[0][0] and self.host_and_port[0][1] and self.subscribe_destination:
+        if (
+            self.host_and_port[0][0]
+            and self.host_and_port[0][1]
+            and self.subscribe_destination
+        ):
             while not self.conn.is_connected() and self.bg_active:
                 try:
                     self.conn.connect(
@@ -155,7 +159,9 @@ class Connection:
                     logger.warning(
                         f"Affected gardens are {[garden.get('name') for garden in gardens]}"
                     )
-                    logger.warning("Waiting %.1f seconds before next attempt", wait_time)
+                    logger.warning(
+                        "Waiting %.1f seconds before next attempt", wait_time
+                    )
                     time.sleep(wait_time)
                     wait_time = min(wait_time * 2, 30)
 

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -125,7 +125,7 @@ class Connection:
         if subscribe_destination:
             self.conn.set_listener("", OperationListener(self.conn, send_destination))
 
-    def connect(self, connected_message=None):
+    def connect(self, connected_message=None, gardens=None):
         wait_time = 0.1
         while not self.conn.is_connected() and self.bg_active:
             try:
@@ -150,6 +150,7 @@ class Connection:
 
             except Exception as e:
                 logger.warning(str(e))
+                logger.warning(f"Affected gardens are {[garden.get('name') for garden in gardens]}")
                 logger.warning("Waiting %.1f seconds before next attempt", wait_time)
                 time.sleep(wait_time)
                 wait_time = min(wait_time * 2, 30)

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -107,6 +107,7 @@ class Connection:
         username=None,
         password=None,
     ):
+        self.host_and_port = host_and_ports
         self.username = username
         self.password = password
         self.subscribe_destination = subscribe_destination
@@ -127,35 +128,36 @@ class Connection:
 
     def connect(self, connected_message=None, gardens=None):
         wait_time = 0.1
-        while not self.conn.is_connected() and self.bg_active:
-            try:
-                self.conn.connect(
-                    username=self.username,
-                    passcode=self.password,
-                    wait=True,
-                    headers={"client-id": self.username},
-                )
-                if self.subscribe_destination:
-                    self.conn.subscribe(
-                        destination=self.subscribe_destination,
-                        id=self.username,
-                        ack="auto",
-                        headers={
-                            "subscription-type": "MULTICAST",
-                            "durable-subscription-name": self.subscribe_destination,
-                        },
+        if self.host_and_port[0][0] and self.host_and_port[0][1] and self.subscribe_destination:
+            while not self.conn.is_connected() and self.bg_active:
+                try:
+                    self.conn.connect(
+                        username=self.username,
+                        passcode=self.password,
+                        wait=True,
+                        headers={"client-id": self.username},
                     )
-                if connected_message is not None and self.conn.is_connected():
-                    logger.info("Stomp successfully " + connected_message)
+                    if self.subscribe_destination:
+                        self.conn.subscribe(
+                            destination=self.subscribe_destination,
+                            id=self.username,
+                            ack="auto",
+                            headers={
+                                "subscription-type": "MULTICAST",
+                                "durable-subscription-name": self.subscribe_destination,
+                            },
+                        )
+                    if connected_message is not None and self.conn.is_connected():
+                        logger.info("Stomp successfully " + connected_message)
 
-            except Exception as e:
-                logger.warning(str(e))
-                logger.warning(
-                    f"Affected gardens are {[garden.get('name') for garden in gardens]}"
-                )
-                logger.warning("Waiting %.1f seconds before next attempt", wait_time)
-                time.sleep(wait_time)
-                wait_time = min(wait_time * 2, 30)
+                except Exception as e:
+                    logger.warning(str(e))
+                    logger.warning(
+                        f"Affected gardens are {[garden.get('name') for garden in gardens]}"
+                    )
+                    logger.warning("Waiting %.1f seconds before next attempt", wait_time)
+                    time.sleep(wait_time)
+                    wait_time = min(wait_time * 2, 30)
 
     def disconnect(self):
         self.bg_active = False

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -156,7 +156,7 @@ class Connection:
                             logger.info("Stomp successfully " + connected_message)
 
                     except Exception as e:
-                        logger.warning(
+                        logger.debug(
                             f"Error connecting: {type(e).__name__}. "
                             f"Affected gardens are {[garden.get('name') for garden in gardens]}"
                         )

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -128,42 +128,43 @@ class Connection:
 
     def connect(self, connected_message=None, gardens=None):
         wait_time = 0.1
-        if (
-            self.host_and_ports[0][0]
-            and self.host_and_ports[0][1]
-            and self.subscribe_destination
-        ):
-            while not self.conn.is_connected() and self.bg_active:
-                try:
-                    self.conn.connect(
-                        username=self.username,
-                        passcode=self.password,
-                        wait=True,
-                        headers={"client-id": self.username},
-                    )
-                    if self.subscribe_destination:
-                        self.conn.subscribe(
-                            destination=self.subscribe_destination,
-                            id=self.username,
-                            ack="auto",
-                            headers={
-                                "subscription-type": "MULTICAST",
-                                "durable-subscription-name": self.subscribe_destination,
-                            },
+        if self.host_and_ports:
+            if (
+                self.host_and_ports[0][0]
+                and self.host_and_ports[0][1]
+                and self.subscribe_destination
+            ):
+                while not self.conn.is_connected() and self.bg_active:
+                    try:
+                        self.conn.connect(
+                            username=self.username,
+                            passcode=self.password,
+                            wait=True,
+                            headers={"client-id": self.username},
                         )
-                    if connected_message is not None and self.conn.is_connected():
-                        logger.info("Stomp successfully " + connected_message)
+                        if self.subscribe_destination:
+                            self.conn.subscribe(
+                                destination=self.subscribe_destination,
+                                id=self.username,
+                                ack="auto",
+                                headers={
+                                    "subscription-type": "MULTICAST",
+                                    "durable-subscription-name": self.subscribe_destination,
+                                },
+                            )
+                        if connected_message is not None and self.conn.is_connected():
+                            logger.info("Stomp successfully " + connected_message)
 
-                except Exception as e:
-                    logger.warning(str(e))
-                    logger.warning(
-                        f"Affected gardens are {[garden.get('name') for garden in gardens]}"
-                    )
-                    logger.warning(
-                        "Waiting %.1f seconds before next attempt", wait_time
-                    )
-                    time.sleep(wait_time)
-                    wait_time = min(wait_time * 2, 30)
+                    except Exception as e:
+                        logger.warning(str(e))
+                        logger.warning(
+                            f"Affected gardens are {[garden.get('name') for garden in gardens]}"
+                        )
+                        logger.warning(
+                            "Waiting %.1f seconds before next attempt", wait_time
+                        )
+                        time.sleep(wait_time)
+                        wait_time = min(wait_time * 2, 30)
 
     def disconnect(self):
         self.bg_active = False

--- a/src/app/beer_garden/api/stomp/server.py
+++ b/src/app/beer_garden/api/stomp/server.py
@@ -150,7 +150,9 @@ class Connection:
 
             except Exception as e:
                 logger.warning(str(e))
-                logger.warning(f"Affected gardens are {[garden.get('name') for garden in gardens]}")
+                logger.warning(
+                    f"Affected gardens are {[garden.get('name') for garden in gardens]}"
+                )
                 logger.warning("Waiting %.1f seconds before next attempt", wait_time)
                 time.sleep(wait_time)
                 wait_time = min(wait_time * 2, 30)

--- a/src/app/beer_garden/api/stomp/stomp_manager.py
+++ b/src/app/beer_garden/api/stomp/stomp_manager.py
@@ -37,7 +37,9 @@ class StompManager(StoppableThread):
                 headers = [self.convert_header_to_dict(stomp_config.get("headers"))]
             self.conn_dict = {
                 f"{host_and_ports}{subscribe_destination}{ssl.get('use_ssl')}": {
-                    "conn": self.connect(stomp_config, [{"name": name, "main": is_main}]),
+                    "conn": self.connect(
+                        stomp_config, [{"name": name, "main": is_main}]
+                    ),
                     "gardens": [{"name": name, "main": is_main}],
                     "headers_list": headers,
                 }

--- a/src/app/beer_garden/api/stomp/stomp_manager.py
+++ b/src/app/beer_garden/api/stomp/stomp_manager.py
@@ -13,7 +13,7 @@ class StompManager(StoppableThread):
     logger = logging.getLogger(__name__)
 
     @staticmethod
-    def connect(stomp_config):
+    def connect(stomp_config, gardens):
         conn = Connection(
             host_and_ports=[(stomp_config.get("host"), stomp_config.get("port"))],
             send_destination=stomp_config.get("send_destination"),
@@ -22,7 +22,7 @@ class StompManager(StoppableThread):
             username=stomp_config.get("username"),
             password=stomp_config.get("password"),
         )
-        conn.connect("connected")
+        conn.connect(connected_message="connected", gardens=gardens)
         return conn
 
     def __init__(self, ep_conn=None, stomp_config=None, name=None, is_main=True):
@@ -37,7 +37,7 @@ class StompManager(StoppableThread):
                 headers = [self.convert_header_to_dict(stomp_config.get("headers"))]
             self.conn_dict = {
                 f"{host_and_ports}{subscribe_destination}{ssl.get('use_ssl')}": {
-                    "conn": self.connect(stomp_config),
+                    "conn": self.connect(stomp_config, [{"name": name, "main": is_main}]),
                     "gardens": [{"name": name, "main": is_main}],
                     "headers_list": headers,
                 }
@@ -72,10 +72,10 @@ class StompManager(StoppableThread):
             ),
         )
 
-    def reconnect(self, conn):
+    def reconnect(self, conn, gardens):
         if not conn.is_connected():
             self.logger.warning("Lost stomp connection")
-            conn.connect("reconnected")
+            conn.connect(connected_message="reconnected", gardens=gardens)
 
     def remove_garden_from_list(self, garden_name=None, skip_key=None):
         """removes garden name from dict list of gardens for stomp subscriptions"""
@@ -109,8 +109,9 @@ class StompManager(StoppableThread):
                 )
         for value in self.conn_dict.values():
             conn = value["conn"]
+            gardens = value["gardens"]
             if conn:
-                self.reconnect(conn)
+                self.reconnect(conn, gardens)
                 if value["headers_list"]:
                     for headers in value["headers_list"]:
                         conn.send_event(event=event, headers=headers)
@@ -147,7 +148,7 @@ class StompManager(StoppableThread):
                 )
         else:
             self.conn_dict[conn_dict_key] = {
-                "conn": self.connect(stomp_config),
+                "conn": self.connect(stomp_config, [{"name": name, "main": is_main}]),
                 "gardens": [{"name": name, "main": is_main}],
             }
         if "headers_list" not in self.conn_dict:

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -336,7 +336,7 @@ def forward(operation: Operation):
 
 def setup_stomp(garden):
     host_and_ports = [
-        (garden.connection_params["stomp_host"], garden.connection_params["stomp_port"])
+        (garden.connection_params.get("stomp_host"), garden.connection_params.get("stomp_port"))
     ]
     conn = stomp.Connection(host_and_ports=host_and_ports)
     if garden.connection_params.get("stomp_ssl"):

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -336,7 +336,10 @@ def forward(operation: Operation):
 
 def setup_stomp(garden):
     host_and_ports = [
-        (garden.connection_params.get("stomp_host"), garden.connection_params.get("stomp_port"))
+        (
+            garden.connection_params.get("stomp_host"),
+            garden.connection_params.get("stomp_port"),
+        )
     ]
     conn = stomp.Connection(host_and_ports=host_and_ports)
     if garden.connection_params.get("stomp_ssl"):

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -90,6 +90,7 @@ import gardenService from './js/services/garden_service.js';
 import runnerService from './js/services//runner_service.js';
 
 import aboutController from './js/controllers/about.js';
+import updateRequestExpirationController from './js/controllers/update_request_expiration.js';
 import adminQueueController from './js/controllers/admin_queue.js';
 import adminSystemController from './js/controllers/admin_system.js';
 import adminSystemLogsController from './js/controllers/admin_system_logs.js';
@@ -204,4 +205,5 @@ angular.module('bgApp',
 .controller('JobCreateCommandController', jobCreateCommandController)
 .controller('JobCreateRequestController', jobCreateRequestController)
 .controller('JobCreateTriggerController', jobCreateTriggerController)
-.controller('LoginController', loginController);
+.controller('LoginController', loginController)
+.controller('UpdateRequestExpirationController', updateRequestExpirationController)


### PR DESCRIPTION
Fixed error that cause Beer Garden not to start when garden is configured to use stomp but is the field in config are empty. Also added logger warning message for connection failures to include a list of gardens affected so if the problem is with the connection config you can find which gardens to check in the logs.

Fixes #907 