### PR TITLE
Catching exception caused from multiple Request Event Processors

### DIFF
--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -17,7 +17,7 @@ import pika.spec
 import six
 import urllib3
 
-
+from beer_garden.errors import NotUniqueException
 from brewtils.choices import parse
 from brewtils.errors import ConflictError, ModelValidationError, RequestPublishException
 from brewtils.models import Choices, Events, Request, RequestTemplate, System, Operation
@@ -794,8 +794,11 @@ def handle_event(event):
     elif event.garden != config.get("garden.name"):
 
         if event.name == Events.REQUEST_CREATED.name:
-            if db.query_unique(Request, id=event.payload.id) is None:
+            # Attempt to create the request, if it already exists then continue on
+            try:
                 db.create(event.payload)
+            except NotUniqueException:
+                pass
 
         elif event.name in (Events.REQUEST_STARTED.name, Events.REQUEST_COMPLETED.name):
             # When we send child requests to child gardens where the parent was on


### PR DESCRIPTION
The main processor and every Entry Point spins up a Request Listener for Events. This causes duplicate events to be sent across Beer Garden, as intended so any entry point can get an event that they are waiting on. This is also causing a race condition when a Child Garden creates a Request because now two processors are attempting to duplicate that in the Parent database. For now, we will just catch this exception until we have a better approach for handling events.

fixes: #902 

Just realized this was the same solution I came up with in PR #746 