### PR TITLE
Fixing HTTP Linting Error

### DIFF
--- a/src/app/beer_garden/__init__.py
+++ b/src/app/beer_garden/__init__.py
@@ -6,5 +6,6 @@ __all__ = ["__version__", "application"]
 # COMPONENTS #
 application = None
 
+
 def signal_handler(_signal_number, _stack_frame):
     application.stop()

--- a/src/app/beer_garden/__init__.py
+++ b/src/app/beer_garden/__init__.py
@@ -6,6 +6,5 @@ __all__ = ["__version__", "application"]
 # COMPONENTS #
 application = None
 
-
 def signal_handler(_signal_number, _stack_frame):
     application.stop()

--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -50,10 +50,10 @@ from beer_garden.api.http.processors import EventManager, websocket_publish
 from beer_garden.events import publish
 from beer_garden.events.processors import QueueListener
 
-io_loop: IOLoop
+io_loop: IOLoop = None
 server: HTTPServer
 tornado_app: Application
-logger: logging.Logger
+logger: logging.Logger = None
 event_publishers = None
 api_spec: APISpec
 anonymous_principal: Principal


### PR DESCRIPTION
This is just a test for the API code that was failing the lint checker. It was failing because the values were not declared.... So I declared them as None and it works. Not sure why it doesn't also hit `server`, `tornado_app`, or any of the other ones.