### PR TITLE
Reducing to testing only with Echo for Garden setup

### DIFF
--- a/.github/workflows/integration-actions.yml
+++ b/.github/workflows/integration-actions.yml
@@ -179,10 +179,10 @@ jobs:
           with:
             repository: beer-garden/example-plugins
             path: ./tmp
-
-        - name: Move Subset of Test Plugins
-          run: |
-            cp -r ./tmp/echo ./docker/docker-compose/data/localplugins
+#
+#        - name: Move Subset of Test Plugins
+#          run: |
+#            cp -r ./tmp/echo ./docker/docker-compose/data/localplugins
 
         - name: Verify Local Plugins
           run: ls ./docker/docker-compose/data/localplugins

--- a/.github/workflows/integration-actions.yml
+++ b/.github/workflows/integration-actions.yml
@@ -1,11 +1,11 @@
 name: Integration-Actions
 
-#on: pull_request # Used only for testing
+on: pull_request # Used only for testing
 
 # This will only run on the Default/Base Branch OR when a Tag is created
-on:
-  schedule:
-    - cron: '0 0 * * *' # Every Day at Midnight
+#on:
+#  schedule:
+#    - cron: '0 0 * * *' # Every Day at Midnight
 
 jobs:
   Remote-Plugin-Testing:
@@ -181,11 +181,6 @@ jobs:
         - name: Move Subset of Test Plugins
           run: |
             cp -r ./tmp/echo ./docker/docker-compose/data/localplugins
-            cp -r ./tmp/complex ./docker/docker-compose/data/localplugins
-            cp -r ./tmp/dynamic ./docker/docker-compose/data/localplugins
-            cp -r ./tmp/sleeper ./docker/docker-compose/data/localplugins
-            cp -r ./tmp/echo-sleeper ./docker/docker-compose/data/localplugins
-            cp -r ./tmp/error ./docker/docker-compose/data/localplugins
 
         - name: Verify Local Plugins
           run: ls ./docker/docker-compose/data/localplugins

--- a/.github/workflows/integration-actions.yml
+++ b/.github/workflows/integration-actions.yml
@@ -10,6 +10,7 @@ on: pull_request # Used only for testing
 jobs:
   Remote-Plugin-Testing:
     runs-on: ${{ matrix.os }}
+    if: "false"
 
     strategy:
       matrix:
@@ -74,6 +75,7 @@ jobs:
 
   Local-Plugin-Testing:
     runs-on: ${{ matrix.os }}
+    if: "false"
 
     strategy:
       matrix:
@@ -213,6 +215,15 @@ jobs:
         - name: Test Gardens
           run: python${{ matrix.python-version }} -m pytest gardens/
           working-directory: ./test/integration
+          continue-on-error: true
+
+        - name: Grab logs from Child Beer-Garden
+          run: RELEASE=${{matrix.child-garden}} docker-compose logs --tail 100 beer-garden-child
+          working-directory: ./docker/docker-compose
+
+        - name: Grab logs from Beer-Garden
+          run: docker-compose logs --tail 100 beer-garden
+          working-directory: ./docker/docker-compose
 
         - name: Shutdown Docker Containers
           run: docker-compose stop

--- a/.github/workflows/integration-actions.yml
+++ b/.github/workflows/integration-actions.yml
@@ -179,10 +179,10 @@ jobs:
           with:
             repository: beer-garden/example-plugins
             path: ./tmp
-#
-#        - name: Move Subset of Test Plugins
-#          run: |
-#            cp -r ./tmp/echo ./docker/docker-compose/data/localplugins
+
+        - name: Move Subset of Test Plugins
+          run: |
+            cp -r ./tmp/echo ./docker/docker-compose/data/localplugins
 
         - name: Verify Local Plugins
           run: ls ./docker/docker-compose/data/localplugins

--- a/.github/workflows/integration-actions.yml
+++ b/.github/workflows/integration-actions.yml
@@ -1,16 +1,16 @@
 name: Integration-Actions
 
-on: pull_request # Used only for testing
+#on: pull_request # Used only for testing
 
 # This will only run on the Default/Base Branch OR when a Tag is created
-#on:
-#  schedule:
-#    - cron: '0 0 * * *' # Every Day at Midnight
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every Day at Midnight
 
 jobs:
   Remote-Plugin-Testing:
     runs-on: ${{ matrix.os }}
-    if: "false"
+#    if: "false"
 
     strategy:
       matrix:
@@ -75,7 +75,7 @@ jobs:
 
   Local-Plugin-Testing:
     runs-on: ${{ matrix.os }}
-    if: "false"
+#    if: "false"
 
     strategy:
       matrix:
@@ -142,6 +142,7 @@ jobs:
 
   Garden-Testing:
     runs-on: ${{ matrix.os }}
+#    if: "false"
 
     strategy:
       matrix:

--- a/.github/workflows/integration-actions.yml
+++ b/.github/workflows/integration-actions.yml
@@ -215,15 +215,6 @@ jobs:
         - name: Test Gardens
           run: python${{ matrix.python-version }} -m pytest gardens/
           working-directory: ./test/integration
-          continue-on-error: true
-
-        - name: Grab logs from Child Beer-Garden
-          run: RELEASE=${{matrix.child-garden}} docker-compose logs --tail 100 beer-garden-child
-          working-directory: ./docker/docker-compose
-
-        - name: Grab logs from Beer-Garden
-          run: docker-compose logs --tail 100 beer-garden
-          working-directory: ./docker/docker-compose
 
         - name: Shutdown Docker Containers
           run: docker-compose stop

--- a/test/integration/gardens/setup/garden_setup_test.py
+++ b/test/integration/gardens/setup/garden_setup_test.py
@@ -1,39 +1,21 @@
 import pytest
 from brewtils.models import PatchOperation
-import time
 
 try:
     from helper.assertion import assert_successful_request
-    from helper import wait_for_response, delete_plugins
-    from helper.plugin import create_plugin, start_plugin, stop_plugin, TestPluginV1
+    from helper import wait_for_response
 except:
     from ...helper.assertion import assert_successful_request
-    from ...helper import wait_for_response, delete_plugins
-    from ...helper.plugin import (create_plugin, start_plugin, stop_plugin,
-                                  TestPluginV1)
+    from ...helper import wait_for_response
 
 
 @pytest.fixture(scope="class")
 def system_spec():
-    return {'namespace': 'childdocker', 'system': 'test', 'system_version': '3.0.0.dev0', 'instance_name': 'default',
-            'command': 'add'}
+    return {'namespace': 'childdocker', 'system': 'echo', 'system_version': '3.0.0.dev0', 'instance_name': 'default',
+            'command': 'say'}
 
 
-@pytest.fixture(scope="class")
-@pytest.mark.usefixtures('child_easy_client')
-def manage_plugin(child_easy_client):
-    """Ensure there are no "test" plugins before or after the test"""
-
-    plugin = create_plugin("test", "3.0.0.dev0", TestPluginV1)
-    start_plugin(plugin, child_easy_client)
-    # Give child a couple seconds to publish events
-    time.sleep(15)
-    yield
-    stop_plugin(plugin)
-    delete_plugins(child_easy_client, "test")
-
-
-@pytest.mark.usefixtures('easy_client', 'parser', 'child_easy_client', 'request_generator', 'manage_plugin')
+@pytest.mark.usefixtures('easy_client', 'parser', 'child_easy_client', 'request_generator')
 class TestGardenSetup(object):
     child_garden_name = "childdocker"
 
@@ -104,14 +86,14 @@ class TestGardenSetup(object):
         assert self.child_garden_name in namespaces.keys() and namespaces[self.child_garden_name] > 0
 
     def test_child_request_from_parent(self):
-        request = self.request_generator.generate_request(parameters={"a": 1, "b": 2})
+        request = self.request_generator.generate_request(parameters={"message": "test_string", "loud": True})
         response = wait_for_response(self.easy_client, request)
-        assert_successful_request(response, output="3")
+        assert_successful_request(response, output="test_string!!!!!!!!!")
 
     def test_child_request_from_child(self):
-        request = self.request_generator.generate_request(parameters={"a": 1, "b": 2})
+        request = self.request_generator.generate_request(parameters={"message": "test_string", "loud": True})
         response = wait_for_response(self.child_easy_client, request)
-        assert_successful_request(response, output="3")
+        assert_successful_request(response, output="test_string!!!!!!!!!")
 
     def test_verify_requests(self):
         requests = self.easy_client.find_requests()


### PR DESCRIPTION
Fixing the errors in the overnight actions for Garden to Garden testing. The new `client` decorator is not on the Echo Plugin, so we will use that one.