### PR TITLE
Namespace not required for Jobs

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -275,7 +275,6 @@ class Request(MongoModel, Document):
         "system": {"field": StringField, "kwargs": {"required": True}},
         "system_version": {"field": StringField, "kwargs": {"required": True}},
         "instance_name": {"field": StringField, "kwargs": {"required": True}},
-        "namespace": {"field": StringField, "kwargs": {"required": True}},
         "command": {"field": StringField, "kwargs": {"required": True}},
         "command_type": {"field": StringField, "kwargs": {}},
         "parameters": {"field": DictField, "kwargs": {}},
@@ -283,6 +282,9 @@ class Request(MongoModel, Document):
         "metadata": {"field": DictField, "kwargs": {}},
         "output_type": {"field": StringField, "kwargs": {}},
     }
+
+    # Shared field with RequestTemplate, but it is required when saving Request
+    namespace = StringField(required=True)
 
     for field_name, field_info in TEMPLATE_FIELDS.items():
         locals()[field_name] = field_info["field"](**field_info["kwargs"])
@@ -588,6 +590,9 @@ class RequestTemplate(MongoModel, EmbeddedDocument):
 
     for field_name, field_info in Request.TEMPLATE_FIELDS.items():
         locals()[field_name] = field_info["field"](**field_info["kwargs"])
+
+    # Shared field with Request, but it is not required when saving RequestTemplate
+    namespace = StringField(required=False)
 
 
 class DateTrigger(MongoModel, EmbeddedDocument):

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -275,6 +275,7 @@ class Request(MongoModel, Document):
         "system": {"field": StringField, "kwargs": {"required": True}},
         "system_version": {"field": StringField, "kwargs": {"required": True}},
         "instance_name": {"field": StringField, "kwargs": {"required": True}},
+        "namespace": {"field": StringField, "kwargs": {"required": False}},
         "command": {"field": StringField, "kwargs": {"required": True}},
         "command_type": {"field": StringField, "kwargs": {}},
         "parameters": {"field": DictField, "kwargs": {}},
@@ -283,11 +284,11 @@ class Request(MongoModel, Document):
         "output_type": {"field": StringField, "kwargs": {}},
     }
 
-    # Shared field with RequestTemplate, but it is required when saving Request
-    namespace = StringField(required=True)
-
     for field_name, field_info in TEMPLATE_FIELDS.items():
         locals()[field_name] = field_info["field"](**field_info["kwargs"])
+
+    # Shared field with RequestTemplate, but it is required when saving Request
+    namespace = StringField(required=True)
 
     parent = ReferenceField(
         "Request", dbref=True, required=False, reverse_delete_rule=CASCADE
@@ -590,9 +591,6 @@ class RequestTemplate(MongoModel, EmbeddedDocument):
 
     for field_name, field_info in Request.TEMPLATE_FIELDS.items():
         locals()[field_name] = field_info["field"](**field_info["kwargs"])
-
-    # Shared field with Request, but it is not required when saving RequestTemplate
-    namespace = StringField(required=False)
 
 
 class DateTrigger(MongoModel, EmbeddedDocument):

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -208,9 +208,8 @@ class TestRequest(object):
 
     # Namespace was removed from the TEMPLATE_FIELDS list, so reduce by one
     def test_template_check(self):
-        assert (
-            len(Request.TEMPLATE_FIELDS)
-            == len(RequestTemplateSchema.get_attribute_names()) - 1
+        assert len(Request.TEMPLATE_FIELDS) == len(
+            RequestTemplateSchema.get_attribute_names()
         )
 
 

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -206,10 +206,11 @@ class TestRequest(object):
     #     request.save()
     #     self.assertNotEqual(request.updated_at, "this_will_be_updated")
 
+    # Namespace was removed from the TEMPLATE_FIELDS list, so reduce by one
     def test_template_check(self):
         assert len(Request.TEMPLATE_FIELDS) == len(
             RequestTemplateSchema.get_attribute_names()
-        )
+        ) - 1
 
 
 class TestSystem(object):

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -208,9 +208,10 @@ class TestRequest(object):
 
     # Namespace was removed from the TEMPLATE_FIELDS list, so reduce by one
     def test_template_check(self):
-        assert len(Request.TEMPLATE_FIELDS) == len(
-            RequestTemplateSchema.get_attribute_names()
-        ) - 1
+        assert (
+            len(Request.TEMPLATE_FIELDS)
+            == len(RequestTemplateSchema.get_attribute_names()) - 1
+        )
 
 
 class TestSystem(object):

--- a/src/app/test/scheduler_test.py
+++ b/src/app/test/scheduler_test.py
@@ -51,8 +51,8 @@ def trigger_template():
 
 class TestRunJob(object):
     def test_run_job(self, monkeypatch, scheduler, bg_request_template):
-        process_mock = Mock()
-        monkeypatch.setattr(beer_garden.scheduler, "process_request", process_mock)
+        router_mock = Mock()
+        monkeypatch.setattr(beer_garden.scheduler, "beer_garden.router.route", router_mock)
 
         event_mock = Mock()
         monkeypatch.setattr(threading, "Event", event_mock)
@@ -62,14 +62,14 @@ class TestRunJob(object):
 
         run_job("job_id", bg_request_template)
 
-        created_request = process_mock.call_args[0][0]
+        created_request = router_mock.call_args[0][0]
         assert created_request.metadata["_bg_job_id"] == "job_id"
 
     def test_request_injection(
         self, monkeypatch, scheduler, trigger_template, trigger_event
     ):
-        process_mock = Mock()
-        monkeypatch.setattr(beer_garden.scheduler, "process_request", process_mock)
+        router_mock = Mock()
+        monkeypatch.setattr(beer_garden.scheduler, "beer_garden.router.route", router_mock)
 
         event_mock = Mock()
         monkeypatch.setattr(threading, "Event", event_mock)
@@ -79,5 +79,5 @@ class TestRunJob(object):
 
         run_job("job_id", trigger_template, event=trigger_event)
 
-        created_request = process_mock.call_args[0][0]
+        created_request = router_mock.call_args[0][0]
         assert created_request.parameters["message"] == "Hello my/test/path.txt!"

--- a/src/app/test/scheduler_test.py
+++ b/src/app/test/scheduler_test.py
@@ -52,7 +52,7 @@ def trigger_template():
 class TestRunJob(object):
     def test_run_job(self, monkeypatch, scheduler, bg_request_template):
         router_mock = Mock()
-        monkeypatch.setattr(beer_garden.scheduler, "beer_garden.router.route", router_mock)
+        monkeypatch.setattr(beer_garden.router, "route", router_mock)
 
         event_mock = Mock()
         monkeypatch.setattr(threading, "Event", event_mock)
@@ -69,7 +69,7 @@ class TestRunJob(object):
         self, monkeypatch, scheduler, trigger_template, trigger_event
     ):
         router_mock = Mock()
-        monkeypatch.setattr(beer_garden.scheduler, "beer_garden.router.route", router_mock)
+        monkeypatch.setattr(beer_garden.router, "route", router_mock)
 
         event_mock = Mock()
         monkeypatch.setattr(threading, "Event", event_mock)

--- a/src/app/test/scheduler_test.py
+++ b/src/app/test/scheduler_test.py
@@ -52,7 +52,7 @@ def trigger_template():
 class TestRunJob(object):
     def test_run_job(self, monkeypatch, scheduler, bg_request_template):
         router_mock = Mock()
-        monkeypatch.setattr(beer_garden.router, "route", router_mock)
+        monkeypatch.setattr("beer_garden.router.route", router_mock)
 
         event_mock = Mock()
         monkeypatch.setattr(threading, "Event", event_mock)
@@ -63,13 +63,13 @@ class TestRunJob(object):
         run_job("job_id", bg_request_template)
 
         created_request = router_mock.call_args[0][0]
-        assert created_request.metadata["_bg_job_id"] == "job_id"
+        assert created_request.model.metadata["_bg_job_id"] == "job_id"
 
     def test_request_injection(
         self, monkeypatch, scheduler, trigger_template, trigger_event
     ):
         router_mock = Mock()
-        monkeypatch.setattr(beer_garden.router, "route", router_mock)
+        monkeypatch.setattr("beer_garden.router.route", router_mock)
 
         event_mock = Mock()
         monkeypatch.setattr(threading, "Event", event_mock)
@@ -80,4 +80,4 @@ class TestRunJob(object):
         run_job("job_id", trigger_template, event=trigger_event)
 
         created_request = router_mock.call_args[0][0]
-        assert created_request.parameters["message"] == "Hello my/test/path.txt!"
+        assert created_request.model.parameters["message"] == "Hello my/test/path.txt!"


### PR DESCRIPTION
When creating a Job, the namespace field is not required to be populated.