### PR TITLE
Issue/912

### DIFF
--- a/src/app/beer_garden/api/stomp/__init__.py
+++ b/src/app/beer_garden/api/stomp/__init__.py
@@ -9,7 +9,6 @@ import beer_garden.config as config
 import beer_garden.events
 import beer_garden.router
 from beer_garden.api.stomp.manager import StompManager
-from beer_garden.api.stomp.transport import format_connection_params
 from beer_garden.events import publish
 from beer_garden.events.processors import QueueListener
 from beer_garden.garden import get_gardens
@@ -45,7 +44,7 @@ def run(ep_conn):
     for garden in get_gardens(include_local=False):
         if garden.name != garden_name and garden.connection_type:
             if garden.connection_type.casefold() == "stomp":
-                connection_params = format_connection_params(garden.connection_params)
+                connection_params = garden.connection_params.get("stomp", {})
                 connection_params["send_destination"] = None
                 conn_manager.add_connection(
                     stomp_config=connection_params, name=garden.name

--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -2,7 +2,7 @@ import logging
 from box import Box
 from brewtils.models import Event, Events
 
-from beer_garden.api.stomp.transport import Connection, format_connection_params
+from beer_garden.api.stomp.transport import Connection
 from beer_garden.events import publish
 from beer_garden.events.processors import BaseProcessor
 
@@ -129,9 +129,7 @@ class StompManager(BaseProcessor):
 
             if event.payload.connection_type:
                 if event.payload.connection_type.casefold() == "stomp":
-                    stomp_config = format_connection_params(
-                        event.payload.connection_params
-                    )
+                    stomp_config = event.payload.connection_params.get("stomp", {})
                     stomp_config["send_destination"] = None
                     skip_key = self.add_connection(
                         stomp_config=stomp_config, name=event.payload.name

--- a/src/app/beer_garden/api/stomp/transport.py
+++ b/src/app/beer_garden/api/stomp/transport.py
@@ -150,8 +150,8 @@ class Connection:
 
     def __init__(
         self,
-        host: str,
-        port: int,
+        host: str = None,
+        port: int = None,
         send_destination: str = None,
         subscribe_destination: str = None,
         ssl=None,

--- a/src/app/beer_garden/api/stomp/transport.py
+++ b/src/app/beer_garden/api/stomp/transport.py
@@ -79,17 +79,6 @@ def send(
         conn.send(body=message, headers=headers, destination=destination)
 
 
-def format_connection_params(connection_params):
-    """Strips leading term from connection parameters"""
-    params = {}
-
-    for k, v in connection_params.items():
-        if k.startswith("stomp_"):
-            params[k[6:]] = v
-
-    return params
-
-
 class OperationListener(stomp.ConnectionListener):
     def __init__(self, conn=None, send_destination=None):
         self.conn = conn

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -590,7 +590,7 @@ def _forward_http(operation: Operation, target_garden: Garden):
         conn_info: Connection info
     """
 
-    conn_info = target_garden.connection_params
+    conn_info = target_garden.connection_params.get("http", {})
 
     easy_client = EasyClient(
         bg_host=conn_info.get("host"),

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -38,12 +38,7 @@ import beer_garden.queues
 import beer_garden.requests
 import beer_garden.scheduler
 import beer_garden.systems
-from beer_garden.api.stomp.transport import (
-    consolidate_headers,
-    process,
-    Connection,
-    format_connection_params,
-)
+from beer_garden.api.stomp.transport import Connection, consolidate_headers, process
 from beer_garden.errors import RoutingRequestException, UnknownGardenException
 from beer_garden.events import publish
 from beer_garden.events.processors import BaseProcessor
@@ -314,8 +309,7 @@ def forward(operation: Operation):
 def create_stomp_connection(garden: Garden) -> Connection:
     """Create a stomp connection wrapper for a garden
 
-    Uses the format_connection_params to rip the "stomp_" prefix from the garden's
-    connection params and constructs a stomp connection wrapper from them.
+    Constructs a stomp connection wrapper from the garden's stomp connection parameters.
 
     Will ignore subscribe_destination as the router shouldn't be subscribing to
     anything.
@@ -327,7 +321,7 @@ def create_stomp_connection(garden: Garden) -> Connection:
         The created connection wrapper
 
     """
-    connection_params = format_connection_params(garden.connection_params)
+    connection_params = garden.connection_params.get("stomp", {})
     connection_params["subscribe_destination"] = None
 
     return Connection(**connection_params)

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -99,124 +99,136 @@ export default function gardenService($http) {
         'type': 'string',
         'enum': GardenService.CONNECTION_TYPES,
       },
-      'name': {
-        'title': 'Garden Name',
-        'description': 'This is the globally routing name that Beer Garden utilizes when routing requests and events',
-        'type': 'string',
-      },
-      'host': {
-        'title': 'Host Name',
-        'description': 'Beer-garden hostname',
-        'type': 'string',
-        'minLength': 1,
-      },
-      'port': {
-        'title': 'Port',
-        'description': 'Beer-garden port',
-        'type': 'integer',
-        'minLength': 1,
-      },
-      'url_prefix': {
-        'title': 'URL Prefix',
-        'description': 'URL path that will be used as a prefix when communicating with Beer-garden. Useful if Beer-garden is running on a URL other than \'/\'.',
-        'type': 'string',
-      },
-      'ca_cert': {
-        'title': 'CA Cert Path',
-        'description': 'Path to certificate file containing the certificate of the authority that issued the Beer-garden server certificate',
-        'type': 'string',
-      },
-      'ca_verify': {
-        'title': 'CA Cert Verify',
-        'description': 'Whether to verify Beer-garden server certificate',
-        'type': 'boolean',
-      },
-      'ssl': {
-        'title': 'SSL Enabled',
-        'description': 'Whether to connect with provided certifications',
-        'type': 'boolean',
-      },
-      'client_cert': {
-        'title': 'Client Cert Path',
-        'description': 'Path to client certificate to use when communicating with Beer-garden',
-        'type': 'string',
-      },
-      'stomp_host': {
-        'title': 'Host Name',
-        'description': 'Beer-garden hostname',
-        'type': 'string',
-        'minLength': 1,
-      },
-      'stomp_port': {
-        'title': 'Port',
-        'description': 'Beer-garden port',
-        'type': 'integer',
-        'minLength': 1,
-      },
-      'stomp_send_destination': {
-        'title': 'Send Destination',
-        'description': 'Destination queue where Stomp will send messages.',
-        'type': 'string',
-      },
-      'stomp_subscribe_destination': {
-        'title': 'Subscribe Destination',
-        'description': 'Destination queue where Stomp will listen for messages.',
-        'type': 'string',
-      },
-      'stomp_username': {
-        'title': 'Username',
-        'description': 'Username for Stomp connection.',
-        'type': 'string',
-      },
-      'stomp_password': {
-        'title': 'Password',
-        'description': 'Password for Stomp connection.',
-        'type': 'string',
-      },
-      'stomp_ssl': {
+      'http': {
         'title': ' ',
-          'type': 'object',
-          'properties':{
-          'use_ssl': {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'title': 'Garden Name',
+            'description': 'This is the globally routing name that Beer Garden utilizes when routing requests and events',
+            'type': 'string',
+          },
+          'host': {
+            'title': 'Host Name',
+            'description': 'Beer-garden hostname',
+            'type': 'string',
+            'minLength': 1,
+          },
+          'port': {
+            'title': 'Port',
+            'description': 'Beer-garden port',
+            'type': 'integer',
+            'minLength': 1,
+          },
+          'url_prefix': {
+            'title': 'URL Prefix',
+            'description': 'URL path that will be used as a prefix when communicating with Beer-garden. Useful if Beer-garden is running on a URL other than \'/\'.',
+            'type': 'string',
+          },
+          'ca_cert': {
+            'title': 'CA Cert Path',
+            'description': 'Path to certificate file containing the certificate of the authority that issued the Beer-garden server certificate',
+            'type': 'string',
+          },
+          'ca_verify': {
+            'title': 'CA Cert Verify',
+            'description': 'Whether to verify Beer-garden server certificate',
+            'type': 'boolean',
+          },
+          'ssl': {
             'title': 'SSL Enabled',
             'description': 'Whether to connect with provided certifications',
             'type': 'boolean',
           },
-          'ca_cert': {
-            'title': 'CA Cert',
-            'description': 'Path to certificate file containing the certificate of the authority that issued the message broker certificate',
-            'type': 'string',
-          },
           'client_cert': {
-            'title': 'Client Cert',
-            'description': 'Path to client public certificate to use when communicating with the message broker',
-            'type': 'string',
-          },
-          'client_key': {
-            'title': 'Client Key',
-            'description': 'Path to client private key to use when communicating with the message broker',
+            'title': 'Client Cert Path',
+            'description': 'Path to client certificate to use when communicating with Beer-garden',
             'type': 'string',
           },
         },
       },
-      'stomp_headers': {
-        'title': 'Headers',
-        'description': 'Headers to be sent with message',
-        'type': 'array',
-        'items':{
-          'title': ' ',
-          'type': 'object',
-          'properties': {
-            'key': {
-              'title': 'Key',
-              'description': '',
-              'type': 'string',
+      'stomp': {
+        'title': ' ',
+        'type': 'object',
+        'properties': {
+          'host': {
+            'title': 'Host Name',
+            'description': 'Beer-garden hostname',
+            'type': 'string',
+            'minLength': 1,
+          },
+          'port': {
+            'title': 'Port',
+            'description': 'Beer-garden port',
+            'type': 'integer',
+            'minLength': 1,
+          },
+          'send_destination': {
+            'title': 'Send Destination',
+            'description': 'Destination queue where Stomp will send messages.',
+            'type': 'string',
+          },
+          'subscribe_destination': {
+            'title': 'Subscribe Destination',
+            'description': 'Destination queue where Stomp will listen for messages.',
+            'type': 'string',
+          },
+          'username': {
+            'title': 'Username',
+            'description': 'Username for Stomp connection.',
+            'type': 'string',
+          },
+          'password': {
+            'title': 'Password',
+            'description': 'Password for Stomp connection.',
+            'type': 'string',
+          },
+          'ssl': {
+            'title': ' ',
+              'type': 'object',
+              'properties':{
+              'use_ssl': {
+                'title': 'SSL Enabled',
+                'description': 'Whether to connect with provided certifications',
+                'type': 'boolean',
+              },
+              'ca_cert': {
+                'title': 'CA Cert',
+                'description': 'Path to certificate file containing the certificate of the authority that issued the message broker certificate',
+                'type': 'string',
+              },
+              'client_cert': {
+                'title': 'Client Cert',
+                'description': 'Path to client public certificate to use when communicating with the message broker',
+                'type': 'string',
+              },
+              'client_key': {
+                'title': 'Client Key',
+                'description': 'Path to client private key to use when communicating with the message broker',
+                'type': 'string',
+              },
             },
-            'value': {
-              'title': 'Value',
-              'description': '',
-              'type': 'string',
-            }
+          },
+          'headers': {
+            'title': 'Headers',
+            'description': 'Headers to be sent with message',
+            'type': 'array',
+            'items': {
+              'title': ' ',
+              'type': 'object',
+              'properties': {
+                'key': {
+                  'title': 'Key',
+                  'description': '',
+                  'type': 'string',
+                },
+                'value': {
+                  'title': 'Value',
+                  'description': '',
+                  'type': 'string',
+                }
+              },
+            },
           },
         },
       },
@@ -240,26 +252,26 @@ export default function gardenService($http) {
             {
               'title': 'HTTP',
               'items': [
-                'host',
-                'port',
-                'url_prefix',
-                'ssl',
-                'ca_cert',
-                'ca_verify',
-                'client_cert'
+                'http.host',
+                'http.port',
+                'http.url_prefix',
+                'http.ssl',
+                'http.ca_cert',
+                'http.ca_verify',
+                'http.client_cert'
               ],
             },
             {
               'title': 'STOMP',
               'items': [
-                'stomp_host',
-                'stomp_port',
-                'stomp_send_destination',
-                'stomp_subscribe_destination',
-                'stomp_username',
-                'stomp_password',
-                'stomp_ssl',
-                'stomp_headers',
+                'stomp.host',
+                'stomp.port',
+                'stomp.send_destination',
+                'stomp.subscribe_destination',
+                'stomp.username',
+                'stomp.password',
+                'stomp.ssl',
+                'stomp.headers',
               ],
             },
           ],


### PR DESCRIPTION
Fixes #912, groups garden connection parameters.

There's currently no migration for existing garden connections. You'll have to re-enter any prior connection information you had saved for a child garden. I don't really think it's worth the hassle of trying to write a migration.

Should be merged after #961.