### PR TITLE
Wrapping all stomp handler calls in a try

### DIFF
--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -3,6 +3,7 @@ from box import Box
 from brewtils.models import Event, Events
 
 import beer_garden.log
+import beer_garden.requests
 import beer_garden.router
 from beer_garden.api.stomp.transport import Connection, parse_header_list
 from beer_garden.events import publish
@@ -122,31 +123,26 @@ class StompManager(BaseProcessor):
                     self.conn_dict[key]["conn"].disconnect()
                     self.conn_dict.pop(key)
 
-    def handle_event(self, event):
-        # And also register handlers that the entry point needs to care about
-        for handler in [beer_garden.router.handle_event, beer_garden.log.handle_event]:
-            try:
-                handler(event)
-            except Exception as ex:
-                logger.exception(f"Error executing callback for {event!r}: {ex}")
+    def _event_handler(self, event):
+        """Internal event handler"""
+        if not event.error:
+            if event.name == Events.GARDEN_REMOVED.name:
+                self.remove_garden_from_list(garden_name=event.payload.name)
 
-        if event.name == Events.GARDEN_REMOVED.name:
-            self.remove_garden_from_list(garden_name=event.payload.name)
+            elif event.name == Events.GARDEN_UPDATED.name:
+                skip_key = None
 
-        elif event.name == Events.GARDEN_UPDATED.name:
-            skip_key = None
+                if event.payload.connection_type:
+                    if event.payload.connection_type.casefold() == "stomp":
+                        stomp_config = event.payload.connection_params.get("stomp", {})
+                        stomp_config["send_destination"] = None
+                        skip_key = self.add_connection(
+                            stomp_config=stomp_config, name=event.payload.name
+                        )
 
-            if event.payload.connection_type:
-                if event.payload.connection_type.casefold() == "stomp":
-                    stomp_config = event.payload.connection_params.get("stomp", {})
-                    stomp_config["send_destination"] = None
-                    skip_key = self.add_connection(
-                        stomp_config=stomp_config, name=event.payload.name
-                    )
-
-            self.remove_garden_from_list(
-                garden_name=event.payload.name, skip_key=skip_key
-            )
+                self.remove_garden_from_list(
+                    garden_name=event.payload.name, skip_key=skip_key
+                )
 
         for value in self.conn_dict.values():
             conn = value["conn"]
@@ -157,3 +153,26 @@ class StompManager(BaseProcessor):
                             conn.send(event, headers=headers)
                     else:
                         conn.send(event)
+
+    def handle_event(self, event):
+        """Main event entry point
+
+        This registers handlers that this entry point needs to care about.
+
+        - All entry points need the router and log handlers
+        - You might think that the requests handler isn't needed since the stomp entry
+        point specifically doesn't support wait events. However, the request validator
+        does use wait events internally, so we still need it.
+        - And then the actually event handler logic for this entry point
+
+        """
+        for handler in [
+            beer_garden.router.handle_event,
+            beer_garden.log.handle_event,
+            beer_garden.requests.handle_event,
+            self._event_handler,
+        ]:
+            try:
+                handler(event)
+            except Exception as ex:
+                logger.exception(f"Error executing callback for {event!r}: {ex}")


### PR DESCRIPTION
This wraps the event handling for the stomp entry point in a try so it doesn't cause problems if there's ever an exception.