### PR TITLE
Issue/991

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -208,12 +208,18 @@ def _setup_tornado_app() -> Application:
         (rf"{prefix}api/v1/jobs/(\w+)/?", v1.job.JobAPI),
         (rf"{prefix}api/v1/logging/?", v1.logging.LoggingAPI),
         (rf"{prefix}api/v1/gardens/([\w%]+)/?", v1.garden.GardenAPI),
-        (rf"{prefix}api/v1/files/?", v1.file.FileAPI),
-        (rf"{prefix}api/v1/files/id/?", v1.file.FileNameAPI),
         # Beta
         (rf"{prefix}api/vbeta/events/?", vbeta.event.EventPublisherAPI),
         (rf"{prefix}api/vbeta/runners/?", vbeta.runner.RunnerListAPI),
         (rf"{prefix}api/vbeta/runners/(\w+)/?", vbeta.runner.RunnerAPI),
+        (
+            rf"{prefix}api/vbeta/files/?",
+            beer_garden.api.http.handlers.vbeta.chunk.FileChunkAPI,
+        ),
+        (
+            rf"{prefix}api/vbeta/files/id/?",
+            beer_garden.api.http.handlers.vbeta.chunk.ChunkNameAPI,
+        ),
         (rf"{prefix}api/vbeta/file/?", vbeta.file.RawFileAPI),
         # V2
         (rf"{prefix}api/v2/users/?", v1.user.UsersAPI),

--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -220,7 +220,8 @@ def _setup_tornado_app() -> Application:
             rf"{prefix}api/vbeta/chunks/id/?",
             beer_garden.api.http.handlers.vbeta.chunk.ChunkNameAPI,
         ),
-        (rf"{prefix}api/vbeta/file/?", vbeta.file.RawFileAPI),
+        (rf"{prefix}api/vbeta/file/?", vbeta.file.RawFileListAPI),
+        (rf"{prefix}api/vbeta/file/(\w+)/?", vbeta.file.RawFileAPI),
         # V2
         (rf"{prefix}api/v2/users/?", v1.user.UsersAPI),
         (rf"{prefix}api/v2/users/(\w+)/?", v1.user.UserAPI),

--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -213,11 +213,11 @@ def _setup_tornado_app() -> Application:
         (rf"{prefix}api/vbeta/runners/?", vbeta.runner.RunnerListAPI),
         (rf"{prefix}api/vbeta/runners/(\w+)/?", vbeta.runner.RunnerAPI),
         (
-            rf"{prefix}api/vbeta/files/?",
+            rf"{prefix}api/vbeta/chunks/?",
             beer_garden.api.http.handlers.vbeta.chunk.FileChunkAPI,
         ),
         (
-            rf"{prefix}api/vbeta/files/id/?",
+            rf"{prefix}api/vbeta/chunks/id/?",
             beer_garden.api.http.handlers.vbeta.chunk.ChunkNameAPI,
         ),
         (rf"{prefix}api/vbeta/file/?", vbeta.file.RawFileAPI),

--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -214,6 +214,7 @@ def _setup_tornado_app() -> Application:
         (rf"{prefix}api/vbeta/events/?", vbeta.event.EventPublisherAPI),
         (rf"{prefix}api/vbeta/runners/?", vbeta.runner.RunnerListAPI),
         (rf"{prefix}api/vbeta/runners/(\w+)/?", vbeta.runner.RunnerAPI),
+        (rf"{prefix}api/vbeta/file/?", vbeta.file.RawFileAPI),
         # V2
         (rf"{prefix}api/v2/users/?", v1.user.UsersAPI),
         (rf"{prefix}api/v2/users/(\w+)/?", v1.user.UserAPI),

--- a/src/app/beer_garden/api/http/handlers/v1/__init__.py
+++ b/src/app/beer_garden/api/http/handlers/v1/__init__.py
@@ -16,4 +16,3 @@ import beer_garden.api.http.handlers.v1.user
 import beer_garden.api.http.handlers.v1.garden
 import beer_garden.api.http.handlers.v1.forward
 import beer_garden.api.http.handlers.v1.namespace
-import beer_garden.api.http.handlers.v1.file

--- a/src/app/beer_garden/api/http/handlers/vbeta/__init__.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+import beer_garden.api.http.handlers.vbeta.chunk
 import beer_garden.api.http.handlers.vbeta.event
 import beer_garden.api.http.handlers.vbeta.file
 import beer_garden.api.http.handlers.vbeta.runner

--- a/src/app/beer_garden/api/http/handlers/vbeta/__init__.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 
 import beer_garden.api.http.handlers.vbeta.event
+import beer_garden.api.http.handlers.vbeta.file
 import beer_garden.api.http.handlers.vbeta.runner

--- a/src/app/beer_garden/api/http/handlers/vbeta/chunk.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/chunk.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from brewtils.errors import ModelValidationError
-from brewtils.models import Operation
+from brewtils.models import Operation, Resolvable
+from brewtils.schema_parser import SchemaParser
 from tornado.escape import json_decode
 
 from beer_garden.api.http.authorization import Permissions, authenticated
@@ -229,7 +230,7 @@ class ChunkNameAPI(BaseHandler):
         if file_size is None:
             raise ModelValidationError(f"No file_size sent with file {file_name}.")
 
-        response = await self.client(
+        file_status = await self.client(
             Operation(
                 operation_type="FILE_CREATE",
                 args=[file_name, int(file_size), int(chunk_size)],
@@ -239,8 +240,12 @@ class ChunkNameAPI(BaseHandler):
                     "owner_id": owner_id,
                     "owner_type": owner_type,
                 },
-            )
+            ),
+            serialize_kwargs={"to_string": False},
         )
+
+        resolvable = Resolvable(storage="gridfs", details=file_status)
+        response = SchemaParser.serialize(resolvable, to_string=True)
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")
         self.write(response)

--- a/src/app/beer_garden/api/http/handlers/vbeta/chunk.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/chunk.py
@@ -8,7 +8,7 @@ from beer_garden.api.http.authorization import Permissions, authenticated
 from beer_garden.api.http.base_handler import BaseHandler
 
 
-class FileAPI(BaseHandler):
+class FileChunkAPI(BaseHandler):
     @authenticated(permissions=[Permissions.READ])
     async def get(self):
         """
@@ -162,7 +162,7 @@ class FileAPI(BaseHandler):
         self.write(response)
 
 
-class FileNameAPI(BaseHandler):
+class ChunkNameAPI(BaseHandler):
     @authenticated(permissions=[Permissions.READ])
     async def get(self):
         """

--- a/src/app/beer_garden/api/http/handlers/vbeta/chunk.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/chunk.py
@@ -244,7 +244,7 @@ class ChunkNameAPI(BaseHandler):
             serialize_kwargs={"to_string": False},
         )
 
-        resolvable = Resolvable(storage="gridfs", details=file_status)
+        resolvable = Resolvable(type="chunk", storage="gridfs", details=file_status)
         response = SchemaParser.serialize(resolvable, to_string=True)
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -95,7 +95,9 @@ class RawFileListAPI(BaseHandler):
         db_file.file.put(io.BytesIO(self.request.body))
         db_file.save()
 
-        resolvable = Resolvable(storage="gridfs", details={"id": str(db_file.id)})
+        resolvable = Resolvable(
+            type="bytes", storage="gridfs", details={"id": str(db_file.id)}
+        )
         response = SchemaParser.serialize(resolvable, to_string=True)
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -17,7 +17,7 @@ class RawFileAPI(BaseHandler):
         summary: Retrieve a File
         parameters:
           - name: file_id
-            in: body
+            in: path
             required: true
             description: The file ID
             type: string

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -91,9 +91,8 @@ class RawFileListAPI(BaseHandler):
         tags:
           - Files
         """
-        name = self.get_argument("name", default="")
-        db_file = RawFile(name=self.get_argument("name", default=""))
-        db_file.file.put(io.BytesIO(self.request.body), filename=name)
+        db_file = RawFile()
+        db_file.file.put(io.BytesIO(self.request.body))
         db_file.save()
 
         resolvable = Resolvable(storage="gridfs", details={"id": str(db_file.id)})

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -70,7 +70,7 @@ class RawFileAPI(BaseHandler):
 class RawFileListAPI(BaseHandler):
 
     @authenticated(permissions=[Permissions.CREATE])
-    async def put(self):
+    async def post(self):
         """
         ---
         summary: Create a new File

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import io
 
-from brewtils.resolvers.bytes import BYTES_PREFIX
+from brewtils.models import Resolvable
+from brewtils.schema_parser import SchemaParser
 
 from beer_garden.api.http.authorization import Permissions, authenticated
 from beer_garden.api.http.base_handler import BaseHandler
@@ -96,5 +97,8 @@ class RawFileListAPI(BaseHandler):
         db_file.file.put(io.BytesIO(self.request.body), filename=name)
         db_file.save()
 
+        resolvable = Resolvable(storage="gridfs", details={"id": str(db_file.id)})
+        response = SchemaParser.serialize(resolvable, to_string=True)
+
         self.set_header("Content-Type", "application/json; charset=UTF-8")
-        self.write(BYTES_PREFIX + str(db_file.id))
+        self.write(response)

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -69,7 +69,6 @@ class RawFileAPI(BaseHandler):
 
 
 class RawFileListAPI(BaseHandler):
-
     @authenticated(permissions=[Permissions.CREATE])
     async def post(self):
         """

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+import io
+
+from brewtils.models import Operation
+
+from beer_garden.api.http.authorization import Permissions, authenticated
+from beer_garden.api.http.base_handler import BaseHandler
+from beer_garden.db.mongo.models import RawFile
+
+
+class RawFileAPI(BaseHandler):
+    @authenticated(permissions=[Permissions.READ])
+    async def get(self):
+        """
+        ---
+        summary: Retrieve a File
+        parameters:
+          - name: name
+            in: query
+            required: true
+            description: The file name
+            type: string
+        responses:
+          200:
+            description: The requested File or FileChunk data
+            schema:
+              $ref: '#/definitions/FileStatus'
+          404:
+            $ref: '#/definitions/404Error'
+          50x:
+            $ref: '#/definitions/50xError'
+        tags:
+          - Files
+        """
+        db_file = RawFile.objects.get(name=self.get_argument("name", default=""))
+        file = db_file.file.read()
+
+        self.set_header("Content-Type", "application/octet-stream")
+        self.write(file)
+
+    @authenticated(permissions=[Permissions.CREATE])
+    async def put(self):
+        """
+        ---
+        summary: Create a new File
+        parameters:
+          - name: name
+            in: query
+            required: true
+            description: The file name
+            type: string
+          - name: body
+            in: body
+            required: true
+            description: The data
+        responses:
+          201:
+            description: A new File is created
+            schema:
+              $ref: '#/definitions/FileStatus'
+          400:
+            $ref: '#/definitions/400Error'
+          50x:
+            $ref: '#/definitions/50xError'
+        tags:
+          - Files
+        """
+        db_file = RawFile(name=self.get_argument("name", default=""))
+        db_file.file.put(io.BytesIO(self.request.body))
+        db_file.save()
+
+        self.set_status(201)
+
+    async def delete(self):
+        """
+        ---
+        summary: Delete a file
+        parameters:
+          - name: file_name
+            in: query
+            required: true
+            description: The name of the file
+            type: string
+        responses:
+          200:
+            description: The file and all of its contents have been removed.
+            schema:
+              $ref: '#/definitions/FileStatus'
+          400:
+            $ref: '#/definitions/400Error'
+          50x:
+            $ref: '#/definitions/50xError'
+        tags:
+          - Files
+        """
+        db_file = RawFile.objects.get(name=self.get_argument("name", default=""))
+        db_file.file.delete()
+        db_file.save()
+
+        self.set_status(204)

--- a/src/app/beer_garden/api/http/handlers/vbeta/file.py
+++ b/src/app/beer_garden/api/http/handlers/vbeta/file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import io
 
-from brewtils.resolvers.parameter import BYTES_PREFIX
+from brewtils.resolvers.bytes import BYTES_PREFIX
 
 from beer_garden.api.http.authorization import Permissions, authenticated
 from beer_garden.api.http.base_handler import BaseHandler

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -762,5 +762,4 @@ class FileChunk(MongoModel, Document):
 
 
 class RawFile(Document):
-    name = StringField()
     file = FileField()

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -757,3 +757,8 @@ class FileChunk(MongoModel, Document):
     data = StringField(required=True)
     # Delete Rule (2) = CASCADE; This causes this document to be deleted when the owner doc is.
     owner = LazyReferenceField(File, required=False, reverse_delete_rule=CASCADE)
+
+
+class RawFile(Document):
+    name = StringField()
+    file = FileField()

--- a/src/app/beer_garden/files.py
+++ b/src/app/beer_garden/files.py
@@ -12,7 +12,7 @@ from brewtils.models import (
     Operation,
     Request,
 )
-from brewtils.resolvers.parameter import UI_FILE_ID_PREFIX
+from brewtils.resolvers.file import UI_FILE_ID_PREFIX
 from bson import ObjectId
 from bson.errors import InvalidId
 from datetime import datetime

--- a/src/app/beer_garden/files.py
+++ b/src/app/beer_garden/files.py
@@ -12,7 +12,7 @@ from brewtils.models import (
     Operation,
     Request,
 )
-from brewtils.resolvers.file import UI_FILE_ID_PREFIX
+from brewtils.resolvers.chunks import UI_FILE_ID_PREFIX
 from bson import ObjectId
 from bson.errors import InvalidId
 from datetime import datetime

--- a/src/app/beer_garden/files.py
+++ b/src/app/beer_garden/files.py
@@ -12,7 +12,6 @@ from brewtils.models import (
     Operation,
     Request,
 )
-from brewtils.resolvers.chunks import UI_FILE_ID_PREFIX
 from bson import ObjectId
 from bson.errors import InvalidId
 from datetime import datetime
@@ -24,8 +23,8 @@ import beer_garden.db.api as db
 import beer_garden.router as router
 from beer_garden.errors import NotUniqueException
 
-# 15MB
-MAX_CHUNK_SIZE = 1024 * 1024 * 15
+UI_FILE_ID_PREFIX = "BGFileID:"
+MAX_CHUNK_SIZE = 1024 * 1024 * 15  # 15MB
 OWNERSHIP_PRIORITY = {
     "JOB": 1,
     "REQUEST": 2,

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -532,6 +532,8 @@ class RequestValidator(object):
                 return int(value)
             elif parameter.type.upper() == "BASE64":
                 return value
+            elif parameter.type.upper() == "BYTES":
+                return value
             else:
                 raise ModelValidationError(
                     "Unknown type for parameter. Please contact a system administrator."

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -528,7 +528,7 @@ class RequestValidator(object):
                 return int(value)
             elif parameter.type.upper() == "DATETIME":
                 return int(value)
-            elif parameter.type.upper() in ("ANY", "BASE64", "BYTES", "FILE"):
+            elif parameter.type.upper() in ("ANY", "BASE64", "BYTES"):
                 return value
             else:
                 raise ModelValidationError(

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -511,8 +511,6 @@ class RequestValidator(object):
                 return int(value)
             elif parameter.type.upper() == "FLOAT":
                 return float(value)
-            elif parameter.type.upper() == "ANY":
-                return value
             elif parameter.type.upper() == "BOOLEAN":
                 if value in [True, False]:
                     return value
@@ -530,9 +528,7 @@ class RequestValidator(object):
                 return int(value)
             elif parameter.type.upper() == "DATETIME":
                 return int(value)
-            elif parameter.type.upper() == "BASE64":
-                return value
-            elif parameter.type.upper() == "BYTES":
+            elif parameter.type.upper() in ("ANY", "BASE64", "BYTES", "FILE"):
                 return value
             else:
                 raise ModelValidationError(


### PR DESCRIPTION
Fixes #991.

This moves the old files REST API back into vbeta - it shouldn't have been in v1. This API has also been renamed to "chunks", so its new location is /api/vbeta/chunks. This will still be used by `base64` parameters.

There is a new, simpler api at /api/vbeta/file. This is used by `bytes` parameters.

The long-term plan is to combine these into a single unified api.