### PR TITLE
Integration tests for old version of brewtils now pass

### DIFF
--- a/test/integration/helper/plugin.py
+++ b/test/integration/helper/plugin.py
@@ -57,6 +57,15 @@ class Thread_Plugin(Plugin):
 
 def create_plugin(name, version, clazz, **kwargs):
     config = helper.get_config()
+
+    # Brewtils 3.2.0ish has a bug that breaks when reusing the same client class
+    # It's been fixed in brewtils, but fix it here so we can run tests on that version
+    # See https://github.com/beer-garden/beer-garden/issues/1014
+    if hasattr(clazz, "current_request"):
+        delattr(clazz, "current_request")
+    if hasattr(clazz, "_current_request"):
+        delattr(clazz, "_current_request")
+
     return Thread_Plugin(
         client=clazz(),
         name=name,


### PR DESCRIPTION
This helps with #1014, even though it's already closed. It tweaks the integration tests so they can successfully test versions of brewtils where this was a problem.