### PR TITLE
Adding client_max_body_size directives to nginx configs

### DIFF
--- a/rpm/centos7/resources/nginx/bg.conf
+++ b/rpm/centos7/resources/nginx/bg.conf
@@ -1,7 +1,8 @@
 
 location ~ / {
-    alias   /opt/beer-garden/ui/dist/;
+    client_max_body_size 100m;
 
+    alias /opt/beer-garden/ui/dist/;
     try_files $uri $uri/ @beergarden;
 }
 

--- a/src/ui/default.conf.template
+++ b/src/ui/default.conf.template
@@ -5,6 +5,8 @@ server {
     root   /usr/share/nginx/html;
     index  index.html;
 
+    client_max_body_size 100m;
+
     location / {
         try_files $uri $uri/ @beergarden;
     }


### PR DESCRIPTION
Fixes #1027, adjusts nginx configs to allow larger request bodies.