### PR TITLE
Publishing an event AND raising the exception for bad reqeusts

### DIFF
--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -613,7 +613,8 @@ def process_request(
         try:
             request = RequestValidator.instance().validate_request(request)
         except ModelValidationError:
-            return invalid_request(request)
+            invalid_request(request)
+            raise
 
     if request.command_type == "EPHEMERAL":
         logger.debug(f"Publishing {request!r}")


### PR DESCRIPTION
Related to #1040.

The linked PR modified handling of an invalid request to publish an event with the Request's status set to INVALID. That allows invalid downstream requests to be detected properly on the upstream. However, that breaks the integration tests that are expecting non-200 response codes.

This PR tweaks the error handling to do both.