### PR TITLE
Removing forward processor

### DIFF
--- a/src/app/beer_garden/api/stomp/__init__.py
+++ b/src/app/beer_garden/api/stomp/__init__.py
@@ -7,10 +7,8 @@ from brewtils.models import Event, Events
 
 import beer_garden.config as config
 import beer_garden.events
-import beer_garden.router
 from beer_garden.api.stomp.manager import StompManager
 from beer_garden.events import publish
-from beer_garden.events.processors import QueueListener
 from beer_garden.garden import get_gardens
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -25,7 +23,6 @@ def run(ep_conn):
     conn_manager = StompManager(ep_conn)
 
     _setup_event_handling(conn_manager)
-    _setup_operation_forwarding()
 
     entry_config = config.get("entry.stomp")
     parent_config = config.get("parent.stomp")
@@ -76,18 +73,6 @@ def run(ep_conn):
     conn_manager.stop()
     conn_manager.join(5)
 
-    logger.debug("Stopping forward processing")
-    beer_garden.router.forward_processor.stop()
-
 
 def _setup_event_handling(conn_manager):
     beer_garden.events.manager = conn_manager
-
-
-def _setup_operation_forwarding():
-    beer_garden.router.forward_processor = QueueListener(
-        action=beer_garden.router.forward
-    )
-
-    logger.debug("Starting forward processor")
-    beer_garden.router.forward_processor.start()

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -47,7 +47,6 @@ from beer_garden.errors import (
     UnknownGardenException,
 )
 from beer_garden.events import publish
-from beer_garden.events.processors import BaseProcessor
 from beer_garden.garden import get_garden, get_gardens
 from beer_garden.requests import complete_request
 
@@ -69,9 +68,6 @@ t_pool = ThreadPoolExecutor()
 garden_lock = threading.RLock()
 gardens: Dict[str, Garden] = {}  # garden_name -> garden
 stomp_garden_connections: Dict[str, Connection] = {}
-
-# Used by entry points
-forward_processor: BaseProcessor
 
 # Used for determining WHERE to route an operation
 routing_lock = threading.RLock()


### PR DESCRIPTION
Misc cleanup.

`beer_garden.router.forward_processor` was originally the queue used to ship requests to child gardens. Things would be put on the queue and immediately return. I think the purpose of this was to minimize the time spent blocking the http entry point's ioloop?

It's no longer used, I think mostly because error handling is such a pain. We don't have any good way to inform the frontend if there was an issue forwarding the request, which is bad. So we currently just push the request to the child garden immediately in the same thread context. The changes in this PR should have been made at the same time as that change, so this just fixes that oversight.

Last thing - the file parameter forwarding still has references to the `forward_processor`. I'm pretty sure this wasn't working already, but we do need to come up with a way to get file parameters working on child gardens.