### PR TITLE
#1064 - Add github action to assign new issues to the Backlog project

### DIFF
--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -1,0 +1,19 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.BUILDBOT_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to Backlog
+    steps:
+      - name: Assign NEW issues to Backlog project
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        if: github.event.action == 'opened'
+        with:
+          project: "https://github.com/orgs/beer-garden/projects/24"
+          column_name: "New Issues"


### PR DESCRIPTION
Closes #1064 

This will assign newly opened issues to the Backlog project and place them in the "New Issues" column.