### PR TITLE
Republishing a modified event when child request changes

### DIFF
--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -754,6 +754,12 @@ def invalid_request(request: Request = None):
     return request
 
 
+@publish_event(Events.REQUEST_UPDATED)
+def update_request(request: Request):
+    db.update(request)
+    return request
+
+
 def process_wait(request: Request, timeout: float) -> Request:
     """Helper to process a request and wait for completion using a threading.Event
 
@@ -825,7 +831,7 @@ def handle_event(event):
                     setattr(existing_request, field, getattr(event.payload, field))
 
                 try:
-                    db.update(existing_request)
+                    update_request(existing_request)
                 except RequestStatusTransitionError:
                     pass
             else:


### PR DESCRIPTION
Fixes #1057 - child requests on a downstream garden should now be properly updated in the UI.

## Test Instructions
- Set up parent and child gardens named 'parent' and 'child'
- Run the `echo` example plugin on the parent garden
- Run the `sleeper` example plugin on the child garden
- Modify the `echo-sleeper` plugin so that the SystemClient targets the sleeper plugin on the child garden:
```python
        self.sleeper_client = SystemClient(system_namespace="child", system_name="sleeper")
```
- Use the parent garden UI to create a `say_sleep` request
- On the request view page click the request to expand the child request view

Before this PR the status of the child request targeted at the parent garden would appear and update normally. However, the child request targeted at the child garden would either fail to appear or not update as the status changes.

This PR corrects this - now both child requests should appear and update normally.

