### PR TITLE
Issue/870

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -460,15 +460,10 @@ class Request(MongoModel, Document):
         # Deal with has_parent
         if self.has_parent is None:
             self.has_parent = bool(self.parent)
-        elif self.has_parent is False and self.parent:
+        elif self.has_parent != bool(self.parent):
             raise ModelValidationError(
-                f"Can not save Request {self}: Request has a parent field but "
-                f"has_parent is False"
-            )
-        elif self.has_parent is True and not self.parent:
-            raise ModelValidationError(
-                f"Can not save Request {self}: Request does not have a parent field "
-                f"but has_parent is True"
+                f"Cannot save Request {self}: parent value of {self.parent!r} is not "
+                f"consistent with has_parent value of {self.has_parent}"
             )
 
     def clean_update(self):

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -409,6 +409,10 @@ class Request(MongoModel, Document):
             self.parameters_gridfs = None
 
     def save(self, *args, **kwargs):
+        # Set has_parent if not already set
+        if self.has_parent is None:
+            self.has_parent = bool(self.parent)
+
         self.updated_at = datetime.datetime.utcnow()
         max_size = 15 * 1_000_000
         encoding = "utf-8"

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -409,10 +409,6 @@ class Request(MongoModel, Document):
             self.parameters_gridfs = None
 
     def save(self, *args, **kwargs):
-        # Set has_parent if not already set
-        if self.has_parent is None:
-            self.has_parent = bool(self.parent)
-
         self.updated_at = datetime.datetime.utcnow()
         max_size = 15 * 1_000_000
         encoding = "utf-8"
@@ -459,6 +455,20 @@ class Request(MongoModel, Document):
         ):
             raise ModelValidationError(
                 f"Can not save Request {self}: Invalid output type '{self.output_type}'"
+            )
+
+        # Deal with has_parent
+        if self.has_parent is None:
+            self.has_parent = bool(self.parent)
+        elif self.has_parent is False and self.parent:
+            raise ModelValidationError(
+                f"Can not save Request {self}: Request has a parent field but "
+                f"has_parent is False"
+            )
+        elif self.has_parent is True and not self.parent:
+            raise ModelValidationError(
+                f"Can not save Request {self}: Request does not have a parent field "
+                f"but has_parent is True"
             )
 
     def clean_update(self):

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -73,24 +73,19 @@ class RequestValidator(object):
         system = self.get_and_validate_system(request)
         command = self.get_and_validate_command_for_system(request, system)
         request.parameters = self.get_and_validate_parameters(request, command)
-        request.has_parent = self.get_and_validate_parent(request)
+
+        self.validate_parent_status(request)
 
         return request
 
-    def get_and_validate_parent(self, request):
+    def validate_parent_status(self, request):
         """Ensure that a Request's parent request hasn't already completed.
 
         :param request: The request to validate
-        :return: Boolean indicating if this request has a parent
         :raises ConflictError: The parent request has already completed
         """
-        if not request.parent:
-            return False
-
-        if request.parent.status in Request.COMPLETED_STATUSES:
+        if request.parent and request.parent.status in Request.COMPLETED_STATUSES:
             raise ConflictError("Parent request has already completed")
-
-        return True
 
     def get_and_validate_system(self, request):
         """Ensure there is a system in the DB that corresponds to this Request.

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -159,31 +159,55 @@ class TestRequest(object):
         assert "name" in repr(request)
         assert "CREATED" in repr(request)
 
-    @pytest.mark.parametrize(
-        "req",
-        [
-            Request(system="foo", command="bar", status="bad"),
-            Request(system="foo", command="bar", command_type="BAD"),
-            Request(system="foo", command="bar", output_type="BAD"),
-        ],
-    )
-    def test_clean_fail(self, req):
-        with pytest.raises(ModelValidationError):
+    class TestClean:
+        @pytest.mark.parametrize(
+            "req",
+            [
+                Request(system="foo", command="bar", status="bad"),
+                Request(system="foo", command="bar", command_type="BAD"),
+                Request(system="foo", command="bar", output_type="BAD"),
+            ],
+        )
+        def test_bad_values(self, req):
+            with pytest.raises(ModelValidationError):
+                req.clean()
+
+        @pytest.mark.parametrize(
+            "parent, has_parent",
+            [(None, False), ("something", True)],
+        )
+        def test_set_has_parent(self, parent, has_parent):
+            req = Request(command="bar", parent=parent)
             req.clean()
+            assert req.has_parent is has_parent
 
-    @pytest.mark.parametrize(
-        "start,end",
-        [("SUCCESS", "IN_PROGRESS"), ("SUCCESS", "ERROR"), ("IN_PROGRESS", "CREATED")],
-    )
-    def test_invalid_status_transitions(self, bg_request, start, end):
-        bg_request.status = start
-        bg_request.output = None
+        @pytest.mark.parametrize(
+            "parent, has_parent",
+            [(None, True), ("something", False)],
+        )
+        def test_parent_mismatch(self, parent, has_parent):
+            req = Request(command="bar", parent=parent, has_parent=has_parent)
+            with pytest.raises(ModelValidationError):
+                req.clean()
 
-        db.create(bg_request)
+    class TestCleanUpdate:
+        @pytest.mark.parametrize(
+            "start, end",
+            [
+                ("SUCCESS", "IN_PROGRESS"),
+                ("SUCCESS", "ERROR"),
+                ("IN_PROGRESS", "CREATED"),
+            ],
+        )
+        def test_invalid_transitions(self, bg_request, start, end):
+            bg_request.status = start
+            bg_request.output = None
 
-        with pytest.raises(RequestStatusTransitionError):
-            bg_request.status = end
-            db.update(bg_request)
+            db.create(bg_request)
+
+            with pytest.raises(RequestStatusTransitionError):
+                bg_request.status = end
+                db.update(bg_request)
 
     # TODO - Make these integration tests
     # @patch("bg_utils.mongo.models.Request.objects")

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -183,7 +183,7 @@ class TestRequest(object):
 
         @pytest.mark.parametrize(
             "parent, has_parent",
-            [(None, True), ("something", False)],
+            [(None, True), (Request(command="say"), False)],
         )
         def test_parent_mismatch(self, parent, has_parent):
             req = Request(command="bar", parent=parent, has_parent=has_parent)


### PR DESCRIPTION
This fixes #870, fixes a deficiency with log read requests.

One of the steps in creating a request is validation. There are a couple of things that we need to validate, things like "does a system with this name and version actually exist?"

The request validator has been around since the very beginning, and one of my pet peeves with it is that it modifies the request object. One of the steps involved in validation is "does this request have a parent request that's already complete?" A side-effect of this validation was setting the `has_parent` field of the request.

Because the log read request is an admin-type request we don't to subject it to the same validation as a "regular" request. This is normally fine since it's hard-coded ahead of time - there's nothing dynamic to validate.

These two things combined to cause the issue we were seeing. To correct I've moved the `has_parent` determination to a more general location in the database model and out of the request validator.

## Test Instructions
- Create a log read request
- Look at the request that was just created, it should now have a `has_parent` field