### PR TITLE
Issue/958 - Added config option for changing commands of non-dev systems

### DIFF
--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1261,10 +1261,16 @@ _PLUGIN_SPEC = {
                 },
             },
         },
-        "allow_update_systems": {
+        "allow_system_command_updates": {
             "type": "bool",
             "default": False,
-            "description": "Allow updating the commands of a a non-dev system",
+            "description": "Allow commands of non-dev systems to be updated",
+            "long_description": "When False, this prevents changes to the command "
+            "definitions of a registered version of a system. This means that the "
+            "system will fail to start if the commands do not match what is on "
+            "record for that version of the system. When True, the system will be "
+            "allowed to start and the commands on record will be updated accordingly. "
+            "NOTE: System versions containing 'dev' are exempt from this check.",
         },
         "status_heartbeat": {
             "type": "int",

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1261,7 +1261,7 @@ _PLUGIN_SPEC = {
                 },
             },
         },
-        "allow_update_system": {
+        "allow_update_systems": {
             "type": "bool",
             "default": False,
             "description": "Allow updating the commands of a a non-dev system",

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1261,6 +1261,11 @@ _PLUGIN_SPEC = {
                 },
             },
         },
+        "allow_update_system": {
+            "type": "bool",
+            "default": "false",
+            "description": "Allow updating the commands of a a non-dev system", 
+        },
         "status_heartbeat": {
             "type": "int",
             "default": 10,

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1261,7 +1261,7 @@ _PLUGIN_SPEC = {
                 },
             },
         },
-        "allow_system_command_updates": {
+        "allow_command_updates": {
             "type": "bool",
             "default": False,
             "description": "Allow commands of non-dev systems to be updated",

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1263,8 +1263,8 @@ _PLUGIN_SPEC = {
         },
         "allow_update_system": {
             "type": "bool",
-            "default": "false",
-            "description": "Allow updating the commands of a a non-dev system", 
+            "default": False,
+            "description": "Allow updating the commands of a a non-dev system",
         },
         "status_heartbeat": {
             "type": "int",

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -124,6 +124,7 @@ def update_system(
 
         if (
             system.commands
+            and not config.get("plugin.allow_update_systems")
             and "dev" not in system.version
             and system.has_different_commands(brew_commands)
         ):

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -124,7 +124,7 @@ def update_system(
 
         if (
             system.commands
-            and not config.get("plugin.allow_update_systems")
+            and not config.get("plugin.allow_system_command_updates")
             and "dev" not in system.version
             and system.has_different_commands(brew_commands)
         ):

--- a/src/app/beer_garden/systems.py
+++ b/src/app/beer_garden/systems.py
@@ -124,7 +124,7 @@ def update_system(
 
         if (
             system.commands
-            and not config.get("plugin.allow_system_command_updates")
+            and not config.get("plugin.allow_command_updates")
             and "dev" not in system.version
             and system.has_different_commands(brew_commands)
         ):

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -116,6 +116,7 @@ parent:
     subscribe_destination: Beer_Garden_Forward_Parent
     username: beer_garden
 plugin:
+  allow_update_systems: false
   local:
     auth:
       password: password
@@ -134,7 +135,6 @@ plugin:
     logging:
       config_file: example_configs/plugin-logging.yaml
       fallback_level: INFO
-  allow_update_systems: false
   status_heartbeat: 5
   status_timeout: 30
 request_validation:

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -116,7 +116,7 @@ parent:
     subscribe_destination: Beer_Garden_Forward_Parent
     username: beer_garden
 plugin:
-  allow_update_systems: false
+  allow_system_command_updates: false
   local:
     auth:
       password: password

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -134,6 +134,7 @@ plugin:
     logging:
       config_file: example_configs/plugin-logging.yaml
       fallback_level: INFO
+  allow_update_systems: false
   status_heartbeat: 5
   status_timeout: 30
 request_validation:

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -116,7 +116,7 @@ parent:
     subscribe_destination: Beer_Garden_Forward_Parent
     username: beer_garden
 plugin:
-  allow_system_command_updates: false
+  allow_command_updates: false
   local:
     auth:
       password: password

--- a/src/app/test/systems_test.py
+++ b/src/app/test/systems_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import pytest
+from mock import Mock
+from mongoengine import connect
+from brewtils.models import System, Command
+from brewtils.errors import ModelValidationError
+
+import beer_garden
+import beer_garden.router
+from beer_garden.systems import create_system, update_system
+
+@pytest.fixture()
+def mongo_conn():
+    connect("beer_garden", host="mongomock://localhost")
+
+def test_disallow_system_command_updates(mongo_conn, monkeypatch):
+    system = System(
+        name='original',
+        version='v0.0.1',
+        namespace='beer_garden',
+        commands=[Command(name='original')]
+    )
+    create_system(system)
+    monkeypatch.setattr(beer_garden.db.api, "modify", Mock())
+    monkeypatch.setattr(beer_garden.router, "add_routing_system", Mock())
+    try:
+        update_system(system=system, new_commands=[Command(name='changed_command')])
+        raise AssertionError()
+    except ModelValidationError:
+        pass
+
+def test_allow_system_command_updates(mongo_conn, monkeypatch):
+    system = System(
+        name='test',
+        version='v0.0.1',
+        namespace='beer_garden',
+        commands=[Command(name='original')]
+    )
+
+    create_system(system)
+    monkeypatch.setattr(beer_garden.config, "get", lambda x: True)
+    monkeypatch.setattr(beer_garden.db.api, "modify", Mock())
+    monkeypatch.setattr(beer_garden.router, "add_routing_system", Mock())
+    update_system(system=system, new_commands=[Command(name='changed_command')])

--- a/src/app/test/systems_test.py
+++ b/src/app/test/systems_test.py
@@ -9,36 +9,39 @@ import beer_garden
 import beer_garden.router
 from beer_garden.systems import create_system, update_system
 
+
 @pytest.fixture()
 def mongo_conn():
     connect("beer_garden", host="mongomock://localhost")
 
+
 def test_disallow_system_command_updates(mongo_conn, monkeypatch):
     system = System(
-        name='original',
-        version='v0.0.1',
-        namespace='beer_garden',
-        commands=[Command(name='original')]
+        name="original",
+        version="v0.0.1",
+        namespace="beer_garden",
+        commands=[Command(name="original")],
     )
     create_system(system)
     monkeypatch.setattr(beer_garden.db.api, "modify", Mock())
     monkeypatch.setattr(beer_garden.router, "add_routing_system", Mock())
     try:
-        update_system(system=system, new_commands=[Command(name='changed_command')])
+        update_system(system=system, new_commands=[Command(name="changed_command")])
         raise AssertionError()
     except ModelValidationError:
         pass
 
+
 def test_allow_system_command_updates(mongo_conn, monkeypatch):
     system = System(
-        name='test',
-        version='v0.0.1',
-        namespace='beer_garden',
-        commands=[Command(name='original')]
+        name="test",
+        version="v0.0.1",
+        namespace="beer_garden",
+        commands=[Command(name="original")],
     )
 
     create_system(system)
     monkeypatch.setattr(beer_garden.config, "get", lambda x: True)
     monkeypatch.setattr(beer_garden.db.api, "modify", Mock())
     monkeypatch.setattr(beer_garden.router, "add_routing_system", Mock())
-    update_system(system=system, new_commands=[Command(name='changed_command')])
+    update_system(system=system, new_commands=[Command(name="changed_command")])

--- a/src/app/test/systems_test.py
+++ b/src/app/test/systems_test.py
@@ -1,47 +1,47 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
-from mongoengine import connect
-from brewtils.models import System, Command
 from brewtils.errors import ModelValidationError
+from brewtils.models import Command, System
+from mongoengine import connect
 
-import beer_garden
-import beer_garden.router
+from beer_garden import config
 from beer_garden.systems import create_system, update_system
 
 
-@pytest.fixture()
-def mongo_conn():
-    connect("beer_garden", host="mongomock://localhost")
-
-
-def test_disallow_system_command_updates(mongo_conn, monkeypatch):
-    system = System(
-        name="original",
-        version="v0.0.1",
-        namespace="beer_garden",
-        commands=[Command(name="original")],
-    )
-    create_system(system)
-    monkeypatch.setattr(beer_garden.db.api, "modify", Mock())
-    monkeypatch.setattr(beer_garden.router, "add_routing_system", Mock())
-    try:
-        update_system(system=system, new_commands=[Command(name="changed_command")])
-        raise AssertionError()
-    except ModelValidationError:
-        pass
-
-
-def test_allow_system_command_updates(mongo_conn, monkeypatch):
-    system = System(
-        name="test",
-        version="v0.0.1",
-        namespace="beer_garden",
-        commands=[Command(name="original")],
+@pytest.fixture
+def system():
+    yield create_system(
+        System(
+            name="original",
+            version="v0.0.1",
+            namespace="beer_garden",
+            commands=[Command(name="original")],
+        )
     )
 
-    create_system(system)
-    monkeypatch.setattr(beer_garden.config, "get", lambda x: True)
-    monkeypatch.setattr(beer_garden.db.api, "modify", Mock())
-    monkeypatch.setattr(beer_garden.router, "add_routing_system", Mock())
-    update_system(system=system, new_commands=[Command(name="changed_command")])
+
+class TestSystem:
+    @classmethod
+    def setup_class(cls):
+        connect("beer_garden", host="mongomock://localhost")
+
+    def test_disallow_system_command_updates(self, system):
+        """System commands should not be allowed to update if the
+        allow_system_command_updates config is set to False
+        """
+        config._CONFIG = {"plugin": {"allow_system_command_updates": False}}
+
+        with pytest.raises(ModelValidationError):
+            update_system(system=system, new_commands=[Command(name="changed_command")])
+
+    def test_allow_system_command_updates(self, system):
+        """System commands should be allowed to update if the
+        allow_system_command_updates config is set to True
+        """
+        config._CONFIG = {"plugin": {"allow_system_command_updates": True}}
+        updated_system = update_system(
+            system=system, new_commands=[Command(name="changed_command")]
+        )
+        assert (
+            updated_system.commands[0].name == "changed_command"
+        ), "System command should be updated with the new command name"

--- a/src/app/test/systems_test.py
+++ b/src/app/test/systems_test.py
@@ -25,20 +25,20 @@ class TestSystem:
     def setup_class(cls):
         connect("beer_garden", host="mongomock://localhost")
 
-    def test_disallow_system_command_updates(self, system):
+    def test_disallow_command_updates(self, system):
         """System commands should not be allowed to update if the
-        allow_system_command_updates config is set to False
+        allow_command_updates config is set to False
         """
-        config._CONFIG = {"plugin": {"allow_system_command_updates": False}}
+        config._CONFIG = {"plugin": {"allow_command_updates": False}}
 
         with pytest.raises(ModelValidationError):
             update_system(system=system, new_commands=[Command(name="changed_command")])
 
-    def test_allow_system_command_updates(self, system):
+    def test_allow_command_updates(self, system):
         """System commands should be allowed to update if the
-        allow_system_command_updates config is set to True
+        allow_command_updates config is set to True
         """
-        config._CONFIG = {"plugin": {"allow_system_command_updates": True}}
+        config._CONFIG = {"plugin": {"allow_command_updates": True}}
         updated_system = update_system(
             system=system, new_commands=[Command(name="changed_command")]
         )


### PR DESCRIPTION
Fixes #958. I'm unsure if `allow_update_systems` might be too vague of a config option. The description in `config.py` suffices, though.

Tested with brewtils' `update_system`.