### PR TITLE
Overriding operation target garden if necessary

### DIFF
--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -43,6 +43,7 @@ import beer_garden.systems
 from beer_garden.api.stomp.transport import Connection, consolidate_headers, process
 from beer_garden.errors import (
     ForwardException,
+    RoutingException,
     RoutingRequestException,
     UnknownGardenException,
 )
@@ -176,27 +177,7 @@ def route(operation: Operation):
         )
 
     # Determine which garden the operation is targeting
-    target_garden = _determine_target_garden(operation)
-
-    if not target_garden and not operation.target_garden_name:
-        raise UnknownGardenException(
-            f"Could not determine the target garden for routing {operation!r}"
-        )
-
-    elif not target_garden:
-        logger.warning(
-            f"Couldn't determine a target garden but the operation had one, using "
-            f"{operation.target_garden_name}"
-        )
-
-    elif not operation.target_garden_name:
-        operation.target_garden_name = target_garden
-
-    else:
-        # This is most likely caused by an operation targeted at a grandchild of the
-        # source garden
-        if operation.target_garden_name != target_garden:
-            operation.target_garden_name = target_garden
+    operation.target_garden_name = _determine_target(operation)
 
     # If it's targeted at THIS garden, execute
     if operation.target_garden_name == config.get("garden.name"):
@@ -531,9 +512,38 @@ def _pre_execute(operation: Operation) -> Operation:
     return operation
 
 
-def _determine_target_garden(operation: Operation) -> str:
-    """Determine the system the operation is targeting"""
+def _determine_target(operation: Operation) -> str:
+    """Determine the garden the operation is targeting"""
+    # First determine the target based on the operation type
+    target_garden = _target_from_type(operation)
 
+    # Now do some additional processing to ensure the target is correct
+    if not target_garden and not operation.target_garden_name:
+        raise UnknownGardenException(
+            f"Could not determine the target garden for routing {operation!r}"
+        )
+
+    elif not target_garden:
+        logger.warning(
+            f"Couldn't determine a target garden but the operation had one, using "
+            f"{operation.target_garden_name}"
+        )
+        return operation.target_garden_name
+
+    elif not operation.target_garden_name:
+        return target_garden
+
+    else:
+        # This is most likely caused by an operation targeted at a grandchild of the
+        # source garden
+        if operation.target_garden_name != target_garden:
+            return target_garden
+
+    raise RoutingException(f"Unable to determine target garden for {operation!r}")
+
+
+def _target_from_type(operation: Operation) -> str:
+    """Determine the target garden based on the operation type"""
     # Certain operations are ASSUMED to be targeted at the local garden
     if (
         "READ" in operation.operation_type

--- a/src/app/test/router_test.py
+++ b/src/app/test/router_test.py
@@ -1,105 +1,46 @@
 # -*- coding: utf-8 -*-
 import pytest
-from box import Box
-from brewtils.models import Garden, System
-from brewtils.test.comparable import assert_garden_equal
+from brewtils.models import Operation
 from mock import Mock
 
-import beer_garden.config as config
 import beer_garden.garden
 import beer_garden.router
-
-
-@pytest.fixture(autouse=True)
-def setup():
-    beer_garden.router.gardens = {}
-
-    conf = Box(default_box=True)
-    conf.garden.name = "parent"
-    config.assign(conf, force=True)
+from beer_garden.errors import UnknownGardenException
+from beer_garden.router import _determine_target
 
 
 @pytest.fixture
-def p_sys_1():
-    return System(namespace="p", name="sys", version="1")
+def op():
+    return Operation(source_garden_name="parent")
 
 
-@pytest.fixture
-def p_sys_2():
-    return System(namespace="p", name="sys", version="2")
+class TestDetermineTarget:
+    def test_neither(self, monkeypatch, op):
+        monkeypatch.setattr(
+            beer_garden.router, "_target_from_type", Mock(return_value=None)
+        )
+        with pytest.raises(UnknownGardenException):
+            _determine_target(op)
 
+    def test_target_from_op(self, monkeypatch, op):
+        monkeypatch.setattr(
+            beer_garden.router, "_target_from_type", Mock(return_value=None)
+        )
+        op.target_garden_name = "parent"
 
-@pytest.fixture
-def c_sys_1():
-    return System(namespace="c", name="sys", version="1")
+        assert _determine_target(op) == "parent"
 
+    def test_target_from_type(self, monkeypatch, op):
+        monkeypatch.setattr(
+            beer_garden.router, "_target_from_type", Mock(return_value="parent")
+        )
 
-@pytest.fixture
-def c_sys_2():
-    return System(namespace="c", name="sys", version="2")
+        assert _determine_target(op) == "parent"
 
+    def test_mismatch(self, monkeypatch, op):
+        monkeypatch.setattr(
+            beer_garden.router, "_target_from_type", Mock(return_value="child")
+        )
+        op.target_garden_name = "parent"
 
-@pytest.fixture
-def l_garden():
-    return Garden(
-        name="parent",
-        connection_type="local",
-        systems=[]
-        # name="parent", connection_type="local", systems=[str(p_sys_1), str(p_sys_2)]
-    )
-
-
-@pytest.fixture
-def p_garden(p_sys_1, p_sys_2):
-    return Garden(name="parent", connection_type="local", systems=[p_sys_1, p_sys_2])
-
-
-@pytest.fixture
-def c_garden(c_sys_1, c_sys_2):
-    return Garden(name="child", connection_type="http", systems=[c_sys_1, c_sys_2])
-
-
-@pytest.fixture
-def get_gardens_mock(monkeypatch):
-    mock = Mock(return_value=[])
-    monkeypatch.setattr(beer_garden.router, "get_gardens", mock)
-    return mock
-
-
-@pytest.fixture
-def get_local_garden_mock(monkeypatch):
-    mock = Mock(return_value=[])
-    monkeypatch.setattr(beer_garden.router, "local_garden", mock)
-    return mock
-
-
-@pytest.mark.skip
-class TestSetupRouting:
-    def test_all(self, get_gardens_mock, get_local_garden_mock, p_garden, c_garden):
-        get_gardens_mock.return_value = [c_garden]
-        get_local_garden_mock.return_value = p_garden
-
-        beer_garden.router.setup_routing()
-
-        assert str(c_garden) in beer_garden.router.gardens
-        assert str(p_garden) in beer_garden.router.gardens
-
-        assert_garden_equal(c_garden, beer_garden.router.gardens[str(c_garden)])
-        assert_garden_equal(p_garden, beer_garden.router.gardens[str(p_garden)])
-
-    def test_ignore_local(
-        self, get_gardens_mock, get_local_garden_mock, l_garden, c_garden
-    ):
-        """Systems in p_garden should be ignored"""
-        get_gardens_mock.return_value = [c_garden]
-        get_local_garden_mock.return_value = l_garden
-
-        beer_garden.router.setup_routing()
-
-        assert str(c_garden) in beer_garden.router.gardens
-        assert str(l_garden) in beer_garden.router.gardens
-
-        assert_garden_equal(c_garden, beer_garden.router.gardens[str(c_garden)])
-
-        # "l_garden" is the local garden so it shouldn't have any systems
-        assert not beer_garden.router.gardens[str(l_garden)].systems
+        assert _determine_target(op) == "child"


### PR DESCRIPTION
This fixes #1076, multi-level garden routing.

Prior to this PR the routing process would not attempt to determine the target garden for an operation if one already existed on the model. Due to how we handle garden visibility, this meant that requests would never be able to be routed more than one garden away.

This PR tweaks that process to always attempt to determine the target garden.

## Test Instructions
- Set up a parent -> child -> grandchild garden structure
- From the parent, attempt to create a request for a system on the grandchild garden. It should work as normal