### PR TITLE
#940 - Change garden routing to allow any garden name

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -199,7 +199,7 @@ def _setup_tornado_app() -> Application:
         (rf"{prefix}api/v1/tokens/(\w+)/?", v1.token.TokenAPI),
         (rf"{prefix}api/v1/jobs/(\w+)/?", v1.job.JobAPI),
         (rf"{prefix}api/v1/logging/?", v1.logging.LoggingAPI),
-        (rf"{prefix}api/v1/gardens/([\w%]+)/?", v1.garden.GardenAPI),
+        (rf"{prefix}api/v1/gardens/(.*)/?", v1.garden.GardenAPI),
         # Beta
         (rf"{prefix}api/vbeta/events/?", vbeta.event.EventPublisherAPI),
         (rf"{prefix}api/vbeta/runners/?", vbeta.runner.RunnerListAPI),

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -60,7 +60,7 @@ export default function adminGardenController(
     $scope.create_garden_popover_message = null
     $scope.create_garden_popover_active = false
     for (let i = 0; i < $scope.data.length; i++) {
-        if ($scope.data[i].name == $scope.create_garden_name) {
+        if ($scope.data[i].name == encodeURIComponent($scope.create_garden_name)) {
             $scope.is_unique_garden_name = false;
             $scope.create_garden_popover_message = "Garden name is already in use."
             break;
@@ -68,12 +68,16 @@ export default function adminGardenController(
     }
   }
 
+  $scope.decode = function(str) {
+    return decodeURIComponent(str);
+  }
+
   $scope.createGarden = function() {
     if ($scope.is_unique_garden_name) {
         GardenService.createGarden({"name":encodeURIComponent($scope.create_garden_name), "status":"NOT_CONFIGURED"});
         $state.go('base.garden_view',
               {
-                'name': $scope.create_garden_name,
+                'name': encodeURIComponent($scope.create_garden_name),
               }
             );
     }

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -70,7 +70,7 @@ export default function adminGardenController(
 
   $scope.createGarden = function() {
     if ($scope.is_unique_garden_name) {
-        GardenService.createGarden({"name":$scope.create_garden_name, "status":"NOT_CONFIGURED"});
+        GardenService.createGarden({"name":encodeURIComponent($scope.create_garden_name), "status":"NOT_CONFIGURED"});
         $state.go('base.garden_view',
               {
                 'name': $scope.create_garden_name,

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -15,7 +15,7 @@ export default function gardenService($http) {
   }
 
   GardenService.getGarden = function(name){
-    return $http.get('api/v1/gardens/' + name);
+    return $http.get('api/v1/gardens/' + encodeURIComponent(name));
   }
 
   GardenService.createGarden = function(garden){
@@ -23,7 +23,7 @@ export default function gardenService($http) {
   }
 
   GardenService.updateGardenConfig = function(garden){
-    return $http.patch('api/v1/gardens/' + garden.name, {operation: 'config', path: '', value: garden});
+    return $http.patch('api/v1/gardens/' + encodeURIComponent(garden.name), {operation: 'config', path: '', value: garden});
   }
 
   GardenService.syncGardens = function(){
@@ -31,11 +31,11 @@ export default function gardenService($http) {
   }
 
   GardenService.syncGarden = function(name){
-    return $http.patch('api/v1/gardens/' + name, {operation: 'sync', path: '', value: ''})
+    return $http.patch('api/v1/gardens/' + encodeURIComponent(name), {operation: 'sync', path: '', value: ''})
   }
 
   GardenService.deleteGarden = function(name){
-    return $http.delete('api/v1/gardens/' + name);
+    return $http.delete('api/v1/gardens/' + encodeURIComponent(name));
   }
 
   GardenService.serverModelToForm = function(model){

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -68,14 +68,14 @@
 
         <button type="button" class="btn btn-primary btn-lg btn-block"
                 ng-click="editGarden(garden)" style="...">
-          Edit {{garden.name}} configurations
+          Edit {{decode(garden.name)}} configurations
         </button>
         <button type="button" class="btn btn-danger btn-lg btn-block"
                 ng-click="deleteGarden(garden.name)" style="..."
                 ng-show="garden.id != null && garden.connection_type != 'LOCAL'"
-                confirm="Are you sure you want to delete {{garden.name}}?
-                    This will also delete all Systems assocaited with {{garden.name}}.">
-          Delete {{garden.name}}
+                confirm="Are you sure you want to delete {{decode(garden.name)}}?
+                    This will also delete all Systems assocaited with {{decode(garden.name)}}.">
+          Delete {{decode(garden.name)}}
         </button>
       </div>
     </div>

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -42,7 +42,7 @@
   <div ng-repeat="garden in data" class="container-item panel panel-default">
     <div class="panel-heading">
       <h3>
-        <span>{{garden.name}}</span>
+        <span>{{decode(garden.name)}}</span>
         <span ng-show="garden.id == null || garden.connection_type == 'LOCAL'">(LOCAL)</span>
         <span ng-show="garden.id != null && garden.connection_type != 'LOCAL'">(REMOTE)</span>
       </h3>


### PR DESCRIPTION
Closes #940 

This PR changes the routing regex for tornado to be less restrictive, allowing all characters. A further PR will be created to always urlencode garden names before routing so that users won't be able to create invalid garden names.

One minor issue is that the `(.*)` group will capture the ending slash of a url, if present. For example: 
In `.../api/v1/gardens/garden-name/`, the captured group will be `garden-name/` instead of `garden-name`.

This hasn't affected my ability to access the garden in any way, but I can't figure out what that group is used for. If it's an issue, maybe `([^/]+)/?` will be a better regex here, to include all characters except for `/`.

To test: 
- Create a garden with special characters in the name, such as `-`, `&`, or `%`.