### PR TITLE
Updating job counts no longer revives a removed job

### DIFF
--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -463,6 +463,8 @@ def run_job(job_id, request_template, **kwargs):
         return
 
     try:
+        logger.debug(f"About to execute {db_job!r}")
+
         request = beer_garden.router.route(
             Operation(
                 operation_type="REQUEST_CREATE",
@@ -480,12 +482,15 @@ def run_job(job_id, request_template, **kwargs):
 
         request = get_request(request.id)
 
+        updates = {}
         if request.status == "ERROR":
-            db_job.error_count += 1
+            updates["inc__error_count"] = 1
+            logger.debug(f"{db_job!r} request completed with ERROR status")
         elif request.status == "SUCCESS":
-            db_job.success_count += 1
+            logger.debug(f"{db_job!r} request completed with SUCCESS status")
+            updates["inc__success_count"] = 1
 
-        db.update(db_job)
+        db.modify(db_job, **updates)
     except Exception as ex:
         logger.exception(f"Error executing {db_job}: {ex}")
 


### PR DESCRIPTION
Fixes #1081, zombie jobs.

Updating the job count in the database after an execution was recreating the job if it was removed. This change uses the `modify` api to only update the necessary field.

This PR doesn't modify or add any tests as the scheduler doesn't currently have any. I'd like to merge this anyway and attempt a refactor + test coverage effort for the scheduler module separately.

## Test Instructions
To see this bug in action create a schedule job for a request that takes a while to complete. I used the `sleep` command, 60 seconds. Remove the job when you see the log message that the plugin has just started to sleep. You should be able to view the scheduler page and see the job isn't there. Then wait for the "I'm awake" log message - at that point refresh the scheduler page and you should see the job has returned.

Using this branch you should be able to do that again, only now the job won't be back.