### PR TITLE
Issue/1085

### DIFF
--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -73,11 +73,7 @@ export default function commandViewController(
       };
     }
 
-    return RequestService.createRequestWait(request).then(
-      function(response) {
-        return response.data;
-      }
-    );
+    return RequestService.createRequestWait(request);
   };
 
   $scope.checkInstance = function() {

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -41,8 +41,7 @@ export default function requestService($q, $http, $timeout) {
                 checkForCompletion(id);
               }, 500);
             } else {
-              response.data = JSON.parse(response.data.output);
-              deferred.resolve(response);
+              deferred.resolve(response.data);
             }
         });
       };

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -50,6 +50,9 @@ export default function requestService($q, $http, $timeout) {
       service.createRequest(request, options).then(
         (response) => {
           checkForCompletion(response.data.id);
+        },
+        (response) => {
+          deferred.reject(response.data);
         }
       );
 


### PR DESCRIPTION
Fixes #1085. Fixes the error indicator when a command-based choices request fails.

Depends on https://github.com/beer-garden/angular-schema-form-addons/pull/30.

## Test instructions
Run the `dynamic` plugin, and open the UI page to execute the `say_specific_from_command_fully_specified` command. This command's choices parameter is targeting the `default` instance, which no longer exists. So there are no choices available for the `message` parameter but also no indication that anything has gone wrong. If you check the browser console you can see an error, which is another indication that something isn't working correctly.

Using this branch and the linked PR, go to the page again. There should now be a warning indicator next to the `message` parameter title.