### PR TITLE
Waiting for a request to complete will now time out

### DIFF
--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -73,7 +73,7 @@ export default function commandViewController(
       };
     }
 
-    return RequestService.createRequestWait(request);
+    return RequestService.createRequest(request, true);
   };
 
   $scope.checkInstance = function() {


### PR DESCRIPTION
Fixes #1087 - command-based choices will time out if the request takes longer than 30 seconds to complete.

## Test Instructions

1. Modify the `dynamic` plugin `get_choices` function to sleep for 31 seconds
2. Navigate to the command page for `say_specific_from_command` in a browser
3. Wait 30 seconds. An indication should appear with a tooltip indicating a timeout expired.