### PR TITLE
Adding css rule to help with hiding animated elements

### DIFF
--- a/src/ui/src/styles/custom.css
+++ b/src/ui/src/styles/custom.css
@@ -293,3 +293,6 @@ table.dataTable{
 #loading i{
   margin-top: 10px;
 }
+
+/* Allows animated elements to be hidden immediately */
+.animate-fix.ng-animate { -webkit-animation: none 0s; }


### PR DESCRIPTION
Part of #393.

By default AngularJS will wait for an element's animation to complete before hiding it. This can cause the choices loading indicator to hang around for a couple extra seconds. This css rule "fixes" that.