### PR TITLE
Fix double URL encoding on UI

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/garden.py
+++ b/src/app/beer_garden/api/http/handlers/v1/garden.py
@@ -4,6 +4,7 @@ from beer_garden.api.http.base_handler import BaseHandler
 from brewtils.errors import ModelValidationError
 from brewtils.models import Operation
 from brewtils.schema_parser import SchemaParser
+from requests.utils import unquote
 
 
 class GardenAPI(BaseHandler):
@@ -32,7 +33,7 @@ class GardenAPI(BaseHandler):
         """
 
         response = await self.client(
-            Operation(operation_type="GARDEN_READ", args=[garden_name])
+            Operation(operation_type="GARDEN_READ", args=[unquote(garden_name)])
         )
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")
@@ -59,7 +60,9 @@ class GardenAPI(BaseHandler):
         tags:
           - Garden
         """
-        await self.client(Operation(operation_type="GARDEN_DELETE", args=[garden_name]))
+        await self.client(
+            Operation(operation_type="GARDEN_DELETE", args=[unquote(garden_name)])
+        )
 
         self.set_status(204)
 
@@ -119,14 +122,14 @@ class GardenAPI(BaseHandler):
                 response = await self.client(
                     Operation(
                         operation_type="GARDEN_UPDATE_STATUS",
-                        args=[garden_name, operation.upper()],
+                        args=[unquote(garden_name), operation.upper()],
                     )
                 )
             elif operation == "heartbeat":
                 response = await self.client(
                     Operation(
                         operation_type="GARDEN_UPDATE_STATUS",
-                        args=[garden_name, "RUNNING"],
+                        args=[unquote(garden_name), "RUNNING"],
                     )
                 )
             elif operation == "config":
@@ -140,7 +143,7 @@ class GardenAPI(BaseHandler):
                 response = await self.client(
                     Operation(
                         operation_type="GARDEN_SYNC",
-                        kwargs={"sync_target": garden_name},
+                        kwargs={"sync_target": unquote(garden_name)},
                     )
                 )
 

--- a/src/app/beer_garden/api/http/handlers/v1/garden.py
+++ b/src/app/beer_garden/api/http/handlers/v1/garden.py
@@ -59,9 +59,7 @@ class GardenAPI(BaseHandler):
         tags:
           - Garden
         """
-        await self.client(
-            Operation(operation_type="GARDEN_DELETE", args=[garden_name])
-        )
+        await self.client(Operation(operation_type="GARDEN_DELETE", args=[garden_name]))
 
         self.set_status(204)
 

--- a/src/app/beer_garden/api/http/handlers/v1/garden.py
+++ b/src/app/beer_garden/api/http/handlers/v1/garden.py
@@ -4,7 +4,6 @@ from beer_garden.api.http.base_handler import BaseHandler
 from brewtils.errors import ModelValidationError
 from brewtils.models import Operation
 from brewtils.schema_parser import SchemaParser
-from requests.utils import unquote
 
 
 class GardenAPI(BaseHandler):
@@ -33,7 +32,7 @@ class GardenAPI(BaseHandler):
         """
 
         response = await self.client(
-            Operation(operation_type="GARDEN_READ", args=[unquote(garden_name)])
+            Operation(operation_type="GARDEN_READ", args=[garden_name])
         )
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")
@@ -61,7 +60,7 @@ class GardenAPI(BaseHandler):
           - Garden
         """
         await self.client(
-            Operation(operation_type="GARDEN_DELETE", args=[unquote(garden_name)])
+            Operation(operation_type="GARDEN_DELETE", args=[garden_name])
         )
 
         self.set_status(204)
@@ -122,14 +121,14 @@ class GardenAPI(BaseHandler):
                 response = await self.client(
                     Operation(
                         operation_type="GARDEN_UPDATE_STATUS",
-                        args=[unquote(garden_name), operation.upper()],
+                        args=[garden_name, operation.upper()],
                     )
                 )
             elif operation == "heartbeat":
                 response = await self.client(
                     Operation(
                         operation_type="GARDEN_UPDATE_STATUS",
-                        args=[unquote(garden_name), "RUNNING"],
+                        args=[garden_name, "RUNNING"],
                     )
                 )
             elif operation == "config":
@@ -143,7 +142,7 @@ class GardenAPI(BaseHandler):
                 response = await self.client(
                     Operation(
                         operation_type="GARDEN_SYNC",
-                        kwargs={"sync_target": unquote(garden_name)},
+                        kwargs={"sync_target": garden_name},
                     )
                 )
 

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -60,7 +60,7 @@ export default function adminGardenController(
     $scope.create_garden_popover_message = null
     $scope.create_garden_popover_active = false
     for (let i = 0; i < $scope.data.length; i++) {
-        if ($scope.data[i].name == encodeURIComponent($scope.create_garden_name)) {
+        if ($scope.data[i].name == $scope.create_garden_name) {
             $scope.is_unique_garden_name = false;
             $scope.create_garden_popover_message = "Garden name is already in use."
             break;
@@ -68,16 +68,12 @@ export default function adminGardenController(
     }
   }
 
-  $scope.decode = function(str) {
-    return decodeURIComponent(str);
-  }
-
   $scope.createGarden = function() {
     if ($scope.is_unique_garden_name) {
-        GardenService.createGarden({"name":encodeURIComponent($scope.create_garden_name), "status":"NOT_CONFIGURED"});
+        GardenService.createGarden({"name":$scope.create_garden_name, "status":"NOT_CONFIGURED"});
         $state.go('base.garden_view',
               {
-                'name': encodeURIComponent($scope.create_garden_name),
+                'name': $scope.create_garden_name,
               }
             );
     }

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -42,7 +42,7 @@
   <div ng-repeat="garden in data" class="container-item panel panel-default">
     <div class="panel-heading">
       <h3>
-        <span>{{decode(garden.name)}}</span>
+        <span>{{garden.name}}</span>
         <span ng-show="garden.id == null || garden.connection_type == 'LOCAL'">(LOCAL)</span>
         <span ng-show="garden.id != null && garden.connection_type != 'LOCAL'">(REMOTE)</span>
       </h3>
@@ -68,14 +68,14 @@
 
         <button type="button" class="btn btn-primary btn-lg btn-block"
                 ng-click="editGarden(garden)" style="...">
-          Edit {{decode(garden.name)}} configurations
+          Edit {{garden.name}} configurations
         </button>
         <button type="button" class="btn btn-danger btn-lg btn-block"
                 ng-click="deleteGarden(garden.name)" style="..."
                 ng-show="garden.id != null && garden.connection_type != 'LOCAL'"
-                confirm="Are you sure you want to delete {{decode(garden.name)}}?
-                    This will also delete all Systems assocaited with {{decode(garden.name)}}.">
-          Delete {{decode(garden.name)}}
+                confirm="Are you sure you want to delete {{garden.name}}?
+                    This will also delete all Systems assocaited with {{garden.name}}.">
+          Delete {{garden.name}}
         </button>
       </div>
     </div>


### PR DESCRIPTION
Closes #1100

This PR also removes all URL decoding from the UI - what the user sees as a garden name should be what's read directly from Beergarden's DB.


## To Test
- Create gardens in the Beergarden UI with special characters (`@ # $ % ^ & *`)
- Ensure that no garden names double-encode
- Ensure that the URL for the 'edit config' page of a garden is properly URLencoded

Note that the issue linked to this PR says:

>Somewhat related, I also notice that the URL that you get directed to after creating a garden ends up being double-encoded. Meaning that if I create a garden named "g@rden", I should be redirected to:
>`/admin/gardens/g%40rden/`

... although, this PR does not encode the `@` symbol. This doesn't seem to cause an issue with routing, however.