### PR TITLE
#1104 - Explicitly write default Garden configs upon Garden creation

### DIFF
--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -15,6 +15,7 @@ from typing import List
 
 from brewtils.errors import PluginError
 from brewtils.models import Event, Events, Garden, Operation, System
+from brewtils.specification import _CONNECTION_SPEC
 from mongoengine import DoesNotExist
 
 import beer_garden.config as config
@@ -22,6 +23,8 @@ import beer_garden.db.api as db
 from beer_garden.events import publish, publish_event
 from beer_garden.namespace import get_namespaces
 from beer_garden.systems import get_systems, remove_system
+
+from yapconf import YapconfSpec
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +180,34 @@ def create_garden(garden: Garden) -> Garden:
         The created Garden
 
     """
+    # Explicitly load default config options into garden params
+    if garden.connection_params is None:
+        garden.connection_params = {}
+
+    connection_params = getattr(garden, "connection_params", {})
+    # bg_host is required by brewtils garden spec
+    connection_params.setdefault('bg_host', '')
+
+    spec = YapconfSpec(_CONNECTION_SPEC)
+    connection_params = spec.load_config(connection_params)
+
+    key_dict = {key: key for key, _ in connection_params.items()}
+    config_map = {
+        "bg_host": "host",
+        "bg_port": "port",
+        "ssl_enabled": "ssl",
+        "bg_url_prefix": "url_prefix",
+        "ca_cert": "ca_cert",
+        "ca_verify": "ca_verify",
+        "client_cert": "client_cert",
+    }
+    key_dict.update(config_map)
+    garden.connection_params['http'] = {
+        key_dict[key]: value for key, value in connection_params.items()
+    }
+    for key in config_map:
+        garden.connection_params.pop(key, None)
+
     garden.status_info["heartbeat"] = datetime.utcnow()
 
     return db.create(garden)

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -197,10 +197,10 @@ def create_garden(garden: Garden) -> Garden:
 
     if garden.connection_params is None:
         garden.connection_params = {}
-    garden.connection_params.setdefault('http', {})
+    garden.connection_params.setdefault("http", {})
 
     for key in config_map:
-        garden.connection_params['http'].setdefault(config_map[key], defaults[key])
+        garden.connection_params["http"].setdefault(config_map[key], defaults[key])
 
     garden.status_info["heartbeat"] = datetime.utcnow()
 

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -186,7 +186,7 @@ def create_garden(garden: Garden) -> Garden:
 
     connection_params = getattr(garden, "connection_params", {})
     # bg_host is required by brewtils garden spec
-    connection_params.setdefault('bg_host', '')
+    connection_params.setdefault("bg_host", "")
 
     spec = YapconfSpec(_CONNECTION_SPEC)
     connection_params = spec.load_config(connection_params)
@@ -202,7 +202,7 @@ def create_garden(garden: Garden) -> Garden:
         "client_cert": "client_cert",
     }
     key_dict.update(config_map)
-    garden.connection_params['http'] = {
+    garden.connection_params["http"] = {
         key_dict[key]: value for key, value in connection_params.items()
     }
     for key in config_map:

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -181,17 +181,10 @@ def create_garden(garden: Garden) -> Garden:
 
     """
     # Explicitly load default config options into garden params
-    if garden.connection_params is None:
-        garden.connection_params = {}
-
-    connection_params = getattr(garden, "connection_params", {})
-    # bg_host is required by brewtils garden spec
-    connection_params.setdefault("bg_host", "")
-
     spec = YapconfSpec(_CONNECTION_SPEC)
-    connection_params = spec.load_config(connection_params)
+    # bg_host is required to load brewtils garden spec
+    defaults = spec.load_config({"bg_host": ""})
 
-    key_dict = {key: key for key, _ in connection_params.items()}
     config_map = {
         "bg_host": "host",
         "bg_port": "port",
@@ -201,12 +194,13 @@ def create_garden(garden: Garden) -> Garden:
         "ca_verify": "ca_verify",
         "client_cert": "client_cert",
     }
-    key_dict.update(config_map)
-    garden.connection_params["http"] = {
-        key_dict[key]: value for key, value in connection_params.items()
-    }
+
+    if garden.connection_params is None:
+        garden.connection_params = {}
+    garden.connection_params.setdefault('http', {})
+
     for key in config_map:
-        garden.connection_params.pop(key, None)
+        garden.connection_params['http'].setdefault(config_map[key], defaults[key])
 
     garden.status_info["heartbeat"] = datetime.utcnow()
 

--- a/src/app/test/garden_test.py
+++ b/src/app/test/garden_test.py
@@ -2,9 +2,7 @@
 import pytest
 from brewtils.models import Garden as BrewtilsGarden
 from brewtils.models import System as BrewtilsSystem
-from brewtils.specification import _CONNECTION_SPEC
 from mongoengine import DoesNotExist, connect
-from yapconf import YapconfSpec
 
 from beer_garden import config
 from beer_garden.db.mongo.models import Garden, System

--- a/src/app/test/garden_test.py
+++ b/src/app/test/garden_test.py
@@ -136,7 +136,7 @@ class TestGarden:
             "client_cert": "/def",
         }
 
-        bg_garden.connection_params = {'http': http_params}
+        bg_garden.connection_params = {"http": http_params}
 
         garden = create_garden(bg_garden)
         for key in http_params:
@@ -161,4 +161,4 @@ class TestGarden:
 
         garden = create_garden(bg_garden)
         for key in config_map:
-            assert garden.connection_params['http'][config_map[key]] == defaults[key]
+            assert garden.connection_params["http"][config_map[key]] == defaults[key]

--- a/src/app/test/garden_test.py
+++ b/src/app/test/garden_test.py
@@ -138,7 +138,6 @@ class TestGarden:
 
         bg_garden.connection_params.update(connection_params)
 
-        # can be fixture-ized?
         correct_config = {
             "host": "localhost",
             "port": 1337,
@@ -151,21 +150,14 @@ class TestGarden:
 
         garden = create_garden(bg_garden)
         for key in correct_config:
-            assert garden.connection_params['http'][key] == correct_config[key]
+            assert garden.connection_params["http"][key] == correct_config[key]
 
         for key in connection_params:
-            assert not key in garden.connection_params
+            assert key not in garden.connection_params
 
     def test_create_garden_with_empty_connection_params(self, bg_garden):
         """create_garden should explicitly load default HTTP configs from brewtils when empty"""
 
-        bg_garden.connection_params = {}
-
-        # bg_host is required by brewtils spec and must be passed to load_config
-        spec = YapconfSpec(_CONNECTION_SPEC)
-        defaults = spec.load_config({'bg_host': ''})
-
-        # can be fixture-ized?
         correct_config = {
             "host": "",
             "port": 2337,
@@ -178,6 +170,6 @@ class TestGarden:
 
         garden = create_garden(bg_garden)
         for key in correct_config:
-            assert garden.connection_params['http'][key] == correct_config[key]
+            assert garden.connection_params["http"][key] == correct_config[key]
 
-        assert not 'bg_host' in garden.connection_params
+        assert "bg_host" not in garden.connection_params

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -54,7 +54,7 @@ export default function gardenService($http) {
           }
           else {
             // Recursively remove null/empty values from json payload
-            parameter_value = (function filter(obj) {
+            var parameter_value = (function filter(obj) {
               Object.entries(obj).forEach(([key, val]) =>
                 (val && typeof val === 'object') && filter(val) ||
                 (val === null || val === "") && delete obj[key]

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -53,7 +53,16 @@ export default function gardenService($http) {
             values[parameter] = stomp_headers;
           }
           else {
-            values[parameter] = model['connection_params'][parameter];
+            // Recursively remove null/empty values from json payload
+            parameter_value = (function filter(obj) {
+              Object.entries(obj).forEach(([key, val]) =>
+                (val && typeof val === 'object') && filter(val) ||
+                (val === null || val === "") && delete obj[key]
+              );
+            return obj;
+            })(model.connection_params[parameter]);
+
+            values[parameter] = parameter_value;
           }
         }
     }


### PR DESCRIPTION
Closes #1104 

The idea behind this change is to use Yapconf to specify default connection parameters for each newly created garden, then overwrite these defaults with the user-specified config.

Worth noting is the difference in specification between `_ENTRY_SPEC` in `config.py` and the form created for the UI in `garden_service.js`. As far as I understand, these should match each other, so I changed the UI end to reflect how `_ENTRY_SPEC` looks. 

## To Test
- Create a new garden in the UI
- Ensure Garden edit page is populated with default values (defined in `config.py`)
- Create a new garden using the API, specifying at least one config option under the garden's `connection_params` (e.g. specify a non-default port).
- Ensure the new garden reflects your changes in the Garden edit page.
