### PR TITLE
#1092 - Store local garden info in the database

### DIFF
--- a/src/app/beer_garden/db/mongo/api.py
+++ b/src/app/beer_garden/db/mongo/api.py
@@ -21,6 +21,7 @@ from beer_garden.db.mongo.parser import MongoParser
 from beer_garden.db.mongo.pruner import MongoPruner
 from beer_garden.db.mongo.util import (
     check_indexes,
+    ensure_local_garden,
     ensure_model_migration,
     ensure_roles,
     ensure_users,
@@ -173,6 +174,7 @@ def initial_setup(guest_login_enabled):
     ensure_model_migration()
 
     for doc in (
+        beer_garden.db.mongo.models.Garden,
         beer_garden.db.mongo.models.Job,
         beer_garden.db.mongo.models.Request,
         beer_garden.db.mongo.models.LegacyRole,
@@ -181,6 +183,7 @@ def initial_setup(guest_login_enabled):
     ):
         check_indexes(doc)
 
+    ensure_local_garden()
     ensure_roles()
     ensure_users(guest_login_enabled)
 

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -733,7 +733,15 @@ class Garden(MongoModel, Document):
     meta = {
         "auto_create_index": False,  # We need to manage this ourselves
         "index_background": True,
-        "indexes": [{"name": "unique_index", "fields": ["name"], "unique": True}],
+        "indexes": [
+            {"name": "unique_index", "fields": ["name"], "unique": True},
+            {
+                "name": "local_unique_index",
+                "fields": ["connection_type"],
+                "unique": True,
+                "partialFilterExpression": {"connection_type": "LOCAL"},
+            },
+        ],
     }
 
     def deep_save(self):

--- a/src/app/beer_garden/db/mongo/util.py
+++ b/src/app/beer_garden/db/mongo/util.py
@@ -12,7 +12,29 @@ from mongoengine.errors import (
 )
 from passlib.apps import custom_app_context
 
+from beer_garden import config
+
 logger = logging.getLogger(__name__)
+
+
+def ensure_local_garden():
+    """Creates an entry in the database for the local garden
+
+    The local garden info is configured via the configuration file. Internally
+    however, it is better to treat local and remote gardens the same in terms of how
+    we access them, etc. For that reason, we read the garden info from the configuration
+    and create or update the Garden database entry for it.
+    """
+    from .models import Garden
+
+    try:
+        garden = Garden.objects.get(connection_type="LOCAL")
+    except DoesNotExist:
+        garden = Garden(connection_type="LOCAL", status="RUNNING")
+
+    garden.name = config.get("garden.name")
+
+    garden.save()
 
 
 def ensure_roles():

--- a/src/app/test/garden_test.py
+++ b/src/app/test/garden_test.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+import pytest
+from brewtils.models import Garden as BrewtilsGarden
+from brewtils.models import System as BrewtilsSystem
+from mongoengine import DoesNotExist, connect
+
+from beer_garden import config
+from beer_garden.db.mongo.models import Garden, System
+from beer_garden.garden import (
+    create_garden,
+    get_garden,
+    get_gardens,
+    local_garden,
+    remove_garden,
+)
+from beer_garden.systems import create_system
+
+
+@pytest.fixture(autouse=True)
+def drop():
+    Garden.drop_collection()
+    System.drop_collection()
+
+
+@pytest.fixture
+def localgarden_system():
+    yield create_system(
+        BrewtilsSystem(
+            name="localsystem", version="1.2.3", namespace="localgarden", local=True
+        )
+    )
+
+
+@pytest.fixture
+def localgarden(localgarden_system):
+    yield create_garden(
+        BrewtilsGarden(
+            name="localgarden", connection_type="LOCAL", systems=[localgarden_system]
+        )
+    )
+
+
+@pytest.fixture
+def remotegarden_system():
+    yield create_system(
+        BrewtilsSystem(
+            name="remotesystem", version="1.2.3", namespace="remotegarden", local=False
+        )
+    )
+
+
+@pytest.fixture
+def remotegarden(remotegarden_system):
+    yield create_garden(
+        BrewtilsGarden(
+            name="remotegarden", connection_type="HTTP", systems=[remotegarden_system]
+        )
+    )
+
+
+class TestGarden:
+    @classmethod
+    def setup_class(cls):
+        connect("beer_garden", host="mongomock://localhost")
+        config._CONFIG = {"garden": {"name": "localgarden"}}
+
+    def test_get_garden(self, localgarden):
+        """get_garden should allow for retrieval by name"""
+        garden = get_garden(localgarden.name)
+
+        assert type(garden) is BrewtilsGarden
+        assert garden.name == localgarden.name
+
+    def test_get_garden_raises_exception_when_not_found(self):
+        """get_garden should raise DoesNotExist if no garden is found"""
+        with pytest.raises(DoesNotExist):
+            get_garden("notagarden")
+
+    def test_get_gardens_includes_localgarden(self, localgarden, remotegarden):
+        """get_gardens should include local gardens when requested"""
+        gardens = get_gardens(include_local=True)
+
+        assert len(gardens) == 2
+        assert localgarden.name in [garden.name for garden in gardens]
+
+    def test_get_gardens_excludes_localgarden(self, localgarden, remotegarden):
+        """get_gardens should exclude local gardens when requested"""
+        gardens = get_gardens(include_local=False)
+
+        assert len(gardens) == 1
+        assert localgarden.name != gardens[0].name
+
+    def test_local_garden_returns_brewtils_model(self, localgarden):
+        """local_garden returns a brewtils Garden"""
+        garden = local_garden()
+
+        assert type(garden) is BrewtilsGarden
+
+    def test_local_garden_returns_all_systems(self, localgarden, remotegarden):
+        """local_garden returns all systems (those of the local garden and its children)
+        when requested"""
+        garden = local_garden(all_systems=True)
+
+        assert len(garden.systems) == 2
+
+    def test_local_garden_returns_local_systems(self, localgarden, remotegarden):
+        """local_garden returns local systems (those of the local garden only)
+        when requested"""
+        garden = local_garden(all_systems=False)
+
+        assert len(garden.systems) == 1
+
+    def test_remove_garden_removes_related_systems(self, localgarden, remotegarden):
+        """remove_garden should also remove any systems of the garden"""
+        remove_garden(remotegarden.name)
+
+        # using len() instead of the QuerySet count() to silence pymongo warnings
+        assert len(Garden.objects.filter(name=remotegarden.name)) == 0
+        assert len(System.objects.filter(namespace=remotegarden.name)) == 0
+
+        # confirm that systems of other gardens remain intact
+        assert len(System.objects.filter(namespace=localgarden.name)) == 1


### PR DESCRIPTION
Closes #1092
Closes #727

This takes the garden name as defined in the config file and creates a Garden entry for it in the database.  It then updates the appropriate places to pull said entry from the db when appropriate.

Things still exist in a slight in-between land in this PR, meaning there are still some distinctions between local and remote gardens that have to be accounted for.  Specifically, local gardens don't get the list of embedded System documents that remote gardens have, and instead that data is assembled in real-time when requested.  This is not ideal, but it's the easiest way to maintain compatibility as we make the incremental model changes necessary for all of the auth stuff.  There are comments in the code that explain why certain things had to hang around.

I wrote a bunch of unit tests, since there were none and I wanted some sort of sanity check that my changes weren't going to break things.  I'm open to writing more if there are any obvious gaps.

# Test Instructions
* The new unit tests I wrote ought to be passing. They should be scrutinized though for usefulness and relative completeness.
* The rest of the testing is really just firing up beer garden and making sure that your usual interactions with the local garden work as you'd expect.  The goal here is that there should be no discernible difference.