### PR TITLE
Deep copying events before sending to handlers

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -4,6 +4,7 @@ import os
 import ssl
 import types
 from typing import Optional, Tuple
+from copy import deepcopy
 
 from apispec import APISpec
 from brewtils.models import Event, Events, Principal
@@ -370,6 +371,6 @@ def _event_callback(event):
         beer_garden.requests.handle_event,
     ]:
         try:
-            handler(event)
+            handler(deepcopy(event))
         except Exception as ex:
             logger.exception(f"Error executing callback for {event!r}: {ex}")

--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -188,6 +188,6 @@ class StompManager(BaseProcessor):
             self._event_handler,
         ]:
             try:
-                handler(event)
+                handler(deepcopy(event))
             except Exception as ex:
                 logger.exception(f"Error executing callback for {event!r}: {ex}")

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from copy import deepcopy
 from brewtils.models import Event
 
 import beer_garden.config
@@ -45,6 +46,6 @@ def garden_callbacks(event: Event) -> None:
         beer_garden.local_plugins.manager.handle_event,
     ]:
         try:
-            handler(event)
+            handler(deepcopy(event))
         except Exception as ex:
             logger.exception(f"Error executing callback for {event!r}: {ex}")

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -34,7 +34,7 @@ def garden_callbacks(event: Event) -> None:
 
     # These are all the MAIN PROCESS subsystems that care about events
     for handler in [
-        #beer_garden.application.handle_event,
+        beer_garden.application.handle_event,
         beer_garden.garden.handle_event,
         beer_garden.plugin.handle_event,
         beer_garden.requests.handle_event,

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -34,7 +34,7 @@ def garden_callbacks(event: Event) -> None:
 
     # These are all the MAIN PROCESS subsystems that care about events
     for handler in [
-        beer_garden.application.handle_event,
+        #beer_garden.application.handle_event,
         beer_garden.garden.handle_event,
         beer_garden.plugin.handle_event,
         beer_garden.requests.handle_event,

--- a/src/app/beer_garden/files.py
+++ b/src/app/beer_garden/files.py
@@ -20,7 +20,6 @@ from typing import Any, Callable, Dict, List, Union
 
 import beer_garden.config as config
 import beer_garden.db.api as db
-import beer_garden.router as router
 from beer_garden.errors import NotUniqueException
 
 MAX_CHUNK_SIZE = 1024 * 1024 * 15  # 15MB
@@ -521,6 +520,8 @@ def forward_file(operation: Operation) -> None:
     """Send file data before forwarding an operation with a file parameter."""
 
     # HEADS UP - THIS IS PROBABLY BROKEN
+    # import here bypasses circular dependency
+    import beer_garden.router as router
 
     for file_id in _find_chunk_params(operation.model.parameters):
         file = check_chunks(file_id)

--- a/src/app/test/events/handlers_test.py
+++ b/src/app/test/events/handlers_test.py
@@ -1,29 +1,17 @@
 # -*- coding: utf-8 -*-
-import beer_garden.events.handlers
-
+from mock import Mock
+from beer_garden.events.handlers import garden_callbacks
 
 class TestHandlers:
     def test_garden_callbacks_no_mangle(self, monkeypatch, bg_event):
-        """garden_ballbacks should send a copy of event to handlers as to not not mangle it"""
+        """garden_ballbacks should send a copy of event to handlers as to not mangle it"""
 
         def mangle(event):
             event = "mangled"
 
-        handlers = [
-            #beer_garden.application.handle_event,
-            beer_garden.garden,
-            beer_garden.plugin,
-            beer_garden.requests,
-            beer_garden.router,
-            beer_garden.systems,
-            beer_garden.scheduler,
-            beer_garden.log,
-            beer_garden.files,
-            beer_garden.local_plugins.manager,
-        ]
-
-        for handler in handlers:
+        beer_garden.events.handlers.event_handlers = Mock()
+        for handler in beer_garden.events.handlers.event_handlers:
             monkeypatch.setattr(handler, "handle_event", mangle)
 
-        beer_garden.events.handlers.garden_callbacks(bg_event)
+        garden_callbacks(bg_event)
         assert bg_event != "mangled"

--- a/src/app/test/events/handlers_test.py
+++ b/src/app/test/events/handlers_test.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import beer_garden.events.handlers
+
+
+class TestHandlers:
+    def test_garden_callbacks_no_mangle(self, monkeypatch, bg_event):
+        """garden_ballbacks should send a copy of event to handlers as to not not mangle it"""
+
+        def mangle(event):
+            event = "mangled"
+
+        handlers = [
+            #beer_garden.application.handle_event,
+            beer_garden.garden,
+            beer_garden.plugin,
+            beer_garden.requests,
+            beer_garden.router,
+            beer_garden.systems,
+            beer_garden.scheduler,
+            beer_garden.log,
+            beer_garden.files,
+            beer_garden.local_plugins.manager,
+        ]
+
+        for handler in handlers:
+            monkeypatch.setattr(handler, "handle_event", mangle)
+
+        beer_garden.events.handlers.garden_callbacks(bg_event)
+        assert bg_event != "mangled"

--- a/src/app/test/events/handlers_test.py
+++ b/src/app/test/events/handlers_test.py
@@ -11,6 +11,7 @@ class TestHandlers:
 
         def mangle(event):
             event = "mangled"
+            return event
 
         beer_garden.application = Mock()
 

--- a/src/app/test/events/handlers_test.py
+++ b/src/app/test/events/handlers_test.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from mock import Mock
+
+import beer_garden
 from beer_garden.events.handlers import garden_callbacks
+
 
 class TestHandlers:
     def test_garden_callbacks_no_mangle(self, monkeypatch, bg_event):
@@ -9,8 +12,19 @@ class TestHandlers:
         def mangle(event):
             event = "mangled"
 
-        beer_garden.events.handlers.event_handlers = Mock()
-        for handler in beer_garden.events.handlers.event_handlers:
+        beer_garden.application = Mock()
+
+        for handler in [
+            beer_garden.garden,
+            beer_garden.plugin,
+            beer_garden.requests,
+            beer_garden.router,
+            beer_garden.systems,
+            beer_garden.scheduler,
+            beer_garden.log,
+            beer_garden.files,
+            beer_garden.local_plugins.manager,
+        ]:
             monkeypatch.setattr(handler, "handle_event", mangle)
 
         garden_callbacks(bg_event)

--- a/src/app/test/events/handlers_test.py
+++ b/src/app/test/events/handlers_test.py
@@ -10,8 +10,7 @@ class TestHandlers:
         """garden_ballbacks should send a copy of event to handlers as to not mangle it"""
 
         def mangle(event):
-            event = "mangled"
-            return event
+            event.garden = "mangled"
 
         beer_garden.application = Mock()
 
@@ -29,4 +28,4 @@ class TestHandlers:
             monkeypatch.setattr(handler, "handle_event", mangle)
 
         garden_callbacks(bg_event)
-        assert bg_event != "mangled"
+        assert bg_event.garden != "mangled"


### PR DESCRIPTION
Closes #978 

Sending references to events before sending them to handlers might mangle the event between handler calls. This PR sends a copy instead to prevent that behavior.

## To Test
Affected handlers are in the following files. Doing things in the UI that create events involving each of these modules would be sufficient testing.
```python
beer_garden.application.handle_event,
beer_garden.garden.handle_event,
beer_garden.plugin.handle_event,
beer_garden.requests.handle_event,
beer_garden.router.handle_event,
beer_garden.systems.handle_event,
beer_garden.scheduler.handle_event,
beer_garden.log.handle_event,
beer_garden.files.handle_event,
beer_garden.local_plugins.manager.handle_event
```