### PR TITLE
One line revert was not actually one line

### DIFF
--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -471,7 +471,14 @@ def _pre_route(operation: Operation) -> Operation:
             operation.model.namespace = config.get("garden.name")
 
     elif operation.operation_type == "SYSTEM_READ_ALL":
-        if operation.kwargs.get("filter_params", {}).get("namespace", "") == "":
+        # what looks like a sensible edit is to change the next line to:
+        #   operation.kwargs.get("filter_params", {}).get("namespace", "") == "":
+        # but that will break everything, as it turns out. So, unless
+        # operation.kwargs has a key called filter_params whose value is a dictionary
+        # that has a key called namespace and its value is an empty string, the follow-
+        # ing never runs. Intuition says that's not what was intended here, so
+        # TODO: look into this
+        if operation.kwargs.get("filter_params", {}).get("namespace") == "":
             operation.kwargs["filter_params"]["namespace"] = config.get("garden.name")
 
     return operation


### PR DESCRIPTION
Integration tests are repaired. Though there remains a question of whether we're actually testing the functionality that we want to see in the garden stomp tests, but that discussion can wait for another day. In any case, local and remote integration tests pass after these edits.

Fundamental problem was in what seemed to be an innocent correction to the router code, adding in a default for a dictionary's `get` call. There's a comment in `src/app/beer_garden/router.py` that warns against doing the same again. But as the comment implies, we're doing checks before any routing occurs to handle different cases, but it seems unlikely that code ever runs. So we should look into that as well (but beware the attendant *whole other cans of worms*).