### PR TITLE
#1038 - Better check for when requests need to be stored in GridFS

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -2,7 +2,6 @@
 import datetime
 import json
 import logging
-import sys
 
 import pytz
 import six

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -414,7 +414,7 @@ class Request(MongoModel, Document):
             self.parameters_gridfs = None
 
     def save(self, *args, **kwargs):
-        """Save a request, moving requests to GridFS if too big"""
+        """Save a request, moving request attributes to GridFS if too big"""
         self.updated_at = datetime.datetime.utcnow()
         # 5MB
         max_param_size = 5 * 1_000_000

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -7,6 +7,7 @@ from mock import Mock
 from mongoengine import NotUniqueError, ValidationError
 
 import beer_garden.db.api as db
+import beer_garden.db.mongo.models
 from beer_garden.api.authorization import Permissions
 from beer_garden.db.mongo.models import (
     Choices,
@@ -258,32 +259,45 @@ class TestRequest(object):
         req.output_gridfs.put = Mock()
         return req
 
-    def test_save_stores_in_gridfs_after_maxsize(self, request_model):
-        request_model.parameters = {"message": "a" * 6 * 1_000_000}
-        request_model.output = "a" * 6 * 1_000_000
+    @pytest.fixture()
+    def max_size(self, monkeypatch):
+        """mock max request size to be arbitrarily small"""
+        monkeypatch.setattr(beer_garden.db.mongo.models, "REQUEST_MAX_PARAM_SIZE", 100)
+        return beer_garden.db.mongo.models.REQUEST_MAX_PARAM_SIZE + 10
+
+    def test_save_stores_in_gridfs_after_maxsize(self, request_model, max_size):
+        request_model.parameters = {"message": "a" * max_size}
+        request_model.output = "a" * max_size
         request_model.save()
 
         request_model.parameters_gridfs.put.assert_called_once()
         request_model.output_gridfs.put.assert_called_once()
 
-    def test_save_retains_if_under_maxsize(self, request_model):
+    def test_save_retains_if_under_maxsize(self, request_model, max_size):
         request_model.save()
 
         request_model.parameters_gridfs.put.assert_not_called()
         request_model.output_gridfs.put.assert_not_called()
 
-    def test_save_retains_only_parameters(self, request_model):
-        request_model.output = "a" * 6 * 1_000_000
+    def test_save_retains_only_parameters(self, request_model, max_size):
+        request_model.output = "a" * max_size
         request_model.save()
 
         request_model.parameters_gridfs.put.assert_not_called()
         request_model.output_gridfs.put.assert_called_once()
 
-    def test_save_retains_only_output(self, request_model):
-        request_model.parameters = {"message": "a" * 6 * 1_000_000}
+    def test_save_retains_only_output(self, request_model, max_size):
+        request_model.parameters = {"message": "a" * max_size}
         request_model.save()
 
         request_model.parameters_gridfs.put.assert_called_once()
+        request_model.output_gridfs.put.assert_not_called()
+
+    def test_save_handles_bool(self, request_model, max_size):
+        request_model.parameters = {"message": True}
+        request_model.save()
+
+        request_model.parameters_gridfs.put.assert_not_called()
         request_model.output_gridfs.put.assert_not_called()
 
 


### PR DESCRIPTION
Closes #1038 

Refactors `save()` in the `Request` Mongo model to transfer the request parameters or request output to GridFS. According to #1038, setting a cap of 5MB on both of these should keep the total size of the Request below 16MB (including other request data that needs to be saved), which is Mongo's limit..

## To test
- Run the unit tests

The unit tests may get more coverage with better Mongo model fixtures, but right now there are none.