### PR TITLE
Issue/1101 - Delete stale systems when syncing child garden

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -757,62 +757,66 @@ class Garden(MongoModel, Document):
     }
 
     def deep_save(self):
-        logger = logging.getLogger(self.__class__.__name__)
-
-        # if the call to this method is on a child garden object, we ensure that
-        # when saving the systems, unknowns are deleted
         if self.connection_type != "LOCAL":
-            # import moved here to avoid a circular import loop
-            from beer_garden.systems import get_systems, remove_system
-
-            def _get_system_triple(system: System) -> Tuple[str, str, str]:
-                return (
-                    system.namespace,
-                    system.name,
-                    system.version,
-                )
-
-            our_namespaces = set(self.namespaces).union(
-                set(map(attrgetter("namespace"), self.systems))
-            )
-            # we leverage the fact that systems must be unique up to the triple of their
-            # namespaces, names and versions
-            child_systems_already_known = {
-                _get_system_triple(system): str(system.id)
-                for system in get_systems(
-                    filter_params={"local": False, "namespace__in": our_namespaces}
-                )
-            }
-
-            for system in self.systems:
-                triple = _get_system_triple(system)
-
-                if triple in child_systems_already_known:
-                    system_id_to_remove = child_systems_already_known.pop(triple)
-
-                    if system_id_to_remove != str(system.id):
-                        logger.debug(
-                            f"Removing System <{triple[0]}"
-                            f", {triple[1]}"
-                            f", {triple[2]}> with ID={system_id_to_remove}"
-                            f"; doesn't match ID={str(system.id)}"
-                            " for known system with same attributes"
-                        )
-                        remove_system(system_id=system_id_to_remove)
-
-                system.save()
-
-            # if there's anything left over, delete those too; this could occur, e.g.,
-            # if a child system deleted a particular version of a plugin and installed
-            # another version of the same plugin
-            for bad_system_id in child_systems_already_known.values():
-                logger.debug(
-                    f"Removing System with ID={str(bad_system_id)} because it "
-                    "matches no known system"
-                )
-                remove_system(system_id=bad_system_id)
+            self._update_associated_systems()
 
         self.save()
+
+    def _update_associated_systems(self):
+        """If the call to the `deep_save` method is on a child garden object, we ensure
+        that when saving the systems, unknowns are deleted."""
+        # import moved here to avoid a circular import loop
+        from beer_garden.systems import get_systems, remove_system
+
+        logger = logging.getLogger(self.__class__.__name__)
+
+        def _get_system_triple(system: System) -> Tuple[str, str, str]:
+            return (
+                system.namespace,
+                system.name,
+                system.version,
+            )
+
+        our_namespaces = set(self.namespaces).union(
+            set(map(attrgetter("namespace"), self.systems))
+        )
+        # we leverage the fact that systems must be unique up to the triple of their
+        # namespaces, names and versions
+        child_systems_already_known = {
+            _get_system_triple(system): str(system.id)
+            for system in get_systems(
+                filter_params={"local": False, "namespace__in": our_namespaces}
+            )
+        }
+
+        for system in self.systems:
+            triple = _get_system_triple(system)
+
+            if triple in child_systems_already_known:
+                system_id_to_remove = child_systems_already_known.pop(triple)
+
+                if system_id_to_remove != str(system.id):
+                    # remove the system from before this update with the same triple
+                    logger.debug(
+                        f"Removing System <{triple[0]}"
+                        f", {triple[1]}"
+                        f", {triple[2]}> with ID={system_id_to_remove}"
+                        f"; doesn't match ID={str(system.id)}"
+                        " for known system with same attributes"
+                    )
+                    remove_system(system_id=system_id_to_remove)
+
+            system.save()
+
+        # if there's anything left over, delete those too; this could occur, e.g.,
+        # if a child system deleted a particular version of a plugin and installed
+        # another version of the same plugin
+        for bad_system_id in child_systems_already_known.values():
+            logger.debug(
+                f"Removing System with ID={str(bad_system_id)} because it "
+                f"matches no known system in child garden ({self.name})"
+            )
+            remove_system(system_id=bad_system_id)
 
 
 class SystemGardenMapping(MongoModel, Document):

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -312,36 +312,8 @@ def handle_event(event):
                 except DoesNotExist:
                     existing_garden = None
 
-                foreign_systems_known_before_update = {
-                    getattr(foreign_system, "id"): foreign_system
-                    for foreign_system in get_systems(filter_params={"local": False})
-                }
-
                 for system in event.payload.systems:
-                    # we whittle down *foreign_systems_known_before_update* to be only
-                    # the systems that aren't in this event's list of systems
-                    foreign_system_id = getattr(system, "id")
-
-                    if (
-                        foreign_system_id is not None
-                        and foreign_system_id in foreign_systems_known_before_update
-                    ):
-                        foreign_systems_known_before_update.pop(foreign_system_id)
-
                     system.local = False
-
-                # now delete (some of) those systems
-                for foreign_system_id in foreign_systems_known_before_update:
-                    foreign_system = foreign_systems_known_before_update[
-                        foreign_system_id
-                    ]
-
-                    # we don't have the garden embedded in the system, so we use
-                    # the namespace as a workaround; this prevents us from incorrectly
-                    # deleting systems if there's more than one child garden
-                    if getattr(foreign_system, "namespace") == event.garden:
-                        logger.debug("Removing System with ID(%s)" % foreign_system_id)
-                        remove_system(system=foreign_system)
 
                 if existing_garden is None:
                     event.payload.connection_type = None

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -312,8 +312,36 @@ def handle_event(event):
                 except DoesNotExist:
                     existing_garden = None
 
+                foreign_systems_known_before_update = {
+                    getattr(foreign_system, "id"): foreign_system
+                    for foreign_system in get_systems(filter_params={"local": False})
+                }
+
                 for system in event.payload.systems:
+                    # we whittle down *foreign_systems_known_before_update* to be only
+                    # the systems that aren't in this event's list of systems
+                    foreign_system_id = getattr(system, "id")
+
+                    if (
+                        foreign_system_id is not None
+                        and foreign_system_id in foreign_systems_known_before_update
+                    ):
+                        foreign_systems_known_before_update.pop(foreign_system_id)
+
                     system.local = False
+
+                # now delete (some of) those systems
+                for foreign_system_id in foreign_systems_known_before_update:
+                    foreign_system = foreign_systems_known_before_update[
+                        foreign_system_id
+                    ]
+
+                    # we don't have the garden embedded in the system, so we use
+                    # the namespace as a workaround; this prevents us from incorrectly
+                    # deleting systems if there's more than one child garden
+                    if getattr(foreign_system, "namespace") == event.garden:
+                        logger.debug("Removing System with ID(%s)" % foreign_system_id)
+                        remove_system(system=foreign_system)
 
                 if existing_garden is None:
                     event.payload.connection_type = None

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -612,14 +612,14 @@ class TestGarden:
 
     @pytest.fixture
     def child_system_v1(self, child_system):
-        system = copy.deepcopy(child_system)
-        setattr(system, "version", self.v1_str)
+        system: System = copy.deepcopy(child_system)
+        system.version = self.v1_str
         return system
 
     @pytest.fixture
     def child_system_v2(self, child_system):
-        system = copy.deepcopy(child_system)
-        setattr(system, "version", self.v2_str)
+        system: System = copy.deepcopy(child_system)
+        system.version = self.v2_str
         return system
 
     @pytest.fixture
@@ -649,9 +649,13 @@ class TestGarden:
     def test_child_garden_system_update(self, child_garden, child_system_v2):
         """If the systems of a child garden are updated, the original systems are
         removed and replaced with the new systems."""
-        orig_ids = set(map(lambda x: str(getattr(x, "id")), child_garden.systems))
+        orig_ids = set(
+            map(lambda x: str(getattr(x, "id")), child_garden.systems)  # noqa: B009
+        )
         orig_versions = set(
-            map(lambda x: str(getattr(x, "version")), child_garden.systems)
+            map(
+                lambda x: str(getattr(x, "version")), child_garden.systems  # noqa: B009
+            )
         )
 
         assert self.v1_str in orig_versions and self.v2_str not in orig_versions
@@ -660,8 +664,14 @@ class TestGarden:
         child_garden.systems = [child_system_v2]
         child_garden.deep_save()
 
-        new_ids = set(map(lambda x: str(getattr(x, "id")), child_garden.systems))
-        new_vers = set(map(lambda x: str(getattr(x, "version")), child_garden.systems))
+        new_ids = set(
+            map(lambda x: str(getattr(x, "id")), child_garden.systems)  # noqa: B009
+        )
+        new_vers = set(
+            map(
+                lambda x: str(getattr(x, "version")), child_garden.systems  # noqa: B009
+            )
+        )
 
         assert self.v1_str not in new_vers and self.v2_str in new_vers
         assert new_ids.intersection(orig_ids) == set()


### PR DESCRIPTION
Closes #1101

To verify the fix for the corner case (running BG in a parent-child configuration,, taking the parent offline, changing Systems on the child, bringing the parent back up and then syncing), a straightforward way is to follow the steps in #1101 while tailing the log of the parent and then seeing that an error is no longer thrown. One could also track the entries in the database across the operations to make sure they are consistent with the actions taken and expected results. This was done with single parent and single child with each of http and stomp entrypoints and tested with multiple children and a grandchild with http. Corner case error appears to be resolved in all of these scenarios.

For the general case, two unit tests are provided to verify that any unknown Systems associated with a remote garden are removed prior to saving the garden to the database.