### PR TITLE
Make code security check compatible with PRs originating from forks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -178,7 +178,6 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
           path: ./new
 
       - name: Scan old security


### PR DESCRIPTION
This should fix the code security check that runs as part of the PR workflow so that it works with PRs based on a forked repo.