### PR TITLE
1132 - Add status_updated_at field to request model

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -109,6 +109,10 @@ class MongoModel:
     def pre_serialize(self):
         pass
 
+    @property
+    def changed_fields(self):
+        return getattr(self, "_changed_fields", [])
+
 
 # MongoEngine needs all EmbeddedDocuments to be defined before any Documents that
 # reference them. So Parameter must be defined before Command, and choices should be
@@ -312,6 +316,7 @@ class Request(MongoModel, Document):
     command_type = StringField(choices=BrewtilsCommand.COMMAND_TYPES)
     created_at = DateTimeField(default=datetime.datetime.utcnow, required=True)
     updated_at = DateTimeField(default=None, required=True)
+    status_updated_at = DateTimeField(default=datetime.datetime.utcnow, required=True)
     error_class = StringField(required=False)
     has_parent = BooleanField(required=False)
     hidden = BooleanField(required=False)
@@ -331,6 +336,7 @@ class Request(MongoModel, Document):
             {"name": "status_index", "fields": ["status"]},
             {"name": "created_at_index", "fields": ["created_at"]},
             {"name": "updated_at_index", "fields": ["updated_at"]},
+            {"name": "status_updated_at_index", "fields": ["status_updated_at"]},
             {"name": "comment_index", "fields": ["comment"]},
             {"name": "parent_ref_index", "fields": ["parent"]},
             {"name": "parent_index", "fields": ["has_parent"]},
@@ -474,12 +480,16 @@ class Request(MongoModel, Document):
                 f"consistent with has_parent value of {self.has_parent}"
             )
 
+        if "status" in self.changed_fields:
+            self.status_updated_at = datetime.datetime.utcnow()
+
     def clean_update(self):
         """Ensure that the update would not result in an illegal status transition"""
         # Get the original status
         old_status = Request.objects.get(id=self.id).status
 
         if self.status != old_status:
+            self.status_updated_at = datetime.datetime.now()
             if old_status in BrewtilsRequest.COMPLETED_STATUSES:
                 raise RequestStatusTransitionError(
                     "Status for a request cannot be updated once it has been "

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -489,7 +489,7 @@ class Request(MongoModel, Document):
         old_status = Request.objects.get(id=self.id).status
 
         if self.status != old_status:
-            self.status_updated_at = datetime.datetime.now()
+            self.status_updated_at = datetime.datetime.utcnow()
             if old_status in BrewtilsRequest.COMPLETED_STATUSES:
                 raise RequestStatusTransitionError(
                     "Status for a request cannot be updated once it has been "

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -301,6 +301,21 @@ class TestRequest(object):
         request_model.parameters_gridfs.put.assert_not_called()
         request_model.output_gridfs.put.assert_not_called()
 
+    def test_save_preserves_status_updated_at_field(self, request_model):
+        request_model.save()
+        first_time = request_model.status_updated_at
+        request_model.save()
+
+        assert first_time == request_model.status_updated_at
+
+    def test_status_changes_status_updated_at_field(self, request_model):
+        request_model.save()
+        first_time = request_model.status_updated_at
+        request_model.status = "SUCCESS"
+        request_model.save()
+
+        assert first_time != request_model.status_updated_at
+
 
 class TestSystem(object):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Requires Brewtils [#358](https://github.com/beer-garden/brewtils/pull/367)

Adds the `status_updated_at` field to the mongo model. Included is a unit test that ensures it is not changed on a `save()`.

