### PR TITLE
Remove (presumed) debugging Exception in execute_job function

### DIFF
--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -364,7 +364,6 @@ class MixedScheduler(object):
             job_id: The job id
             reset_interval: Whether to set the job's interval begin time to now
         """
-        raise Exception()
         job = db.query_unique(Job, id=job_id)
         self.add_job(
             run_job,


### PR DESCRIPTION
Somehow a `raise Exception` call in `execute_job` got left in when that code got merged.  This is just removing that so the function runs as expected.  The fact that the unit tests pass with this exception in there though is a bad sign...