### PR TITLE
#1062 - Run now button

### DIFF
--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -367,7 +367,7 @@ class MixedScheduler(object):
         job = db.query_unique(Job, id=job_id)
         self.add_job(
             run_job,
-            trigger=DateTrigger(datetime.now(), timezone="UTC"),
+            trigger=DateTrigger(datetime.utcnow(), timezone="UTC"),
             trigger_type="date",
             coalesce=job.coalesce,
             kwargs={"job_id": job.id, "request_template": job.request_template},

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1436,6 +1436,13 @@
         "angular": ">= 1.2",
         "angular-sanitize": ">= 1.2",
         "tv4": "~1.0.15"
+      },
+      "dependencies": {
+        "tv4": {
+          "version": "1.0.18",
+          "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.0.18.tgz",
+          "integrity": "sha1-c5d2nwA1jjO/Uo3FyHZMYbbegkU="
+        }
       }
     },
     "angular-schema-form-bootstrap": {
@@ -1448,6 +1455,13 @@
         "angular-sanitize": ">= 1.2",
         "angular-schema-form": "^1.0.0-alpha.4",
         "tv4": "~1.0.15"
+      },
+      "dependencies": {
+        "tv4": {
+          "version": "1.0.18",
+          "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.0.18.tgz",
+          "integrity": "sha1-c5d2nwA1jjO/Uo3FyHZMYbbegkU="
+        }
       }
     },
     "angular-strap": {
@@ -7804,9 +7818,9 @@
       "dev": true
     },
     "tv4": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.0.18.tgz",
-      "integrity": "sha1-c5d2nwA1jjO/Uo3FyHZMYbbegkU="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
     },
     "type-check": {
       "version": "0.3.2",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -40,7 +40,7 @@
     "objectpath": "^2.0.0",
     "startbootstrap-sb-admin-2": "^3.3.7",
     "swagger-ui-dist": "^3.25.0",
-    "tv4": "~1.0.15",
+    "tv4": "~1.3.0",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -118,7 +118,7 @@ import requestViewController, {
 } from "./js/controllers/request_view.js";
 import systemIndexController from "./js/controllers/system_index.js";
 import jobIndexController from "./js/controllers/job_index.js";
-import jobViewController from "./js/controllers/job_view.js";
+import {jobViewController, jobRunNowModalController} from "./js/controllers/job_view.js";
 import jobCreateSystemController from "./js/controllers/job/create_system.js";
 import jobExportController from "./js/controllers/job/export_jobs.js";
 import {
@@ -224,6 +224,7 @@ angular
   .controller("SystemIndexController", systemIndexController)
   .controller("JobIndexController", jobIndexController)
   .controller("JobViewController", jobViewController)
+  .controller("JobRunNowModalController", jobRunNowModalController)
   .controller("JobCreateSystemController", jobCreateSystemController)
   .controller("JobCreateCommandController", jobCreateCommandController)
   .controller("JobCreateRequestController", jobCreateRequestController)

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -118,7 +118,10 @@ import requestViewController, {
 } from "./js/controllers/request_view.js";
 import systemIndexController from "./js/controllers/system_index.js";
 import jobIndexController from "./js/controllers/job_index.js";
-import {jobViewController, jobRunNowModalController} from "./js/controllers/job_view.js";
+import {
+  jobViewController,
+  jobRunNowModalController,
+} from "./js/controllers/job_view.js";
 import jobCreateSystemController from "./js/controllers/job/create_system.js";
 import jobExportController from "./js/controllers/job/export_jobs.js";
 import {

--- a/src/ui/src/js/controllers/job_view.js
+++ b/src/ui/src/js/controllers/job_view.js
@@ -102,7 +102,9 @@ export function jobViewController(
 
     JobService.runAdHocJob(jobId, $scope.resetTheInterval).then(
       function (response) {
-        console.log(`Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`);
+        console.log(
+          `Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`
+        );
         $state.go("base.jobs");
       },
       function (response) {
@@ -136,7 +138,7 @@ export function jobViewController(
       let popupInstance = $uibModal.open({
         animation: true,
         template: modalTemplate,
-        controller: "JobRunNowModalController"
+        controller: "JobRunNowModalController",
       });
 
       popupInstance.result.then(
@@ -148,8 +150,8 @@ export function jobViewController(
       );
     } else {
       runAdHoc(jobId);
-    }    
-  }
+    }
+  };
 
   loadJob();
 }
@@ -167,6 +169,6 @@ export function jobRunNowModalController($scope, $uibModalInstance) {
   };
 
   $scope.cancelRunNow = function () {
-    $uibModalInstance.dismiss("cancel")
+    $uibModalInstance.dismiss("cancel");
   };
 }

--- a/src/ui/src/js/controllers/job_view.js
+++ b/src/ui/src/js/controllers/job_view.js
@@ -121,7 +121,7 @@ export function jobViewController(
    * when the BG API can make sense of a reset interval value
    */
   function isIntervalTrigger(triggerType) {
-    return true;
+    return false;
   }
 
   /*

--- a/src/ui/src/js/controllers/job_view.js
+++ b/src/ui/src/js/controllers/job_view.js
@@ -121,7 +121,7 @@ export function jobViewController(
    * when the BG API can make sense of a reset interval value
    */
   function isIntervalTrigger(triggerType) {
-    return false;
+    return true;
   }
 
   /*

--- a/src/ui/src/js/controllers/job_view.js
+++ b/src/ui/src/js/controllers/job_view.js
@@ -1,10 +1,12 @@
 import { formatDate, formatJsonDisplay } from "../services/utility_service.js";
+import modalTemplate from "../../templates/reset_interval_modal.html";
 
 jobViewController.$inject = [
   "$scope",
   "$rootScope",
   "$state",
   "$stateParams",
+  "$uibModal",
   "JobService",
 ];
 
@@ -14,13 +16,15 @@ jobViewController.$inject = [
  * @param  {Object} $rootScope    Angular's $rootScope object.
  * @param  {Object} $state        Angular's $state object.
  * @param  {Object} $stateParams  Angular's $stateParams object.
+ * @param  {Object} $uibModal     Angular UI's $uibModal object.
  * @param  {Object} JobService    Beer-Garden's job service.
  */
-export default function jobViewController(
+export function jobViewController(
   $scope,
   $rootScope,
   $state,
   $stateParams,
+  $uibModal,
   JobService
 ) {
   $scope.setWindowTitle("scheduler");
@@ -90,5 +94,79 @@ export default function jobViewController(
     loadJob();
   });
 
+  /*
+   * Execute the job service's "run ad hoc job" functionality.
+   */
+  function runAdHoc(jobId) {
+    const resettingInterval = $scope.resetTheInterval;
+
+    JobService.runAdHocJob(jobId, $scope.resetTheInterval).then(
+      function (response) {
+        console.log(`Ad hoc run of ID ${jobId}; reset interval: ${resettingInterval}`);
+        $state.go("base.jobs");
+      },
+      function (response) {
+        alert("Failure! Server returned status " + response.status);
+      }
+    );
+  }
+
+  /*
+   * This is a stub: will be
+   *
+   *   return triggerType === "interval";
+   *
+   * when the BG API can make sense of a reset interval value
+   */
+  function isIntervalTrigger(triggerType) {
+    return true;
+  }
+
+  /*
+   * Schedule a job to be run immediately.
+   */
+  $scope.runJobNow = function (jobData) {
+    $scope.resetTheInterval = false;
+
+    let theTriggerIsInterval = isIntervalTrigger(jobData["trigger_type"]);
+    let jobId = jobData["id"];
+
+    if (theTriggerIsInterval) {
+      // open modal dialog to update resetTheInterval
+      let popupInstance = $uibModal.open({
+        animation: true,
+        template: modalTemplate,
+        controller: "JobRunNowModalController"
+      });
+
+      popupInstance.result.then(
+        function (result) {
+          $scope.resetTheInterval = result;
+          runAdHoc(jobId);
+        },
+        () => console.log("Ad hoc run cancelled")
+      );
+    } else {
+      runAdHoc(jobId);
+    }    
+  }
+
   loadJob();
+}
+
+jobRunNowModalController.$inject = ["$scope", "$uibModalInstance"];
+
+/**
+ * jobRunNowModalController - Controller for the reset interval popup.
+ * @param  {Object} $scope             Angular's $scope object.
+ * @param  {Object} $uibModalInstance  Object for the modal popup window.
+ */
+export function jobRunNowModalController($scope, $uibModalInstance) {
+  $scope.setIntervalReset = function (result) {
+    $uibModalInstance.close(result);
+  };
+
+  $scope.cancelRunNow = function () {
+    $uibModalInstance.dismiss("cancel")
+  };
 }

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -178,17 +178,15 @@ export default function appRun(
         template: loginTemplate,
       });
       loginModal.result.then(
-          () => {
-            $rootScope.changeUser(TokenService.getToken());
-            location.reload();
-          },
-          _.noop // Prevents annoying console log messages
+        () => {
+          $rootScope.changeUser(TokenService.getToken());
+          location.reload();
+        },
+        _.noop // Prevents annoying console log messages
       );
-      loginModal.closed.then(
-          () => {
-            loginModal = undefined;
-          }
-      );
+      loginModal.closed.then(() => {
+        loginModal = undefined;
+      });
       loginModal.closed.then(() => {
         loginModal = undefined;
       });

--- a/src/ui/src/js/services/job_service.js
+++ b/src/ui/src/js/services/job_service.js
@@ -41,6 +41,12 @@ export default function jobService($http, NamespaceService) {
     return $http.patch("api/v1/jobs/" + id, payload);
   };
 
+  JobService.runAdHocJob = function (id, resetInterval) {
+    // `resetInterval` ignored until API understands what to
+    // do with it.
+    return $http.post(`api/v1/jobs/${id}/execute`)
+  };
+
   JobService.updateJob = function (job) {
     return JobService.patchJob(job["id"], {
       operations: [

--- a/src/ui/src/js/services/job_service.js
+++ b/src/ui/src/js/services/job_service.js
@@ -44,7 +44,7 @@ export default function jobService($http, NamespaceService) {
   JobService.runAdHocJob = function (id, resetInterval) {
     // `resetInterval` ignored until API understands what to
     // do with it.
-    return $http.post(`api/v1/jobs/${id}/execute`)
+    return $http.post(`api/v1/jobs/${id}/execute`);
   };
 
   JobService.updateJob = function (job) {

--- a/src/ui/src/partials/job_view.html
+++ b/src/ui/src/partials/job_view.html
@@ -3,27 +3,35 @@
 
   <span ng-if="responseState(response) === 'success'">
     <small>{{data.name}} - {{data.id}}</small>
-    <button type="button" class="btn btn-success pull-right"
-            ng-click="updateJob(data)">
-      Update Job
-    </button>
-    <button type="button" class="btn btn-warning pull-right"
-            ng-if="data.status === 'RUNNING'"
-            ng-click="pauseJob(data.id)">
-      Pause Job
-    </button>
-    <button type="button" class="btn btn-success pull-right"
-            ng-if="data.status === 'PAUSED'"
-            ng-click="resumeJob(data.id)">
-      Resume Job
-    </button>
-    <button type="button" class="btn btn-danger pull-right"
-            confirm="Are you sure you want to delete this job?"
-            ng-click="deleteJob(data.id)">
-      Delete Job
-    </button>
+    
   </span>
 </h1>
+<span>
+  <button type="button" class="btn btn-primary pull-right"
+          ng-click="runJobNow(data)">
+    Run Now
+  </button>
+  <button type="button" class="btn btn-danger pull-right"
+          confirm="Are you sure you want to delete this job?"
+          ng-click="deleteJob(data.id)">
+    Delete Job
+  </button>
+  <button type="button" class="btn btn-warning pull-right"
+          ng-if="data.status === 'RUNNING'"
+          ng-click="pauseJob(data.id)">
+    Pause Job
+  </button>
+  <button type="button" class="btn btn-success pull-right"
+          ng-click="updateJob(data)">
+    Update Job
+  </button>
+  <button type="button" class="btn btn-success pull-right"
+          ng-if="data.status === 'PAUSED'"
+          ng-click="resumeJob(data.id)">
+    Resume Job
+  </button>
+  
+</span>
 
 <fetch-data response="response"></fetch-data>
 

--- a/src/ui/src/templates/reset_interval_modal.html
+++ b/src/ui/src/templates/reset_interval_modal.html
@@ -4,10 +4,10 @@
        </div>
 
        <div class="modal-body">
-              This job has an interval trigger. Choose one of the buttons below to update when the <i>original job</i> should be run again:
+              This job has an interval trigger. Choose one of the buttons below to update when the jobshould be run again:
               <ul>
-                     <li>Selecting "Yes" updates the next run time of the original job based on the current time.</li>
-                     <li>Selecting "No" will keep the original job's existing next run time.</li>
+                     <li>Selecting "Yes" updates the next run time of the job based on the time right now.</li>
+                     <li>Selecting "No" will keep the job's existing next run time.</li>
                      <li>Selecting "Cancel" cancels running the job now and no changes will be made to the next run time.</li>
               </ul>
        </div>

--- a/src/ui/src/templates/reset_interval_modal.html
+++ b/src/ui/src/templates/reset_interval_modal.html
@@ -1,18 +1,30 @@
-<div class="modal-header">
-    <h4>Reset the Job Interval?</h4>
-</div>
+<div class="modal-content">
+       <div class="modal-header">
+              <h4>Reset the Job Interval?</h4>
+       </div>
 
-<div class="modal-footer">
-    <input type="button"
-           class="btn btn-primary"
-           value="Yes"
-           ng-click="setIntervalReset(true)" />
-    <input type="button"
-           class="btn btn-secondary"
-           value="No"
-           ng-click="setIntervalReset(false)" />
-    <input type="button"
-           class="btn btn-danger"
-           value="Cancel"
-           ng-click="cancelRunNow()" />
+       <div class="modal-body">
+              This job has an interval trigger. Choose one of the buttons below to update when the <i>original job</i> should be run again:
+              <ul>
+                     <li>Selecting "Yes" updates the next run time of the original job based on the current time.</li>
+                     <li>Selecting "No" will keep the original job's existing next run time.</li>
+                     <li>Selecting "Cancel" cancels running the job now and no changes will be made to the next run time.</li>
+              </ul>
+       </div>
+
+       <div class="modal-footer">
+       <input type="button"
+              class="btn btn-primary"
+              value="Yes"
+              ng-click="setIntervalReset(true)" />
+       <input type="button"
+              class="btn btn-secondary"
+              value="No"
+              ng-click="setIntervalReset(false)" />
+       <input type="button"
+              class="btn btn-danger"
+              value="Cancel"
+              ng-click="cancelRunNow()" />
+       </div>
 </div>
+       

--- a/src/ui/src/templates/reset_interval_modal.html
+++ b/src/ui/src/templates/reset_interval_modal.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+    <h4>Reset the Job Interval?</h4>
+</div>
+
+<div class="modal-footer">
+    <input type="button"
+           class="btn btn-primary"
+           value="Yes"
+           ng-click="setIntervalReset(true)" />
+    <input type="button"
+           class="btn btn-secondary"
+           value="No"
+           ng-click="setIntervalReset(false)" />
+    <input type="button"
+           class="btn btn-danger"
+           value="Cancel"
+           ng-click="cancelRunNow()" />
+</div>


### PR DESCRIPTION
Closes #1062 

#### Manual Testing
1. Schedule a job from the *Scheduler* page. It doesn't matter at this time what the trigger type of the job is.
2. From the *Request Scheduler* page, click the link for the job (i.e., the job's name ) in the *Job Name* column of the table on that page.
3. The resulting page has a *Run Now* button. Click it. Note that an information message is immediately shown in BG's logging indicating the job's been run. Note that a request with the time the button was clicked shows in the *Request* page and that the table entry reflects the correct job.
4. It's assumed that at some point in the future the "run now" API endpoint will accept a value indicating whether the interval should be reset when scheduling an ad hoc run of a job that has an interval trigger type. The code for this PR anticipates that scenario, but it is turned off by default. To exercise the functionality:
    - Temporarily change line 124 of `beer-garden/src/ui/src/js/controllers/job_view.js` from `return false;` to `return true;`. (Alternately, change the line to what the comment in that function says it should eventually be. In that case, the job must have an *interval* trigger type in order to show the popup).
    - Repeat step 3. above. Note that a console message indicating whether the interval should be reset is shown and reflects whether the *Yes* or *No* button were pushed in the resulting popup. Note that an ad hoc job is not scheduled if the *Cancel* button is chosen instead.
    - Change line 124 back.