### PR TITLE
#1187 - Improve UI handling of refresh tokens

### DIFF
--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -115,17 +115,22 @@ export default function appRun(
     // SystemService.loadSystems();
 
     $rootScope.loadUser(token).then(() => {
-      $state.reload();
       // $rootScope.$broadcast('userChange');
     });
   };
 
   $rootScope.initialLoad = function () {
     // Very first thing is to load up a token if one exists
-    const token = localStorageService.get("token", "sessionStorage");
+    const token = TokenService.getToken();
+    const refreshToken = TokenService.getRefresh();
+
     if (token) {
       TokenService.handleToken(token);
       $rootScope.changeUser(TokenService.getToken());
+    } else if (refreshToken) {
+      TokenService.doRefresh(refreshToken).then(() => {
+        $rootScope.changeUser(TokenService.getToken());
+      });
     }
 
     // Connect to the event socket
@@ -182,17 +187,15 @@ export default function appRun(
         template: loginTemplate,
       });
       loginModal.result.then(
-          () => {
-            $rootScope.changeUser(TokenService.getToken());
-            location.reload();
-          },
-          _.noop // Prevents annoying console log messages
+        () => {
+          $rootScope.changeUser(TokenService.getToken());
+          location.reload();
+        },
+        _.noop // Prevents annoying console log messages
       );
-      loginModal.closed.then(
-          () => {
-            loginModal = undefined;
-          }
-      );
+      loginModal.closed.then(() => {
+        loginModal = undefined;
+      });
       loginModal.closed.then(() => {
         loginModal = undefined;
       });

--- a/src/ui/src/js/services/token_service.js
+++ b/src/ui/src/js/services/token_service.js
@@ -11,14 +11,14 @@ tokenService.$inject = ["$http", "localStorageService"];
 export default function tokenService($http, localStorageService) {
   const service = {
     getToken: () => {
-      return localStorageService.get("token", "sessionStorage");
+      return localStorageService.get("token");
     },
     handleToken: (token) => {
-      localStorageService.set("token", token, "sessionStorage");
+      localStorageService.set("token", token);
       $http.defaults.headers.common.Authorization = "Bearer " + token;
     },
     clearToken: () => {
-      localStorageService.remove("token", "sessionStorage");
+      localStorageService.remove("token");
       $http.defaults.headers.common.Authorization = undefined;
     },
     getRefresh: () => {
@@ -55,10 +55,16 @@ export default function tokenService($http, localStorageService) {
     doRefresh: (refreshToken) => {
       return $http
         .post("/api/v1/token/refresh", { refresh: refreshToken })
-        .then((response) => {
-          service.handleRefresh(response.data.refresh);
-          service.handleToken(response.data.access);
-        });
+        .then(
+          (response) => {
+            service.handleRefresh(response.data.refresh);
+            service.handleToken(response.data.access);
+          },
+          (response) => {
+            service.clearRefresh();
+            service.clearToken();
+          }
+        );
     },
   });
 


### PR DESCRIPTION
Closes #1187

This PR attempts to fix the UI's refresh token handling.  Specifically it fixes a couple of behaviors:

* It's now possible to open new tabs or close and re-open a tab without having your session expire.
* Supplying an invalid token to the `/refresh` endpoint is handled more gracefully (shouldn't result in an unhandled rejection error in the console).

# Test Instructions
* Enable auth and login via the UI.
* Close the tab and then navigate back to beer-garden.  You should still be logged in.
* Ctrl click on something to open it in a new tab.  It should open and not prompt you to login again.  Try navigating around on the original tab, refreshing the page, etc.  You should still not be prompted to login.
* Click "Log Out" on one and then navigating around or refresh in another.  You should be prompted to login since your session has been invalidated across all tabs.