### PR TITLE
#1178 - Improve job import API validation

### DIFF
--- a/src/app/test/scheduler_test.py
+++ b/src/app/test/scheduler_test.py
@@ -1,46 +1,36 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from apscheduler.executors.pool import ThreadPoolExecutor as APThreadPoolExecutor
+from brewtils.models import IntervalTrigger
+from brewtils.models import Job as BrewtilsJob
 from brewtils.models import RequestTemplate
-from pytz import utc
-from watchdog.events import FileSystemEvent
 
-from beer_garden.scheduler import MixedScheduler
-
-
-@pytest.fixture
-def scheduler(jobstore):
-    job_stores = {"beer_garden": jobstore}
-    executors = {"default": APThreadPoolExecutor(1)}
-    job_defaults = {"coalesce": True, "max_instances": 3}
-    interval_config = {
-        "jobstores": job_stores,
-        "executors": executors,
-        "job_defaults": job_defaults,
-        "timezone": utc,
-    }
-
-    return MixedScheduler(interval_config=interval_config)
+from beer_garden.db.mongo.models import Job
+from beer_garden.scheduler import create_jobs
 
 
-@pytest.fixture
-def trigger_event():
-    return FileSystemEvent("my/test/path.txt")
+class TestScheduler:
+    @pytest.fixture(autouse=True)
+    def drop(self):
+        yield
+        Job.drop_collection()
 
+    def test_create_jobs_does_not_create_invalid_jobs(self):
+        valid_job = BrewtilsJob(
+            name="valid_job",
+            trigger_type="interval",
+            trigger=IntervalTrigger(hours=1),
+            request_template=RequestTemplate(
+                system="testsystem",
+                system_version="1.2.3",
+                instance_name="default",
+                command="testcommand",
+            ),
+        )
+        invalid_job = BrewtilsJob(name="invalid_job")
 
-@pytest.fixture
-def trigger_template():
-    request_dict = {
-        "system": "system",
-        "system_version": "1.0.0",
-        "instance_name": "default",
-        "namespace": "ns",
-        "command": "speak",
-        "command_type": "ACTION",
-        "parameters": {"message": "Hello {event/src_path}!"},
-        "comment": "hi!",
-        "metadata": {"request": "stuff"},
-        "output_type": "STRING",
-    }
-    return RequestTemplate(**request_dict)
+        results = create_jobs([valid_job, invalid_job])
+
+        assert len(results["created"]) == 1
+        assert len(results["rejected"]) == 1
+        assert len(Job.objects.all()) == 1


### PR DESCRIPTION
Closes #1178

This PR fixes the lack of validation in the job import API such that it no longer creates Job entries for definitions that fail to pass validation.

It does this largely by replacing the direct interactions with pymongo in the `create_jobs` function with a simple wrapper around the `create_job` function, which saves each entry through the mongoengine model.

# Test Instructions
* Use the import API to import the following, which includes both a valid job definition and an invalid one:
  ```json
  [
    {
      "name": "well_formed_job",
      "misfire_grace_time": 3,
      "trigger": {
        "timezone": "utc",
        "run_date": 1700000000000
      },
      "coalesce": true,
      "trigger_type": "date",
      "timeout": 30,
      "max_instances": 3,
      "request_template": {
        "metadata": {
          "request": "stuff"
        },
        "command": "speak",
        "parameters": {
          "message": "hey!"
        },
        "instance_name": "default",
        "output_type": "STRING",
        "command_type": "ACTION",
        "namespace": "ns",
        "system": "system",
        "system_version": "1.0.0",
        "comment": "hi!"
      }
    },
    {
      "name": "job_with_a_bunch_of_missing_fields"
    }
  ]
  ```
* The response should contain only a single job ID.  Note that the response format now matches what the swagger documentation suggests it's going to be.
* If you check the Jobs (Through the API, UI, or database. Whatever is easiest for you), there should be only one new Job after your import, not 2.
* If you want to sanity check, do the same test on the develop branch.  You'll end up with 2 jobs created, one of which has only the name field populated, which is what this PR is fixing.