### PR TITLE
issue #1165 adds support for bytes type in UI

### DIFF
--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -1,6 +1,7 @@
 auth:
   enabled: false
   guest_login_enabled: true
+  role_definition_file: null
   token_secret: IAMSUPERSECRET
 db:
   connection:

--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -158,14 +158,11 @@ export default function commandViewController(
     let isFormData = false;
     const fd = new FormData();
     for (const i in $scope.command.parameters) {
-      if (
-        $scope.command.parameters[i].type.toLowerCase() === 'bytes' &&
-        !isFormData
-      ) {
-        fd.append('request', JSON.stringify(newRequest));
-        isFormData = true;
-      }
-      if ($scope.command.parameters[i].type.toLowerCase() === 'bytes') {
+      if ($scope.command.parameters[i].type.toLowerCase() === "bytes") {
+        if (!isFormData) {
+          fd.append("request", JSON.stringify(newRequest));
+          isFormData = true;
+        }
         fd.append(
             $scope.command.parameters[i].key,
             document.getElementById($scope.command.parameters[i].key).files[0]

--- a/src/ui/src/js/controllers/command_view.js
+++ b/src/ui/src/js/controllers/command_view.js
@@ -155,7 +155,29 @@ export default function commandViewController(
       };
     }
 
-    RequestService.createRequest(newRequest).then(
+    let isFormData = false;
+    const fd = new FormData();
+    for (const i in $scope.command.parameters) {
+      if (
+        $scope.command.parameters[i].type.toLowerCase() === 'bytes' &&
+        !isFormData
+      ) {
+        fd.append('request', JSON.stringify(newRequest));
+        isFormData = true;
+      }
+      if ($scope.command.parameters[i].type.toLowerCase() === 'bytes') {
+        fd.append(
+            $scope.command.parameters[i].key,
+            document.getElementById($scope.command.parameters[i].key).files[0]
+        );
+      }
+    }
+
+    if (isFormData) {
+      newRequest = fd;
+    }
+
+    RequestService.createRequest(newRequest, false, isFormData).then(
       function (response) {
         $state.go("base.request", { requestId: response.data.id });
       },

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -25,8 +25,22 @@ export default function requestService($q, $http, $interval) {
   };
 
   _.assign(service, {
-    createRequest: (request, waitForCompletion) => {
-      let promise = $http.post("api/v1/requests", request);
+    createRequest: (request, waitForCompletion, isFormData) => {
+      let promise = undefined;
+      if (isFormData) {
+        promise = $http.post(
+            'api/v1/requests',
+            request,
+            {
+              withCredentials: false,
+              headers: {
+                'Content-Type': undefined,
+              },
+            }
+        );
+      } else {
+        promise = $http.post('api/v1/requests', request);
+      }
 
       if (!waitForCompletion) {
         return promise;

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -28,18 +28,13 @@ export default function requestService($q, $http, $interval) {
     createRequest: (request, waitForCompletion, isFormData) => {
       let promise = undefined;
       if (isFormData) {
-        promise = $http.post(
-            'api/v1/requests',
-            request,
-            {
-              withCredentials: false,
-              headers: {
-                'Content-Type': undefined,
-              },
-            }
-        );
+        promise = $http.post("api/v1/requests", request, {
+          headers: {
+            "Content-Type": undefined,
+          },
+        });
       } else {
-        promise = $http.post('api/v1/requests', request);
+        promise = $http.post("api/v1/requests", request);
       }
 
       if (!waitForCompletion) {


### PR DESCRIPTION
Closes: #1165 
Dependent on PRs: [angular-schema-form-addons: #39](https://github.com/beer-garden/angular-schema-form-addons/pull/39) and [angular-schema-form-builder: #26](https://github.com/beer-garden/angular-schema-form-builder/pull/26)

Adds support for bytes type in the UI.


Steps for testing

1. Clone branches [angular-schema-form-addons](https://github.com/west270/angular-schema-form-addons/tree/bg-issue/1165), and [angular-schema-form-builder](https://github.com/west270/angular-schema-form-builder/tree/bg-issue/1165). then run `npm build` on each branch.
2. In the `package.json` for the UI change the lines:
```
"@beer-garden/addons": "^3.2.0",
"@beer-garden/builder": "3.0.2",
``` 
to 
```
"@beer-garden/addons": "file:** path to angular-schema-form-addons **",
"@beer-garden/builder": "file:** path to angular-schema-form-builder **",
```

3. In beer garden ui delete your `node_modules` directory then run `npm install`
4. Lastly start the UI and go to a command that uses bytes type and try to submit a request.