### PR TITLE
#1173 - Add 'reset_interval' option to ad-hoc executions of jobs

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/job.py
+++ b/src/app/beer_garden/api/http/handlers/v1/job.py
@@ -367,7 +367,9 @@ class JobExecutionAPI(AuthorizationHandler):
         _ = self.get_or_raise(Job, JOB_CREATE, id=job_id)
 
         reset_interval = (
-            True if self.get_argument("reset_interval", "False").lower() == "true" else False
+            True 
+            if self.get_argument("reset_interval", "False").lower() == "true"
+            else False
         )
 
         try:

--- a/src/app/beer_garden/api/http/handlers/v1/job.py
+++ b/src/app/beer_garden/api/http/handlers/v1/job.py
@@ -374,9 +374,9 @@ class JobExecutionAPI(AuthorizationHandler):
             await self.client(
                 Operation(operation_type="JOB_EXECUTE", args=[job_id, reset_interval])
             )
-        except ValidationError:  # mongoengine error
+        except ValidationError:
             raise NotFoundError
-        except ModelValidationError:  # also named ValidationError, but is from brewtils...
+        except ModelValidationError:
             raise BadRequest
 
         self.set_status(202)

--- a/src/app/beer_garden/api/http/handlers/v1/job.py
+++ b/src/app/beer_garden/api/http/handlers/v1/job.py
@@ -367,7 +367,7 @@ class JobExecutionAPI(AuthorizationHandler):
         _ = self.get_or_raise(Job, JOB_CREATE, id=job_id)
 
         reset_interval = (
-            True 
+            True
             if self.get_argument("reset_interval", "False").lower() == "true"
             else False
         )

--- a/src/app/beer_garden/api/http/handlers/v1/job.py
+++ b/src/app/beer_garden/api/http/handlers/v1/job.py
@@ -367,7 +367,7 @@ class JobExecutionAPI(AuthorizationHandler):
         _ = self.get_or_raise(Job, JOB_CREATE, id=job_id)
 
         reset_interval = (
-            True if self.get_argument("reset_interval", "False") == "True" else False
+            True if self.get_argument("reset_interval", "False").lower() == "true" else False
         )
 
         try:
@@ -376,8 +376,8 @@ class JobExecutionAPI(AuthorizationHandler):
             )
         except ValidationError:
             raise NotFoundError
-        except ModelValidationError:
-            raise BadRequest
+        except ModelValidationError as exc:
+            raise BadRequest(reason=f"{exc}")
 
         self.set_status(202)
         self.set_header("Content-Type", "application/json; charset=UTF-8")

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -366,7 +366,6 @@ class MixedScheduler(object):
 
         if reset_interval:
             job = beer_garden.application.scheduler.get_job(job_id)
-            # This should reset interval on job
             beer_garden.application.scheduler.reschedule_job(
                 job_id, trigger=job.trigger
             )

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -658,7 +658,7 @@ def execute_job(job_id: str, reset_interval=False) -> Job:
 
     if reset_interval and job.trigger_type != "interval":
         raise ModelValidationError(
-                "reset_interval can only be used with trigger type of interval"
+            "reset_interval can only be used with trigger type of interval"
         )
 
     return job

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -657,7 +657,7 @@ def execute_job(job_id: str, reset_interval=False) -> Job:
     job.reset_interval = reset_interval
 
     if reset_interval and job.trigger_type != "interval":
-        raise ModelValidationError()
+        raise ModelValidationError("reset_interval can only be used with trigger type of interval")
 
     return job
 

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -657,7 +657,9 @@ def execute_job(job_id: str, reset_interval=False) -> Job:
     job.reset_interval = reset_interval
 
     if reset_interval and job.trigger_type != "interval":
-        raise ModelValidationError("reset_interval can only be used with trigger type of interval")
+        raise ModelValidationError(
+                "reset_interval can only be used with trigger type of interval"
+        )
 
     return job
 


### PR DESCRIPTION
Closes #1173

Does not require Brewtils [#369](https://github.com/beer-garden/brewtils/pull/375), but this PR is useful for testing.

# To Test
- Create a job with an `interval` trigger of 30 seconds.
- Wait 15 seconds, then execute the job using the `execute_job` function from the Brewtils [#369](https://github.com/beer-garden/brewtils/pull/375) PR.
- Ensure the job is executed at the expected times - one time when the job is manually executed, then again 30 seconds later (45 seconds after the job was initially created). You can see execution times in Beergarden's logs in the console.
- Create a job without an `interval` trigger, ensure execution returns a `400` when `reset_interval` is True.