### PR TITLE
#1205 - Fix handling of status_updated_at field on Requests

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -113,6 +113,10 @@ class MongoModel:
     def changed_fields(self):
         return getattr(self, "_changed_fields", [])
 
+    @property
+    def created(self):
+        return getattr(self, "_created", False)
+
 
 # MongoEngine needs all EmbeddedDocuments to be defined before any Documents that
 # reference them. So Parameter must be defined before Command, and choices should be
@@ -316,7 +320,7 @@ class Request(MongoModel, Document):
     command_type = StringField(choices=BrewtilsCommand.COMMAND_TYPES)
     created_at = DateTimeField(default=datetime.datetime.utcnow, required=True)
     updated_at = DateTimeField(default=None, required=True)
-    status_updated_at = DateTimeField(default=datetime.datetime.utcnow, required=True)
+    status_updated_at = DateTimeField()
     error_class = StringField(required=False)
     has_parent = BooleanField(required=False)
     hidden = BooleanField(required=False)
@@ -480,7 +484,7 @@ class Request(MongoModel, Document):
                 f"consistent with has_parent value of {self.has_parent}"
             )
 
-        if "status" in self.changed_fields:
+        if "status" in self.changed_fields or self.created:
             self.status_updated_at = datetime.datetime.utcnow()
 
     def clean_update(self):


### PR DESCRIPTION
Closes #1205 

This PR fixes the handling of the `status_updated_at` field on Request to ensure that the model represents instances without that field populated as such, rather than setting it to the current time.

## Test Instructions
* Create a request that does not have `status_updated_at` populated.  You'll have to insert using pymongo directly to do this, since saving through the model will always set it.
   ```python
  import datetime                                                                                                                                                                                                      

  from mongoengine import connect                                                                                                                                                                                                                     
  from beer_garden.db.mongo.models import Request                                                                                                                                                                      
                                        
  # change db as appropriate
  connect(db="localhost", host="mongodb://mongodb")

  collection = Request._get_collection()                                                                                                                                                                               
                                                                                                                                                                                                                     
  request_dict = {                                                                                                                                                                                                     
      "system": "echo",                                                                                                                                                                                                
      "system_version": "3.0.0.dev0",
      "instance_name": "default",
      "command": "say",
      "parameters": {"message": "1205_test", "loud": False},
      "comment": "",
      "metadata": {},
      "namespace": "parent1",
      "output": "1205_test",
      "output_type": "STRING",
      "status": "SUCCESS",
      "command_type": "ACTION",
      "created_at": datetime.datetime(2021, 12, 3, 15, 32, 35, 879461),
      "updated_at": datetime.datetime(2021, 12, 3, 15, 32, 41, 493316),
      "has_parent": False,
      "hidden": False,
  }
                                                                                                                                             
  collection.insert_one(request_dict)

  r1 = Request.objects.get(output="1205_test")
  r1.status_updated_at
  # None
  ```
* If you run the same block of code on the `develop` branch, `status_updated_at` will show the current time despite the fact that it is not populated.  That's what this PR is fixing.