### PR TITLE
#1207 - Add global permission check to forward endpoint

### DIFF
--- a/src/app/beer_garden/api/authorization.py
+++ b/src/app/beer_garden/api/authorization.py
@@ -6,6 +6,8 @@ class Permissions(Enum):
     that the permissions assigned to roles are ones that beer garden recognizes.
     """
 
+    EVENT_FORWARD = "event:forward"
+
     JOB_CREATE = "job:create"
     JOB_READ = "job:read"
     JOB_UPDATE = "job:update"

--- a/src/app/beer_garden/api/http/handlers/authorization_handler.py
+++ b/src/app/beer_garden/api/http/handlers/authorization_handler.py
@@ -120,6 +120,22 @@ class AuthorizationHandler(BaseHandler):
         # duplication of the work required to identify and retrieve the User object.
         _ = self.current_user
 
+    def verify_user_global_permission(self, permission: str) -> None:
+        """Verifies that the requesting use has the specified permission for the Global
+        scope.
+
+        Args:
+            permission: The permission to check against
+
+        Raises:
+            RequestForbidden: The user does not have the required object permissions
+
+        Returns:
+            None
+        """
+        if permission not in self.current_user.global_permissions:
+            raise RequestForbidden
+
     def verify_user_permission_for_object(
         self, permission: str, obj: Union[Document, BrewtilsModel]
     ) -> None:

--- a/src/app/beer_garden/api/http/handlers/v1/forward.py
+++ b/src/app/beer_garden/api/http/handlers/v1/forward.py
@@ -4,12 +4,13 @@ import asyncio
 from brewtils.errors import TimeoutExceededError
 from brewtils.schema_parser import SchemaParser
 
-from beer_garden.api.http.base_handler import BaseHandler
+from beer_garden.api.authorization import Permissions
+from beer_garden.api.http.handlers import AuthorizationHandler
+
+EVENT_FORWARD = Permissions.EVENT_FORWARD.value
 
 
-class ForwardAPI(BaseHandler):
-
-    # @Todo Create new Persmission
+class ForwardAPI(AuthorizationHandler):
     async def post(self):
         """
         ---
@@ -37,7 +38,7 @@ class ForwardAPI(BaseHandler):
             schema:
                 $ref: '#/definitions/Forward'
         responses:
-          200:
+          204:
             description: Forward Request Accepted
           400:
             $ref: '#/definitions/400Error'
@@ -46,6 +47,8 @@ class ForwardAPI(BaseHandler):
         tags:
           - Forward
         """
+        self.verify_user_global_permission(EVENT_FORWARD)
+
         operation = SchemaParser.parse_operation(
             self.request.decoded_body, from_string=True
         )

--- a/src/app/example_configs/roles.yaml
+++ b/src/app/example_configs/roles.yaml
@@ -22,6 +22,7 @@
 
 - name: "superuser"
   permissions:
+    - "event:forward"
     - "job:create"
     - "job:read"
     - "job:update"

--- a/src/app/test/api/http/unit/conftest.py
+++ b/src/app/test/api/http/unit/conftest.py
@@ -6,6 +6,7 @@ from beer_garden.api.http.authentication import issue_token_pair
 from beer_garden.api.http.client import SerializeHelper
 from beer_garden.api.http.handlers.v1.admin import AdminAPI
 from beer_garden.api.http.handlers.v1.command import CommandAPI, CommandListAPI
+from beer_garden.api.http.handlers.v1.forward import ForwardAPI
 from beer_garden.api.http.handlers.v1.garden import GardenAPI, GardenListAPI
 from beer_garden.api.http.handlers.v1.instance import (
     InstanceAPI,
@@ -40,6 +41,7 @@ application = tornado.web.Application(
         (r"/api/v1/config/logging/?", LoggingConfigAPI),
         (r"/api/v1/export/jobs/?", JobExportAPI),
         (r"/api/v1/import/jobs/?", JobImportAPI),
+        (r"/api/v1/forward/?", ForwardAPI),
         (r"/api/v1/gardens/?", GardenListAPI),
         (r"/api/v1/gardens/(.*)/?", GardenAPI),
         (r"/api/v1/instances/(\w+)/?", InstanceAPI),

--- a/src/app/test/api/http/unit/handlers/v1/forward_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/forward_test.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+import json
+
+import pytest
+from tornado.httpclient import HTTPError, HTTPRequest
+
+from beer_garden.api.http.authentication import issue_token_pair
+from beer_garden.db.mongo.models import Garden, Role, RoleAssignment, User
+
+
+@pytest.fixture(autouse=True)
+def garden():
+    garden = Garden(name="somegarden", connection_type="LOCAL").save()
+
+    yield garden
+    garden.delete()
+
+
+@pytest.fixture
+def operation_data():
+    yield {"operation_type": "GARDEN_READ", "garden_name": "somegarden"}
+
+
+@pytest.fixture
+def event_forward_role():
+    role = Role(
+        name="event_forward",
+        permissions=["event:forward"],
+    ).save()
+
+    yield role
+    role.delete()
+
+
+@pytest.fixture
+def user_with_permission(event_forward_role):
+    role_assignment = RoleAssignment(
+        role=event_forward_role,
+        domain={
+            "scope": "Global",
+        },
+    )
+
+    user = User(username="testuser", role_assignments=[role_assignment]).save()
+
+    yield user
+    user.delete()
+
+
+@pytest.fixture
+def user_without_permission(event_forward_role):
+    user = User(username="testuser").save()
+
+    yield user
+    user.delete()
+
+
+@pytest.fixture
+def access_token_permitted(user_with_permission):
+    yield issue_token_pair(user_with_permission)["access"]
+
+
+@pytest.fixture
+def access_token_not_permitted(user_without_permission):
+    yield issue_token_pair(user_without_permission)["access"]
+
+
+class TestGardenAPI:
+    @pytest.mark.gen_test
+    def test_auth_enabled_allows_forward_with_global_permission(
+        self,
+        http_client,
+        base_url,
+        app_config_auth_enabled,
+        access_token_permitted,
+        operation_data,
+    ):
+        url = f"{base_url}/api/v1/forward/"
+        headers = {"Authorization": f"Bearer {access_token_permitted}"}
+
+        request = HTTPRequest(
+            url,
+            method="POST",
+            headers=headers,
+            body=json.dumps(operation_data),
+        )
+        response = yield http_client.fetch(request)
+
+        assert response.code == 204
+
+    @pytest.mark.gen_test
+    def test_auth_enabled_rejects_forward_without_global_permission(
+        self,
+        http_client,
+        base_url,
+        app_config_auth_enabled,
+        access_token_not_permitted,
+        operation_data,
+    ):
+        url = f"{base_url}/api/v1/forward/"
+        headers = {"Authorization": f"Bearer {access_token_not_permitted}"}
+
+        request = HTTPRequest(
+            url, method="POST", headers=headers, body=json.dumps(operation_data)
+        )
+
+        with pytest.raises(HTTPError) as excinfo:
+            yield http_client.fetch(request)
+
+        assert excinfo.value.code == 403


### PR DESCRIPTION
Closes #1207

This PR adds an authorization check to the `/api/v1/forward` endpoint.

## Testing Instructions
### Assumptions
* Your `superuser` role has the "event:forward" permission. Use the `example_configs/roles.yaml` or update your own config file if you are using some custom role config.

### Test with auth disabled
  ```shell
  curl -si -X POST -H "Content-Type: application/json" --data '{"operation_type": "GARDEN_READ", "args": ["somegarden"]}' "http://localhost:8080/api/v1/forward" | head -1
  # HTTP/1.1 204 No Content
  ```
### Test with auth enabled:
  * Create users with and without access:
    ```python
    from mongoengine import connect
    from beer_garden.db.mongo.models import Role, RoleAssignment, User

    # modify db and host parameters are appropriate for your environment
    connect(db="bg-parent1", host="mongodb://mongodb")

    read_only = Role.objects.get(name="read_only")
    role_assignment = RoleAssignment(role=read_only, domain={"scope": "Global"})
    user = User(username="ro_user", role_assignments=[role_assignment])
    user.set_password("password")
    user.save()

    superuser = Role.objects.get(name="superuser")
    role_assignment = RoleAssignment(role=superuser, domain={"scope": "Global"})
    user = User(username="su_user", role_assignments=[role_assignment])
    user.set_password("password")
    user.save()
    ```
  * Login and hit the forward endpoint:
    ```shell
    # Test for user without access: ro_user
    curl -H "Content-Type: application/json" --data '{"username": "ro_user", "password": "password"}' "http://localhost:8080/api/v1/token" | jq -r '.access' > /tmp/ro_user.token
    curl -si -H "Content-Type: application/json" -H "Authorization: Bearer `cat /tmp/ro_user.token`" --data '{"operation_type": "GARDEN_READ", "args": ["somegarden"]}' "http://localhost:8080/api/v1/forward" | head -1
    # HTTP/1.1 403 Unauthorized

    # Test for user with access: su_user
    curl -H "Content-Type: application/json" --data '{"username": "su_user", "password": "password"}' "http://localhost:8080/api/v1/token" | jq -r '.access' > /tmp/su_user.token
    curl -si -H "Content-Type: application/json" -H "Authorization: Bearer `cat /tmp/su_user.token`" --data '{"operation_type": "GARDEN_READ", "args": ["somegarden"]}' "http://localhost:8080/api/v1/forward" | head -1
    # HTTP/1.1 204 No Content
    ```