### PR TITLE
#1209 - Handle parameters set to None in remove_bytes_parameter_base64

### DIFF
--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -706,6 +706,9 @@ def remove_bytes_parameter_base64(
     Returns:
         None
     """
+    if parameters is None:
+        parameters = {}
+
     for param in parameters:
         request_param = parameters[param]
         if isinstance(request_param, dict) and request_param.get("type") == "bytes":


### PR DESCRIPTION
Closes #1209 

This PR adds a `None` check to `remove_bytes_parameter_base64` in `requests.py`.  It ought to never be called with `parameters=None` and I could not reproduce the situation where that happens, but logs received from a user indicate that this can in fact happen and so it should be handled.