### PR TITLE
#1218 - Populate children in the request endpoint response

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -122,6 +122,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Custom tag extractor to find Brewtils Branch
+      - name: Find Brewtils Branch
+        uses: TheBurchLog/body-env-tag-action@1.0
+        with:
+          tag: "brewtils:"
+          env-variable: "brewtils"
+          default-value: "develop"
+          tag-position: -1
+
+      # Used the hashtag here instead of slash allow for branches to have slashes in them
+      - name: Update Brewtils Branch
+        run: sed -i 's#brewtils@develop#brewtils@${{env.brewtils}}#g' requirements-dev.txt
+
       # Need to update if we support other OS's
       - name: Cache PIP Install
         uses: actions/cache@v2

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -52,6 +52,10 @@ class RequestAPI(AuthorizationHandler):
         """
         request = self.get_or_raise(Request, REQUEST_READ, id=request_id)
 
+        # brewtils dependencies make universal handling of children overly cumbersome,
+        # so just manually populate them here for now.
+        request.children = Request.objects.filter(parent=request)
+
         response = MongoParser.serialize(request)
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")


### PR DESCRIPTION
Closes #1218 
This Pull request requires brewtils: 3.8.0

This PR fixes the request endpoint so that `children` gets properly populated.

## Test Instructions
The unit test should pretty well cover this one, but for a functional test, just task the `nested-calls` command and then refresh the request page after it initially loads.  With this fix you should still see the child request on that page after the reload.  Before the fix they would disappear.

**NOTE**: Before the reload you can end up seeing a duplicate child event listed.  This is not a new bug and won't be addressed here.  It's an artifact of the requests finishing sufficiently fast that the initial API response contains the children, and then UI receives a published event on the websocket connection regarding the child request and just creates a second entry for it.

**NOTE 2**: There was a bug with the `nested-calls` example plugin that prevents it from starting.  Be sure to pull the latest master branch and use that version of `nested-calls` if you care to manually test this.