### PR TITLE
Fix gridfs output handling

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -445,7 +445,7 @@ class Request(MongoModel, Document):
             output_json = json.dumps(self.output)
             if len(output_json) > REQUEST_MAX_PARAM_SIZE:
                 self.logger.info("Output size too big, storing in gridfs")
-                self.output_gridfs.put(output_json, encoding=encoding)
+                self.output_gridfs.put(self.output, encoding=encoding)
                 self.output = None
 
         super(Request, self).save(*args, **kwargs)


### PR DESCRIPTION
Closes #1221

This PR reverts the `RequestAPI.get` method back to using the `Operation` flow for retrieving the request.  This results in an extra database lookup explicitly for the authorization check, but ensures that all of the data that is not native to the Request model gets properly added to the request for the response.  In most other cases the `Operation` flow was left intact when adding the authorization checks and it should have been kept here as well, so this is effectively correcting that mistake.

Additionally, this PR reverts a likely unintentional change where gridfs output was being stored in its serialized form rather than raw.  A separate comment on this PR goes into more detail on that.

## Test Instructions
The unit test covers this one pretty well.  If you want to functionally test this you could do the following:

* Task the "echo_json" command with something that's going to spill over and store in gridfs (Hand-hacking the `REQUEST_MAX_PARAM_SIZE` used by the Request model is an easy way to achieve that).
* View the request through the UI.  You should notice:
  * The output is actually displayed (it wasn't prior to these fixes)
  * It is displayed as proper JSON (it would be stringified JSON without the second fix)