### PR TITLE
#1143 - Persist status_updated_at from child garden

### DIFF
--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -892,7 +892,7 @@ def handle_event(event):
             existing_request = db.query_unique(Request, id=event.payload.id)
 
             if existing_request:
-                for field in ("status", "output", "error_class"):
+                for field in ("status", "output", "error_class", "status_updated_at"):
                     setattr(existing_request, field, getattr(event.payload, field))
 
                 try:

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -255,7 +255,7 @@ class TestRequest(object):
             status="CREATED",
             system_version="1.0.0",
             instance_name="foobar",
-            namespace="barfoo",
+            namespace="somegarden",
         )
         req.parameters = {"message": "hi"}
         req.output = "bye"
@@ -304,20 +304,37 @@ class TestRequest(object):
         request_model.parameters_gridfs.put.assert_not_called()
         request_model.output_gridfs.put.assert_not_called()
 
-    def test_save_preserves_status_updated_at_field(self, request_model):
+    def test_save_preserves_status_updated_at_field_when_status_is_not_updated(
+        self, request_model
+    ):
         request_model.save()
         first_time = request_model.status_updated_at
         request_model.save()
 
         assert first_time == request_model.status_updated_at
 
-    def test_status_changes_status_updated_at_field(self, request_model):
+    def test_save_updates_status_updated_at_field_when_status_is_updated(
+        self, request_model
+    ):
         request_model.save()
         first_time = request_model.status_updated_at
         request_model.status = "SUCCESS"
         request_model.save()
 
         assert first_time != request_model.status_updated_at
+
+    def test_save_preserves_status_updated_at_for_child_garden_requests(
+        self, request_model
+    ):
+        request_model.namespace = "child_garden"
+        request_model.save()
+
+        status_updated_at = datetime.utcnow() - timedelta(days=1)
+        request_model.status = "SUCCESS"
+        request_model.status_updated_at = status_updated_at
+        request_model.save()
+
+        assert request_model.status_updated_at == status_updated_at
 
 
 class TestSystem(object):

--- a/src/ui/src/partials/request_view.html
+++ b/src/ui/src/partials/request_view.html
@@ -49,9 +49,9 @@
               class="glyphicon glyphicon-info-sign"
             ></span></span>
           </th>
-	  <th scope="col">Status Updated</th>
           <th scope="col" ng-show="showErrorColumn(request, children)">Error Type</th>
           <th scope="col">Created</th>
+          <th scope="col">Status Updated</th>
           <th scope="col">Updated</th>
           <th scope="col">Comment</th>
         </tr>
@@ -77,9 +77,9 @@
           </td>
           <td>{{request.instance_name}}</td>
           <td>{{request.status}}</td>
-	  <td>{{formatDate(request.status_updated_at)}}</td>
           <td ng-show="showErrorColumn(request, children)">{{request.error_class}}</td>
           <td>{{formatDate(request.created_at)}}</td>
+          <td>{{formatDate(request.status_updated_at)}}</td>
           <td>{{formatDate(request.updated_at)}}</td>
           <td>{{request.comment}}</td>
         </tr>
@@ -98,6 +98,7 @@
           <td><div>{{child.status}}</div></td>
           <td ng-show="showErrorColumn(request, children)"><div>{{child.error_class}}</div></td>
           <td><div>{{formatDate(child.created_at)}}</div></td>
+          <td><div>{{formatDate(child.status_updated_at)}}</div></td>
           <td><div>{{formatDate(child.updated_at)}}</div></td>
           <td><div>{{child.comment}}</div></td>
         </tr>


### PR DESCRIPTION
Fixes #1143

This PR fixes a number of issues related to the `status_updated_at` field on the Request model.

* The "Status Updated" column in the UI has been repositioned.  In the cases of a request with an error, "Status Updated" was positioned somewhat awkwardly in between "Status" and "Error Type" fields.  "Error Type" only shows up when there is an error, which is why the awkwardness of the positioning wasn't initially obvious.
* The "Status Updated" column is now properly displayed for child requests in the request view.
* `status_updated_at` should now be properly preserved on requests originating from child gardens.

That last bullet was sort of the whole point of the original ticket, which I apparently lost sight of when providing guidance and code review on the original PR.  I realized this when looking at this again for the purposes of the first two bullets and so endeavored to fix it here.

The PR is broken up into 3 commits in case it's useful when reviewing / testing:

* [f803efbe6](https://github.com/beer-garden/beer-garden/pull/1224/commits/f803efbe61ab582fa40e360398f7091efe89a590) - UI changes described in the first two bullets
* [7d0ab1b21](https://github.com/beer-garden/beer-garden/pull/1224/commits/7d0ab1b218b6e148050d66de085da204c865db11) - Unit test that should pass when everything is working as intended, but was failing (with a bunch of noise because of a Request --> BrewtilsRequest rename).
* [2a46a58da](https://github.com/beer-garden/beer-garden/pull/1224/commits/2a46a58da078ff3c0bdc4d986a3872b324033149) - Changes to properly preserve `status_update_at`, plus some additional unit test stuff.

## Testing Instructions
To functionally test the changes you can do the following:
* Task the "nested_calls" command on a child garden.
* In the UI, view the request and expand the request list to see the child requests.  "Status Updated" should be properly displayed for the child requests.
* In a python shell or directly in the database, check the `status_updated_at` timestamp of the request in both the child and parent gardens.  They should be identical.  The UI does not display timestamps with sufficient granularity to verify this there.