### PR TITLE
#877 - Added backend support for event blacklist by command

### DIFF
--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -9,6 +9,7 @@ import beer_garden.log
 import beer_garden.requests
 import beer_garden.router
 from beer_garden.api.stomp.transport import Connection, parse_header_list
+from beer_garden.db.mongo.util import is_in_command_black_list
 from beer_garden.events import publish
 from beer_garden.events.processors import BaseProcessor
 
@@ -159,15 +160,16 @@ class StompManager(BaseProcessor):
                     garden_name=event.payload.name, skip_key=skip_key
                 )
 
-        for value in self.conn_dict.values():
-            conn = value["conn"]
-            if conn:
-                if conn.is_connected():
-                    if value["headers_list"]:
-                        for headers in value["headers_list"]:
-                            conn.send(event, headers=headers)
-                    else:
-                        conn.send(event)
+        if not is_in_command_black_list(event):
+            for value in self.conn_dict.values():
+                conn = value["conn"]
+                if conn:
+                    if conn.is_connected():
+                        if value["headers_list"]:
+                            for headers in value["headers_list"]:
+                                conn.send(event, headers=headers)
+                        else:
+                            conn.send(event)
 
     def handle_event(self, event):
         """Main event entry point

--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -9,8 +9,7 @@ import beer_garden.log
 import beer_garden.requests
 import beer_garden.router
 from beer_garden.api.stomp.transport import Connection, parse_header_list
-from beer_garden.db.mongo.util import is_in_command_black_list
-from beer_garden.events import publish
+from beer_garden.events import event_blacklisted, publish
 from beer_garden.events.processors import BaseProcessor
 
 logger = logging.getLogger(__name__)
@@ -160,7 +159,7 @@ class StompManager(BaseProcessor):
                     garden_name=event.payload.name, skip_key=skip_key
                 )
 
-        if not is_in_command_black_list(event):
+        if not event_blacklisted(event):
             for value in self.conn_dict.values():
                 conn = value["conn"]
                 if conn:

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -76,7 +76,7 @@ __all__ = [
     "Role",
     "RoleAssignment",
     "User",
-    "CommandBlackList",
+    "CommandPublishingBlackList",
 ]
 
 REQUEST_MAX_PARAM_SIZE = 5 * 1_000_000
@@ -850,7 +850,7 @@ class RawFile(Document):
     file = FileField()
 
 
-class CommandBlackList(Document):
+class CommandPublishingBlackList(Document):
 
     namespace = StringField(required=True)
     system = StringField(required=True)

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -76,6 +76,7 @@ __all__ = [
     "Role",
     "RoleAssignment",
     "User",
+    "CommandBlackList",
 ]
 
 REQUEST_MAX_PARAM_SIZE = 5 * 1_000_000
@@ -847,6 +848,17 @@ class FileChunk(MongoModel, Document):
 
 class RawFile(Document):
     file = FileField()
+
+
+class CommandBlackList(Document):
+
+    namespace = StringField(required=True)
+    system = StringField(required=True)
+    command = StringField(required=True)
+
+    meta = {
+        "indexes": [{"fields": ["namespace", "system", "command"], "unique": True}],
+    }
 
 
 class Role(Document):

--- a/src/app/beer_garden/db/mongo/util.py
+++ b/src/app/beer_garden/db/mongo/util.py
@@ -392,7 +392,7 @@ def _should_create_admin():
 
 
 def is_in_command_black_list(event):
-    if event.payload_type is "Request":
+    if event.payload_type == "Request":
         try:
             CommandBlackList.objects.get(
                 namespace=event.payload.namespace,

--- a/src/app/beer_garden/db/mongo/util.py
+++ b/src/app/beer_garden/db/mongo/util.py
@@ -16,9 +16,9 @@ from mongoengine.errors import (
 from passlib.apps import custom_app_context
 
 from beer_garden import config
+from beer_garden.db.mongo.models import CommandBlackList
 from beer_garden.errors import ConfigurationError
 from beer_garden.role import sync_roles
-from beer_garden.db.mongo.models import CommandBlackList
 
 logger = logging.getLogger(__name__)
 

--- a/src/app/beer_garden/db/mongo/util.py
+++ b/src/app/beer_garden/db/mongo/util.py
@@ -16,7 +16,6 @@ from mongoengine.errors import (
 from passlib.apps import custom_app_context
 
 from beer_garden import config
-from beer_garden.db.mongo.models import CommandBlackList
 from beer_garden.errors import ConfigurationError
 from beer_garden.role import sync_roles
 
@@ -388,18 +387,4 @@ def _should_create_admin():
     # By default, if they have created other users that are not just the
     # anonymous users, we assume they do not want to re-create the admin
     # user.
-    return False
-
-
-def is_in_command_black_list(event):
-    if event.payload_type == "Request":
-        try:
-            CommandBlackList.objects.get(
-                namespace=event.payload.namespace,
-                system=event.payload.system,
-                command=event.payload.command,
-            )
-            return True
-        except DoesNotExist:
-            pass
     return False

--- a/src/app/beer_garden/db/mongo/util.py
+++ b/src/app/beer_garden/db/mongo/util.py
@@ -18,6 +18,7 @@ from passlib.apps import custom_app_context
 from beer_garden import config
 from beer_garden.errors import ConfigurationError
 from beer_garden.role import sync_roles
+from beer_garden.db.mongo.models import CommandBlackList
 
 logger = logging.getLogger(__name__)
 
@@ -387,4 +388,18 @@ def _should_create_admin():
     # By default, if they have created other users that are not just the
     # anonymous users, we assume they do not want to re-create the admin
     # user.
+    return False
+
+
+def is_in_command_black_list(event):
+    if event.payload_type is "Request":
+        try:
+            CommandBlackList.objects.get(
+                namespace=event.payload.namespace,
+                system=event.payload.system,
+                command=event.payload.command,
+            )
+            return True
+        except DoesNotExist:
+            pass
     return False

--- a/src/app/beer_garden/events/__init__.py
+++ b/src/app/beer_garden/events/__init__.py
@@ -6,7 +6,6 @@ from functools import partial
 
 import wrapt
 from brewtils.models import Event, Events
-from mongoengine.errors import DoesNotExist
 
 from beer_garden import config as config
 from beer_garden.db.mongo.models import CommandPublishingBlackList
@@ -154,8 +153,8 @@ def _event_blacklisted_by_command(event):
                 command=event.payload.command,
             )
             return True
-        except DoesNotExist:
-            pass
+        except CommandPublishingBlackList.DoesNotExist:
+            return False
 
 
 def event_blacklisted(event: Event) -> bool:

--- a/src/app/beer_garden/events/__init__.py
+++ b/src/app/beer_garden/events/__init__.py
@@ -6,8 +6,10 @@ from functools import partial
 
 import wrapt
 from brewtils.models import Event, Events
+from mongoengine.errors import DoesNotExist
 
 from beer_garden import config as config
+from beer_garden.db.mongo.models import CommandPublishingBlackList
 
 # In this master process this should be an instance of EventManager, and in entry points
 # it should be an instance of EntryPointManager
@@ -137,3 +139,33 @@ def _async_callback(task, event_type=None):
             publish(event)
         except Exception as ex:
             logger.exception(f"Error publishing event: {ex}")
+
+
+def _event_blacklisted_by_name(event):
+    return event.name in config.get("parent.skip_events")
+
+
+def _event_blacklisted_by_command(event):
+    if event.payload_type == "Request":
+        try:
+            CommandPublishingBlackList.objects.get(
+                namespace=event.payload.namespace,
+                system=event.payload.system,
+                command=event.payload.command,
+            )
+            return True
+        except DoesNotExist:
+            pass
+
+
+def event_blacklisted(event: Event) -> bool:
+    """
+    This will determine if an event is black listed from being sent to a parent garden.
+
+    Args:
+        event: an Event object
+
+    Returns:
+        Boolean: The result of if event is black listed
+    """
+    return _event_blacklisted_by_name(event) or _event_blacklisted_by_command(event)

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -1,9 +1,8 @@
 from brewtils.models import Event, Operation
 from requests import RequestException
 
-from beer_garden.db.mongo.util import is_in_command_black_list
-
 import beer_garden.config as conf
+from beer_garden.db.mongo.util import is_in_command_black_list
 from beer_garden.events.processors import QueueListener
 
 

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -1,6 +1,8 @@
 from brewtils.models import Event, Operation
 from requests import RequestException
 
+from beer_garden.db.mongo.util import is_in_command_black_list
+
 import beer_garden.config as conf
 from beer_garden.events.processors import QueueListener
 
@@ -43,7 +45,7 @@ class HttpParentUpdater(QueueListener):
         # TODO - This shouldn't be set here
         event.garden = conf.get("garden.name")
 
-        if event.name not in self._black_list:
+        if event.name not in self._black_list and not is_in_command_black_list(event):
             try:
                 operation = Operation(
                     operation_type="PUBLISH_EVENT", model=event, model_type="Event"

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -2,7 +2,7 @@ from brewtils.models import Event, Operation
 from requests import RequestException
 
 import beer_garden.config as conf
-from beer_garden.db.mongo.util import is_in_command_black_list
+from beer_garden.events import event_blacklisted
 from beer_garden.events.processors import QueueListener
 
 
@@ -44,7 +44,7 @@ class HttpParentUpdater(QueueListener):
         # TODO - This shouldn't be set here
         event.garden = conf.get("garden.name")
 
-        if event.name not in self._black_list and not is_in_command_black_list(event):
+        if not event_blacklisted(event):
             try:
                 operation = Operation(
                     operation_type="PUBLISH_EVENT", model=event, model_type="Event"

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -26,6 +26,7 @@ from beer_garden.db.mongo.models import (
     System,
     User,
     UserToken,
+    CommandBlackList,
 )
 
 
@@ -654,6 +655,28 @@ class TestUserToken:
         assert len(UserToken.objects.filter(id=user_token.id)) == 1
         user_token.user.fetch().delete()
         assert len(UserToken.objects.filter(id=user_token.id)) == 0
+
+
+class TestCommandBlackList:
+    namespace = "test"
+    system = "system_test"
+    command = "command_test"
+
+    @pytest.fixture()
+    def command_black_list(self):
+        black_list = CommandBlackList(
+            namespace=self.namespace, system=self.system, command=self.command
+        ).save()
+
+        yield black_list
+        black_list.delete()
+
+    def test_black_list_entries_are_required_to_be_unique(self, command_black_list):
+        """Attempting to create a black list entry already in database should raise an exception"""
+        with pytest.raises(NotUniqueError):
+            CommandBlackList(
+                namespace=self.namespace, system=self.system, command=self.command
+            ).save()
 
 
 class TestGarden:

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -15,6 +15,7 @@ from beer_garden.api.authorization import Permissions
 from beer_garden.db.mongo.models import (
     Choices,
     Command,
+    CommandBlackList,
     DateTrigger,
     Garden,
     Instance,
@@ -26,7 +27,6 @@ from beer_garden.db.mongo.models import (
     System,
     User,
     UserToken,
-    CommandBlackList,
 )
 
 

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -15,7 +15,7 @@ from beer_garden.api.authorization import Permissions
 from beer_garden.db.mongo.models import (
     Choices,
     Command,
-    CommandBlackList,
+    CommandPublishingBlackList,
     DateTrigger,
     Garden,
     Instance,
@@ -664,7 +664,7 @@ class TestCommandBlackList:
 
     @pytest.fixture()
     def command_black_list(self):
-        black_list = CommandBlackList(
+        black_list = CommandPublishingBlackList(
             namespace=self.namespace, system=self.system, command=self.command
         ).save()
 
@@ -674,7 +674,7 @@ class TestCommandBlackList:
     def test_black_list_entries_are_required_to_be_unique(self, command_black_list):
         """Attempting to create a black list entry already in database should raise an exception"""
         with pytest.raises(NotUniqueError):
-            CommandBlackList(
+            CommandPublishingBlackList(
                 namespace=self.namespace, system=self.system, command=self.command
             ).save()
 

--- a/src/app/test/db/mongo/util_test.py
+++ b/src/app/test/db/mongo/util_test.py
@@ -19,13 +19,11 @@ def model_mocks(monkeypatch):
     role_mock = Mock()
     job_mock = Mock()
     principal_mock = Mock()
-    event_mock = Mock()
 
     request_mock.__name__ = "Request"
     system_mock.__name__ = "System"
     role_mock.__name__ = "LegacyRole"
     job_mock.__name__ = "Job"
-    event_mock.__name__ = "event"
     principal_mock.__name__ = "Principal"
 
     monkeypatch.setattr(beer_garden.db.mongo.models, "Request", request_mock)
@@ -40,7 +38,6 @@ def model_mocks(monkeypatch):
         "role": role_mock,
         "job": job_mock,
         "principal": principal_mock,
-        "event": event_mock,
     }
 
 

--- a/src/app/test/db/mongo/util_test.py
+++ b/src/app/test/db/mongo/util_test.py
@@ -7,7 +7,7 @@ from mongoengine import DoesNotExist, connect
 import beer_garden.db.mongo.models
 import beer_garden.db.mongo.util
 from beer_garden import config
-from beer_garden.db.mongo.models import Garden, Role, CommandBlackList
+from beer_garden.db.mongo.models import CommandBlackList, Garden, Role
 from beer_garden.db.mongo.util import (
     ensure_local_garden,
     ensure_roles,

--- a/src/app/test/db/mongo/util_test.py
+++ b/src/app/test/db/mongo/util_test.py
@@ -7,12 +7,8 @@ from mongoengine import DoesNotExist, connect
 import beer_garden.db.mongo.models
 import beer_garden.db.mongo.util
 from beer_garden import config
-from beer_garden.db.mongo.models import CommandBlackList, Garden, Role
-from beer_garden.db.mongo.util import (
-    ensure_local_garden,
-    ensure_roles,
-    is_in_command_black_list,
-)
+from beer_garden.db.mongo.models import Garden, Role
+from beer_garden.db.mongo.util import ensure_local_garden, ensure_roles
 from beer_garden.errors import ConfigurationError
 
 
@@ -23,14 +19,12 @@ def model_mocks(monkeypatch):
     role_mock = Mock()
     job_mock = Mock()
     principal_mock = Mock()
-    black_list_mock = Mock()
     event_mock = Mock()
 
     request_mock.__name__ = "Request"
     system_mock.__name__ = "System"
     role_mock.__name__ = "LegacyRole"
     job_mock.__name__ = "Job"
-    black_list_mock.__name__ = "CommandBlackList"
     event_mock.__name__ = "event"
     principal_mock.__name__ = "Principal"
 
@@ -38,9 +32,6 @@ def model_mocks(monkeypatch):
     monkeypatch.setattr(beer_garden.db.mongo.models, "System", system_mock)
     monkeypatch.setattr(beer_garden.db.mongo.models, "LegacyRole", role_mock)
     monkeypatch.setattr(beer_garden.db.mongo.models, "Job", job_mock)
-    monkeypatch.setattr(
-        beer_garden.db.mongo.models, "CommandBlackList", black_list_mock
-    )
     monkeypatch.setattr(beer_garden.db.mongo.models, "Principal", principal_mock)
 
     return {
@@ -49,7 +40,6 @@ def model_mocks(monkeypatch):
         "role": role_mock,
         "job": job_mock,
         "principal": principal_mock,
-        "black_list": black_list_mock,
         "event": event_mock,
     }
 
@@ -279,41 +269,6 @@ class TestCreateLegacyRole(object):
 
         beer_garden.db.mongo.util._create_role(role)
         assert role.save.called is True
-
-
-class TestCommandBlackList(object):
-    namespace = "test"
-    system = "system_test"
-    command = "command_test"
-
-    @pytest.fixture()
-    def command_black_list(self):
-        black_list = CommandBlackList(
-            namespace=self.namespace, system=self.system, command=self.command
-        ).save()
-
-        yield black_list
-        black_list.delete()
-
-    def test_exists(self, model_mocks, command_black_list):
-        model_mocks["event"].payload_type = "Request"
-        model_mocks["event"].payload.namespace = self.namespace
-        model_mocks["event"].payload.system = self.system
-        model_mocks["event"].payload.command = self.command
-
-        assert is_in_command_black_list(model_mocks["event"])
-
-    def test_missing(self, model_mocks):
-        model_mocks["event"].payload_type = "Request"
-        model_mocks["black_list"].objects.get.return_value = DoesNotExist
-
-        assert not is_in_command_black_list(model_mocks["event"])
-
-    def test_payload_type_not_request(self, model_mocks):
-        model_mocks["event"].payload_type = "Garden_create"
-        model_mocks["black_list"].objects.get.return_value = DoesNotExist
-
-        assert not is_in_command_black_list(model_mocks["event"])
 
 
 class TestEnsureLocalGarden:

--- a/src/app/test/events/init.py
+++ b/src/app/test/events/init.py
@@ -1,27 +1,21 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
+from brewtils.models import Event
 
 from beer_garden import config
-from beer_garden.db.mongo.models import CommandPublishingBlackList
+from beer_garden.db.mongo.models import CommandPublishingBlackList, Request
 from beer_garden.events import event_blacklisted
 
 
-@pytest.fixture
-def model_mocks(monkeypatch):
-    event_mock = Mock()
-
-    event_mock.__name__ = "event"
-
-    return {
-        "event": event_mock,
-    }
-
-
 class TestCommandBlackList(object):
-    namespace = "test"
-    system = "system_test"
-    command = "command_test"
+    event = Event(
+        payload_type="Request",
+        payload=Request(
+            system="system_test",
+            command="command_test",
+            namespace="test",
+        ),
+    )
 
     def config_get(self, config_name):
         return []
@@ -29,29 +23,26 @@ class TestCommandBlackList(object):
     @pytest.fixture()
     def command_black_list(self):
         black_list = CommandPublishingBlackList(
-            namespace=self.namespace, system=self.system, command=self.command
+            namespace=self.event.payload.namespace,
+            system=self.event.payload.system,
+            command=self.event.payload.command,
         ).save()
 
         yield black_list
         black_list.delete()
 
-    def test_exists(self, model_mocks, command_black_list, monkeypatch):
+    def test_exists(self, command_black_list, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
-        model_mocks["event"].payload_type = "Request"
-        model_mocks["event"].payload.namespace = self.namespace
-        model_mocks["event"].payload.system = self.system
-        model_mocks["event"].payload.command = self.command
 
-        assert event_blacklisted(model_mocks["event"])
+        assert event_blacklisted(self.event)
 
-    def test_missing(self, model_mocks, monkeypatch):
+    def test_missing(self, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
-        model_mocks["event"].payload_type = "Request"
 
-        assert not event_blacklisted(model_mocks["event"])
+        assert not event_blacklisted(self.event)
 
-    def test_payload_type_not_request(self, model_mocks, monkeypatch):
+    def test_event_not_request(self, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
-        model_mocks["event"].payload_type = "Garden_create"
+        event = Event(name="ENTRY_STARTED")
 
-        assert not event_blacklisted(model_mocks["event"])
+        assert not event_blacklisted(event)

--- a/src/app/test/events/init.py
+++ b/src/app/test/events/init.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import pytest
+from mock import Mock
+
+from beer_garden import config
+from beer_garden.db.mongo.models import CommandPublishingBlackList
+from beer_garden.events import event_blacklisted
+
+
+@pytest.fixture
+def model_mocks(monkeypatch):
+    event_mock = Mock()
+
+    event_mock.__name__ = "event"
+
+    return {
+        "event": event_mock,
+    }
+
+
+class TestCommandBlackList(object):
+    namespace = "test"
+    system = "system_test"
+    command = "command_test"
+
+    def config_get(self, config_name):
+        return []
+
+    @pytest.fixture()
+    def command_black_list(self):
+        black_list = CommandPublishingBlackList(
+            namespace=self.namespace, system=self.system, command=self.command
+        ).save()
+
+        yield black_list
+        black_list.delete()
+
+    def test_exists(self, model_mocks, command_black_list, monkeypatch):
+        monkeypatch.setattr(config, "get", self.config_get)
+        model_mocks["event"].payload_type = "Request"
+        model_mocks["event"].payload.namespace = self.namespace
+        model_mocks["event"].payload.system = self.system
+        model_mocks["event"].payload.command = self.command
+
+        assert event_blacklisted(model_mocks["event"])
+
+    def test_missing(self, model_mocks, monkeypatch):
+        monkeypatch.setattr(config, "get", self.config_get)
+        model_mocks["event"].payload_type = "Request"
+
+        assert not event_blacklisted(model_mocks["event"])
+
+    def test_payload_type_not_request(self, model_mocks, monkeypatch):
+        monkeypatch.setattr(config, "get", self.config_get)
+        model_mocks["event"].payload_type = "Garden_create"
+
+        assert not event_blacklisted(model_mocks["event"])


### PR DESCRIPTION
closes #877
Added a new model for black listing commands to the database for preventing requests from corresponding commands to be sent to parent.
The requests blocked are base on the combination of namespace, system name, and command name.

Testing

1. start up a parent and child garden
2. in a python console import `CommandBlackList` and connect to child database
3. add command to black list 
```
CommandBlackList(
            namespace="child_namespace", system="echo", command="say"
        ).save()
```
4. Run corresponding command from either the parent or child

Results
If command is ran from the parent the request should be stuck in the created status.
If command is ran from child the parent should not know about the request.
