### PR TITLE
#1230 - Restore garden endpoint DELETE method

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/garden.py
+++ b/src/app/beer_garden/api/http/handlers/v1/garden.py
@@ -45,6 +45,32 @@ class GardenAPI(AuthorizationHandler):
         self.set_header("Content-Type", "application/json; charset=UTF-8")
         self.write(response)
 
+    async def delete(self, garden_name):
+        """
+        ---
+        summary: Delete a specific Garden
+        parameters:
+          - name: garden_name
+            in: path
+            required: true
+            description: Garden to use
+            type: string
+        responses:
+          204:
+            description: Garden has been successfully deleted
+          404:
+            $ref: '#/definitions/404Error'
+          50x:
+            $ref: '#/definitions/50xError'
+        tags:
+          - Garden
+        """
+        garden = self.get_or_raise(Garden, GARDEN_DELETE, name=garden_name)
+
+        await self.client(Operation(operation_type="GARDEN_DELETE", args=[garden.name]))
+
+        self.set_status(204)
+
     async def patch(self, garden_name):
         """
         ---


### PR DESCRIPTION
Closes #1230 

This PR restores the DELETE method on the gardens endpoint, which as inadvertently deleted in the 3.7.1 release.  It also adds the authorization checks and corresponding unit tests.

## Testing Instructions
* Create a garden via the garden admin page on the UI.
* Go back to the garden admin page and click the "Delete <garden>" button.
* The garden should be deleted as expected.