### PR TITLE
#1215 - Cascade delete RawFile when deleting Request

### DIFF
--- a/src/app/beer_garden/db/mongo/pruner.py
+++ b/src/app/beer_garden/db/mongo/pruner.py
@@ -114,6 +114,13 @@ class MongoPruner(StoppableThread):
                     ),
                 }
             )
+            prune_tasks.append(
+                {
+                    "collection": RawFile,
+                    "field": "created_at",
+                    "delete_after": timedelta(minutes=file_ttl),
+                }
+            )
 
         # Look at the various TTLs to determine how often to run
         real_ttls = [x for x in kwargs.values() if x > 0]

--- a/src/app/beer_garden/db/mongo/pruner.py
+++ b/src/app/beer_garden/db/mongo/pruner.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 from brewtils.stoppable_thread import StoppableThread
 from mongoengine import Q
 
-from beer_garden.db.mongo.models import File, Request
+from beer_garden.db.mongo.models import File, RawFile, Request
 
 
 class MongoPruner(StoppableThread):

--- a/src/app/test/conftest.py
+++ b/src/app/test/conftest.py
@@ -42,12 +42,17 @@ def data_cleanup():
     UserToken.drop_collection()
 
 
+@pytest.fixture(scope="module")
+def local_garden_name():
+    return "somegarden"
+
+
 @pytest.fixture(scope="module", autouse=True)
-def app_config_auth_disabled():
+def app_config_auth_disabled(local_garden_name):
     app_config = Box(
         {
             "auth": {"enabled": False, "token_secret": "notsosecret"},
-            "garden": {"name": "somegarden"},
+            "garden": {"name": local_garden_name},
         }
     )
     config.assign(app_config, force=True)
@@ -55,7 +60,7 @@ def app_config_auth_disabled():
 
 
 @pytest.fixture
-def app_config_auth_enabled(monkeypatch):
+def app_config_auth_enabled(monkeypatch, local_garden_name):
     app_config = Box(
         {
             "auth": {
@@ -65,7 +70,7 @@ def app_config_auth_enabled(monkeypatch):
                     "basic": {"enabled": True},
                 },
             },
-            "garden": {"name": "somegarden"},
+            "garden": {"name": local_garden_name},
         }
     )
     monkeypatch.setattr(config, "_CONFIG", app_config)

--- a/src/app/test/db/mongo/pruner_test.py
+++ b/src/app/test/db/mongo/pruner_test.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 from mock import MagicMock, Mock, patch
 
-from beer_garden.db.mongo.models import Request
+from beer_garden.db.mongo.models import File, RawFile, Request
 from beer_garden.db.mongo.pruner import MongoPruner
 
 
@@ -39,24 +39,32 @@ class TestMongoPruner(object):
 
 class TestDetermineTasks(object):
     def test_determine_tasks(self):
-        config = {"info": 5, "action": 10}
+        config = {"info": 5, "action": 10, "file": 15}
 
         prune_tasks, run_every = MongoPruner.determine_tasks(**config)
 
-        assert len(prune_tasks) == 2
+        assert len(prune_tasks) == 4
         assert run_every == 2.5
 
         info_task = prune_tasks[0]
         action_task = prune_tasks[1]
+        file_task = prune_tasks[2]
+        raw_file_task = prune_tasks[3]
 
         assert info_task["collection"] == Request
         assert action_task["collection"] == Request
+        assert file_task["collection"] == File
+        assert raw_file_task["collection"] == RawFile
 
         assert info_task["field"] == "created_at"
         assert action_task["field"] == "created_at"
+        assert file_task["field"] == "updated_at"
+        assert raw_file_task["field"] == "created_at"
 
         assert info_task["delete_after"] == timedelta(minutes=5)
         assert action_task["delete_after"] == timedelta(minutes=10)
+        assert file_task["delete_after"] == timedelta(minutes=15)
+        assert raw_file_task["delete_after"] == timedelta(minutes=15)
 
     def test_setup_pruning_tasks_empty(self):
         prune_tasks, run_every = MongoPruner.determine_tasks()


### PR DESCRIPTION
Closes #1215 
Closes #1216

This PR makes two improvements to the handling of FileField fields:

* The gridfs file referenced by FileFields in the `Request` and `RawFile` models will now be properly cleaned up when the model instance itself is deleted.
* The `Request` model's save() method no longer produces or orphans a bunch of duplicate gridfs entries.

To achieve this, the following was done:

* A `request` LazyReferenceField with a CASCADE delete rule was added to the RawFile model
* The existing `Request.save()` logic was moved into a `_pre_save()` and refined to remove gridfs duplication.
* A new `_post_save()` method on the Request model was added, which updates the `request` reference field on the appropriate RawFile to point to the newly saved Request.
* A `FileFieldHandlingQuerySet` and corresponding `FileFieldHandlingQuerySetNoCache` custom QuerySet is now used by RawFile and Request to ensure that the GridFS files referenced get properly deleted.  Without this the references would be deleted, but not the actual GridFS files.

Additionally, the pruner has been updated to clean up RawFiles on the same interval as Files.

## Test Instructions
To see the changes in action:
* For ease of testing, make sure you don't have any gridfs files in your database (`db.fs.files.drop()` will do the trick).
* Task one of the commands of the `file_bytes` example plugin.
* Task some other request, ensuring that the parameters or output (or both) go over the 5MB (or hand-hacked smaller value) threshold for being stored in gridfs.
* In the database, note the value of `db.fs.files.count()`.  There should be one entry each for the `file_bytes` request as well as the parameters and/or output of the other request (so 2 or 3 depending on what your test data).
* In a python console, do a `Request.objects.all().delete()` or `Request.objects.no_cache().all().delete()`.
* In the database, check that `db.fs.files.count()` is now 0.