### PR TITLE
#1157 - Fix jobs failing routing when routing a spawned request to a child garden

### DIFF
--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger as APInterval
 from brewtils.errors import ModelValidationError
-from brewtils.models import DateTrigger, Event, Events, FileTrigger, Job, Operation
+from brewtils.models import DateTrigger, Event, Events, FileTrigger, Job, Request, Operation
 from mongoengine import ValidationError
 from pathtools.patterns import match_any_paths
 from watchdog.events import (
@@ -512,7 +512,8 @@ def run_job(job_id, request_template, **kwargs):
             logger.debug(f"{db_job!r} request completed with SUCCESS status")
             updates["inc__success_count"] = 1
 
-        db.modify(db_job, **updates)
+        if updates != {}: 
+            db.modify(db_job, **updates)
     except Exception as ex:
         logger.exception(f"Error executing {db_job}: {ex}")
 

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -20,8 +20,8 @@ from brewtils.models import (
     Events,
     FileTrigger,
     Job,
-    Request,
     Operation,
+    Request,
 )
 from mongoengine import ValidationError
 from pathtools.patterns import match_any_paths

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -490,8 +490,8 @@ def run_job(job_id, request_template, **kwargs):
         request = beer_garden.router.route(
             Operation(
                 operation_type="REQUEST_CREATE",
-                model=request_template,
-                model_type="RequestTemplate",
+                model=Request.from_template(request_template),
+                model_type="Request",
                 kwargs={"wait_event": wait_event},
             )
         )

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -14,7 +14,15 @@ from typing import Dict, List, Optional
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger as APInterval
 from brewtils.errors import ModelValidationError
-from brewtils.models import DateTrigger, Event, Events, FileTrigger, Job, Request, Operation
+from brewtils.models import (
+    DateTrigger,
+    Event,
+    Events,
+    FileTrigger,
+    Job,
+    Request,
+    Operation,
+)
 from mongoengine import ValidationError
 from pathtools.patterns import match_any_paths
 from watchdog.events import (
@@ -512,7 +520,7 @@ def run_job(job_id, request_template, **kwargs):
             logger.debug(f"{db_job!r} request completed with SUCCESS status")
             updates["inc__success_count"] = 1
 
-        if updates != {}: 
+        if updates != {}:
             db.modify(db_job, **updates)
     except Exception as ex:
         logger.exception(f"Error executing {db_job}: {ex}")


### PR DESCRIPTION
Closes #1157 

This should fix a routing issue for scheduled jobs to child gardens. Previously, the scheduler tried to forward a `RequestTemplate` to the child garden when tasking for a job, but this changes that to a `Request` so as to fix problems with `RequestTemplate`s in forwarding.

## To Test
- Set up a parent/child garden
- Schedule a job on the parent garden to make a request on the child garden

## Notes
This PR has revealed two other issues:
- The Success/Error counter does not increment as expected. I found that the only time these values are incremented is right after the scheduler sends the request to the child garden. Sometimes, when the scheduler checks if the request's status is `SUCCESS` so that in can increment the success count, it's still `IN_PROGRESS`. This should be handled a different way to insure a request's final status is sent back to the parent garden. (Moved to new issue: #1235)
- Scheduled jobs to child gardens will cause connection errors in the console on restart, since the scheduler tries to begin jobs before the child garden connection is up.