### PR TITLE
Add isort to make format, fix B009 and B010 flake8 errors

### DIFF
--- a/src/app/Makefile
+++ b/src/app/Makefile
@@ -95,6 +95,7 @@ clean: clean-all ## alias of clean-all
 # Formatting
 format: ## Run black formatter in-line
 	black $(MODULE_NAME) $(TEST_DIR)
+	isort $(MODULE_NAME) $(TEST_DIR)
 
 
 # Linting

--- a/src/app/beer_garden/local_plugins/runner.py
+++ b/src/app/beer_garden/local_plugins/runner.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 from brewtils.models import Runner
 
-log_levels = [n for n in getattr(logging, "_nameToLevel").keys()]
+log_levels = [n for n in logging._nameToLevel.keys()]
 
 
 def read_stream(process: subprocess.Popen, stream: TextIOBase, logger: logging.Logger):

--- a/src/app/test/local_plugins/manager_test.py
+++ b/src/app/test/local_plugins/manager_test.py
@@ -176,8 +176,8 @@ class TestLoadNew(object):
         assert len(manager._runners) == 0
         assert "hidden file" in caplog.messages[0]
 
-    def test_scan_path_no_paths(self, manager, caplog):
-        setattr(manager, "_plugin_path", None)
+    def test_scan_path_no_paths(self, monkeypatch, manager, caplog):
+        monkeypatch.setattr(manager, "_plugin_path", None)
 
         with caplog.at_level(logging.DEBUG):
             result = manager.scan_path()


### PR DESCRIPTION
This PR adds isort to the `format` command in the Makefile.  It also cleans up a couple of B009 and B010 errors that were being reported by flake8 (only when run locally for some reason).