### PR TITLE
#1216 - Clean up gridfs items when deleting Request and RawFile

### DIFF
--- a/src/app/beer_garden/db/mongo/querysets.py
+++ b/src/app/beer_garden/db/mongo/querysets.py
@@ -1,0 +1,39 @@
+from mongoengine import QuerySet, QuerySetNoCache, fields
+
+
+def _delete_file_field_objects(queryset):
+    """Deletes the files for each item in the queryset"""
+    file_field_names = []
+
+    for name, field in queryset._document._fields.items():
+        if type(field) == fields.FileField:
+            file_field_names.append(name)
+
+    if file_field_names:
+        for item in queryset.all():
+            for field_name in file_field_names:
+                getattr(item, field_name).delete()
+
+
+class FileFieldHandlingQuerySet(QuerySet):
+    """A QuerySet that appropriately handles cleanup of any FileField fields (gridfs
+    objects) when calling delete()"""
+
+    def delete(self, *args, **kwargs):
+        _delete_file_field_objects(self)
+        super().delete(*args, **kwargs)
+
+    def no_cache(self):
+        """Convert to a non-caching queryset"""
+        return self._clone_into(
+            FileFieldHandlingQuerySetNoCache(self._document, self._collection)
+        )
+
+
+class FileFieldHandlingQuerySetNoCache(QuerySetNoCache):
+    """A QuerySetNoCache that appropriately handles cleanup of any FileField fields
+    (gridfs objects) when calling delete()"""
+
+    def delete(self, *args, **kwargs):
+        _delete_file_field_objects(self)
+        super().delete(*args, **kwargs)

--- a/src/app/test/conftest.py
+++ b/src/app/test/conftest.py
@@ -42,12 +42,17 @@ def data_cleanup():
     UserToken.drop_collection()
 
 
+@pytest.fixture(scope="module")
+def local_garden_name():
+    return "somegarden"
+
+
 @pytest.fixture(scope="module", autouse=True)
-def app_config_auth_disabled():
+def app_config_auth_disabled(local_garden_name):
     app_config = Box(
         {
             "auth": {"enabled": False, "token_secret": "notsosecret"},
-            "garden": {"name": "somegarden"},
+            "garden": {"name": local_garden_name},
         }
     )
     config.assign(app_config, force=True)
@@ -55,7 +60,7 @@ def app_config_auth_disabled():
 
 
 @pytest.fixture
-def app_config_auth_enabled(monkeypatch):
+def app_config_auth_enabled(monkeypatch, local_garden_name):
     app_config = Box(
         {
             "auth": {
@@ -65,7 +70,7 @@ def app_config_auth_enabled(monkeypatch):
                     "basic": {"enabled": True},
                 },
             },
-            "garden": {"name": "somegarden"},
+            "garden": {"name": local_garden_name},
         }
     )
     monkeypatch.setattr(config, "_CONFIG", app_config)

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -8,6 +8,7 @@ from brewtils.errors import ModelValidationError, RequestStatusTransitionError
 from brewtils.schemas import RequestTemplateSchema
 from mock import Mock
 from mongoengine import NotUniqueError, ValidationError, connect
+from mongomock.gridfs import enable_gridfs_integration
 
 import beer_garden.db.api as db
 import beer_garden.db.mongo.models
@@ -21,6 +22,7 @@ from beer_garden.db.mongo.models import (
     Instance,
     Job,
     Parameter,
+    RawFile,
     Request,
     Role,
     RoleAssignment,
@@ -28,6 +30,8 @@ from beer_garden.db.mongo.models import (
     User,
     UserToken,
 )
+
+enable_gridfs_integration()
 
 
 class TestCommand(object):
@@ -249,16 +253,26 @@ class TestRequest(object):
         )
 
     @pytest.fixture()
-    def request_model(self):
+    def raw_file(self):
+        rawfile = RawFile().save()
+
+        yield rawfile
+        rawfile.delete()
+
+    @pytest.fixture()
+    def request_model(self, raw_file, local_garden_name):
         req = Request(
             system="foo",
             command="bar",
             status="CREATED",
             system_version="1.0.0",
             instance_name="foobar",
-            namespace="somegarden",
+            namespace=local_garden_name,
         )
-        req.parameters = {"message": "hi"}
+        req.parameters = {
+            "message": "hi",
+            "file_param": {"type": "bytes", "id": str(raw_file.id)},
+        }
         req.output = "bye"
         req.parameters_gridfs.put = Mock()
         req.output_gridfs.put = Mock()
@@ -336,6 +350,20 @@ class TestRequest(object):
         request_model.save()
 
         assert request_model.status_updated_at == status_updated_at
+
+    def test_save_updates_raw_file_reference(self, request_model):
+        request_model.status = "CREATED"
+        request_model.save()
+
+        assert len(RawFile.objects.filter(request=request_model)) == 1
+
+    def test_delete_cascade_deletes_raw_file(self, request_model, raw_file):
+        request_model.save()
+        raw_file.request = request_model
+        raw_file.save()
+        request_model.delete()
+
+        assert len(RawFile.objects.filter(request=request_model)) == 0
 
 
 class TestSystem(object):

--- a/src/app/test/db/mongo/pruner_test.py
+++ b/src/app/test/db/mongo/pruner_test.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 from mock import MagicMock, Mock, patch
 
-from beer_garden.db.mongo.models import Request
+from beer_garden.db.mongo.models import File, RawFile, Request
 from beer_garden.db.mongo.pruner import MongoPruner
 
 
@@ -39,24 +39,32 @@ class TestMongoPruner(object):
 
 class TestDetermineTasks(object):
     def test_determine_tasks(self):
-        config = {"info": 5, "action": 10}
+        config = {"info": 5, "action": 10, "file": 15}
 
         prune_tasks, run_every = MongoPruner.determine_tasks(**config)
 
-        assert len(prune_tasks) == 2
+        assert len(prune_tasks) == 4
         assert run_every == 2.5
 
         info_task = prune_tasks[0]
         action_task = prune_tasks[1]
+        file_task = prune_tasks[2]
+        raw_file_task = prune_tasks[3]
 
         assert info_task["collection"] == Request
         assert action_task["collection"] == Request
+        assert file_task["collection"] == File
+        assert raw_file_task["collection"] == RawFile
 
         assert info_task["field"] == "created_at"
         assert action_task["field"] == "created_at"
+        assert file_task["field"] == "updated_at"
+        assert raw_file_task["field"] == "created_at"
 
         assert info_task["delete_after"] == timedelta(minutes=5)
         assert action_task["delete_after"] == timedelta(minutes=10)
+        assert file_task["delete_after"] == timedelta(minutes=15)
+        assert raw_file_task["delete_after"] == timedelta(minutes=15)
 
     def test_setup_pruning_tasks_empty(self):
         prune_tasks, run_every = MongoPruner.determine_tasks()

--- a/src/app/test/db/mongo/querysets_test.py
+++ b/src/app/test/db/mongo/querysets_test.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import pytest
+from mock import Mock
+from mongoengine import Document, GridFSProxy, fields
+from mongomock.gridfs import enable_gridfs_integration
+
+from beer_garden.db.mongo.querysets import FileFieldHandlingQuerySet
+
+FILE_COUNT = 3
+
+enable_gridfs_integration()
+
+
+class ModelWithFileField(Document):
+    file_field = fields.FileField()
+
+    meta = {"queryset_class": FileFieldHandlingQuerySet}
+
+
+@pytest.fixture()
+def model_instances():
+    for _ in range(FILE_COUNT):
+        ModelWithFileField().save()
+
+    yield
+    ModelWithFileField.drop_collection()
+
+
+class TestFileFieldHandlingQuerySet:
+    def test_delete_calls_file_field_delete(self, monkeypatch, model_instances):
+        monkeypatch.setattr(GridFSProxy, "delete", Mock())
+        ModelWithFileField.objects.all().delete()
+
+        assert GridFSProxy.delete.call_count == FILE_COUNT
+
+
+class TestFileFieldHandlingQuerySetNoCache:
+    def test_delete_calls_file_field_delete(self, monkeypatch, model_instances):
+        monkeypatch.setattr(GridFSProxy, "delete", Mock())
+        ModelWithFileField.objects.all().no_cache().delete()
+
+        assert GridFSProxy.delete.call_count == FILE_COUNT


### PR DESCRIPTION
Closes #1215 
Closes #1216

This PR makes two improvements to the handling of FileField fields:

* The gridfs file referenced by FileFields in the `Request` and `RawFile` models will now be properly cleaned up when the model instance itself is deleted.
* The `Request` model's save() method no longer produces or orphans a bunch of duplicate gridfs entries.

To achieve this, the following was done:

* A `request` LazyReferenceField with a CASCADE delete rule was added to the RawFile model
* The existing `Request.save()` logic was moved into a `_pre_save()` and refined to remove gridfs duplication.
* A new `_post_save()` method on the Request model was added, which updates the `request` reference field on the appropriate RawFile to point to the newly saved Request.
* A `FileFieldHandlingQuerySet` and corresponding `FileFieldHandlingQuerySetNoCache` custom QuerySet is now used by RawFile and Request to ensure that the GridFS files referenced get properly deleted.  Without this the references would be deleted, but not the actual GridFS files.

Additionally, the pruner has been updated to clean up RawFiles on the same interval as Files.

## Test Instructions
To see the changes in action:
* For ease of testing, make sure you don't have any gridfs files in your database (`db.fs.files.drop()` will do the trick).
* Task one of the commands of the `file_bytes` example plugin.
* Task some other request, ensuring that the parameters or output (or both) go over the 5MB (or hand-hacked smaller value) threshold for being stored in gridfs.
* In the database, note the value of `db.fs.files.count()`.  There should be one entry each for the `file_bytes` request as well as the parameters and/or output of the other request (so 2 or 3 depending on what your test data).
* In a python console, do a `Request.objects.all().delete()` or `Request.objects.no_cache().all().delete()`.
* In the database, check that `db.fs.files.count()` is now 0.