### PR TITLE
#1213 - Improve handling of error events

### DIFF
--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -9,7 +9,7 @@ import beer_garden.log
 import beer_garden.requests
 import beer_garden.router
 from beer_garden.api.stomp.transport import Connection, parse_header_list
-from beer_garden.events import event_blacklisted, publish
+from beer_garden.events import can_send_event_to_parent, publish
 from beer_garden.events.processors import BaseProcessor
 
 logger = logging.getLogger(__name__)
@@ -158,8 +158,7 @@ class StompManager(BaseProcessor):
                 self.remove_garden_from_list(
                     garden_name=event.payload.name, skip_key=skip_key
                 )
-
-        if not event_blacklisted(event):
+        if can_send_event_to_parent(event):
             for value in self.conn_dict.values():
                 conn = value["conn"]
                 if conn:

--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -9,7 +9,7 @@ import beer_garden.log
 import beer_garden.requests
 import beer_garden.router
 from beer_garden.api.stomp.transport import Connection, parse_header_list
-from beer_garden.events import can_send_event_to_parent, publish
+from beer_garden.events import event_blocklisted, publish
 from beer_garden.events.processors import BaseProcessor
 
 logger = logging.getLogger(__name__)
@@ -158,7 +158,7 @@ class StompManager(BaseProcessor):
                 self.remove_garden_from_list(
                     garden_name=event.payload.name, skip_key=skip_key
                 )
-        if can_send_event_to_parent(event):
+        if not event_blocklisted(event):
             for value in self.conn_dict.values():
                 conn = value["conn"]
                 if conn:

--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -338,7 +338,7 @@ class Application(StoppableThread):
             event_manager.register(
                 HttpParentUpdater(
                     easy_client=easy_client,
-                    black_list=config.get("parent.skip_events"),
+                    block_list=config.get("parent.skip_events"),
                     reconnect_action=reconnect_action,
                 )
             )

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -76,7 +76,7 @@ __all__ = [
     "Role",
     "RoleAssignment",
     "User",
-    "CommandPublishingBlackList",
+    "CommandPublishingBlockList",
 ]
 
 REQUEST_MAX_PARAM_SIZE = 5 * 1_000_000
@@ -854,7 +854,7 @@ class RawFile(Document):
     file = FileField()
 
 
-class CommandPublishingBlackList(Document):
+class CommandPublishingBlockList(Document):
 
     namespace = StringField(required=True)
     system = StringField(required=True)

--- a/src/app/beer_garden/events/__init__.py
+++ b/src/app/beer_garden/events/__init__.py
@@ -17,6 +17,25 @@ manager = None
 logger = logging.getLogger(__name__)
 
 
+def _send_event_error(event):
+    return not (
+        event.error and event.name.startswith("REQUEST") and event.payload is None
+    )
+
+
+def can_send_event_to_parent(event):
+    """
+    This will determine if an event can be sent to a parent garden.
+
+    Args:
+        event: an Event object
+
+    Returns:
+        Boolean: Determination of whether event should be sent to parent
+    """
+    return _send_event_error(event) and not event_blacklisted(event)
+
+
 def publish(event: Event) -> None:
     """Convenience method for publishing events
 

--- a/src/app/beer_garden/events/__init__.py
+++ b/src/app/beer_garden/events/__init__.py
@@ -8,32 +8,13 @@ import wrapt
 from brewtils.models import Event, Events
 
 from beer_garden import config as config
-from beer_garden.db.mongo.models import CommandPublishingBlackList
+from beer_garden.db.mongo.models import CommandPublishingBlockList
 
 # In this master process this should be an instance of EventManager, and in entry points
 # it should be an instance of EntryPointManager
 manager = None
 
 logger = logging.getLogger(__name__)
-
-
-def _send_event_error(event):
-    return not (
-        event.error and event.name.startswith("REQUEST") and event.payload is None
-    )
-
-
-def can_send_event_to_parent(event):
-    """
-    This will determine if an event can be sent to a parent garden.
-
-    Args:
-        event: an Event object
-
-    Returns:
-        Boolean: Determination of whether event should be sent to parent
-    """
-    return _send_event_error(event) and not event_blacklisted(event)
 
 
 def publish(event: Event) -> None:
@@ -159,31 +140,40 @@ def _async_callback(task, event_type=None):
             logger.exception(f"Error publishing event: {ex}")
 
 
-def _event_blacklisted_by_name(event):
+def _event_blocklisted_by_name(event):
     return event.name in config.get("parent.skip_events")
 
 
-def _event_blacklisted_by_command(event):
+def _event_blocklisted_by_command(event):
     if event.payload_type == "Request":
         try:
-            CommandPublishingBlackList.objects.get(
+            CommandPublishingBlockList.objects.get(
                 namespace=event.payload.namespace,
                 system=event.payload.system,
                 command=event.payload.command,
             )
             return True
-        except CommandPublishingBlackList.DoesNotExist:
-            return False
+        except CommandPublishingBlockList.DoesNotExist:
+            pass
+    return False
 
 
-def event_blacklisted(event: Event) -> bool:
+def _event_is_blocklisted_error(event: Event):
+    return event.error and event.name.startswith("REQUEST") and event.payload is None
+
+
+def event_blocklisted(event: Event) -> bool:
     """
-    This will determine if an event is black listed from being sent to a parent garden.
+    This will determine if an event is in block list from being sent to a parent garden.
 
     Args:
         event: an Event object
 
     Returns:
-        Boolean: The result of if event is black listed
+        Boolean: The result of if event is in block list
     """
-    return _event_blacklisted_by_name(event) or _event_blacklisted_by_command(event)
+    return (
+        _event_blocklisted_by_name(event)
+        or _event_blocklisted_by_command(event)
+        or _event_is_blocklisted_error(event)
+    )

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -2,7 +2,7 @@ from brewtils.models import Event, Operation
 from requests import RequestException
 
 import beer_garden.config as conf
-from beer_garden.events import can_send_event_to_parent
+from beer_garden.events import event_blocklisted
 from beer_garden.events.processors import QueueListener
 
 
@@ -18,10 +18,10 @@ class HttpParentUpdater(QueueListener):
     """
 
     def __init__(
-        self, easy_client=None, black_list=None, reconnect_action=None, **kwargs
+        self, easy_client=None, block_list=None, reconnect_action=None, **kwargs
     ):
         self._ez_client = easy_client
-        self._black_list = black_list or []
+        self._block_list = block_list or []
         self._reconnect_action = reconnect_action
         self._connected = True
 
@@ -44,7 +44,7 @@ class HttpParentUpdater(QueueListener):
         # TODO - This shouldn't be set here
         event.garden = conf.get("garden.name")
 
-        if can_send_event_to_parent(event):
+        if not event_blocklisted(event):
             try:
                 operation = Operation(
                     operation_type="PUBLISH_EVENT", model=event, model_type="Event"

--- a/src/app/beer_garden/events/parent_procesors.py
+++ b/src/app/beer_garden/events/parent_procesors.py
@@ -2,7 +2,7 @@ from brewtils.models import Event, Operation
 from requests import RequestException
 
 import beer_garden.config as conf
-from beer_garden.events import event_blacklisted
+from beer_garden.events import can_send_event_to_parent
 from beer_garden.events.processors import QueueListener
 
 
@@ -44,7 +44,7 @@ class HttpParentUpdater(QueueListener):
         # TODO - This shouldn't be set here
         event.garden = conf.get("garden.name")
 
-        if not event_blacklisted(event):
+        if can_send_event_to_parent(event):
             try:
                 operation = Operation(
                     operation_type="PUBLISH_EVENT", model=event, model_type="Event"

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -15,7 +15,7 @@ from beer_garden.api.authorization import Permissions
 from beer_garden.db.mongo.models import (
     Choices,
     Command,
-    CommandPublishingBlackList,
+    CommandPublishingBlockList,
     DateTrigger,
     Garden,
     Instance,
@@ -663,18 +663,18 @@ class TestCommandBlackList:
     command = "command_test"
 
     @pytest.fixture()
-    def command_black_list(self):
-        black_list = CommandPublishingBlackList(
+    def command_blocklist(self):
+        blocklist = CommandPublishingBlockList(
             namespace=self.namespace, system=self.system, command=self.command
         ).save()
 
-        yield black_list
-        black_list.delete()
+        yield blocklist
+        blocklist.delete()
 
-    def test_black_list_entries_are_required_to_be_unique(self, command_black_list):
-        """Attempting to create a black list entry already in database should raise an exception"""
+    def test_blocklist_entries_are_required_to_be_unique(self, command_blocklist):
+        """Attempting to create a blocklist entry already in database should raise an exception"""
         with pytest.raises(NotUniqueError):
-            CommandPublishingBlackList(
+            CommandPublishingBlockList(
                 namespace=self.namespace, system=self.system, command=self.command
             ).save()
 

--- a/src/app/test/db/mongo/models_test.py
+++ b/src/app/test/db/mongo/models_test.py
@@ -657,7 +657,7 @@ class TestUserToken:
         assert len(UserToken.objects.filter(id=user_token.id)) == 0
 
 
-class TestCommandBlackList:
+class TestCommandBlockList:
     namespace = "test"
     system = "system_test"
     command = "command_test"

--- a/src/app/test/events/init.py
+++ b/src/app/test/events/init.py
@@ -3,8 +3,8 @@ import pytest
 from brewtils.models import Event
 
 from beer_garden import config
-from beer_garden.db.mongo.models import CommandPublishingBlackList, Request
-from beer_garden.events import can_send_event_to_parent, event_blacklisted
+from beer_garden.db.mongo.models import CommandPublishingBlockList, Request
+from beer_garden.events import event_blocklisted
 
 
 class TestSendEventToParent(object):
@@ -21,46 +21,44 @@ class TestSendEventToParent(object):
         return []
 
     @pytest.fixture()
-    def command_black_list(self):
-        black_list = CommandPublishingBlackList(
+    def command_blocklist(self):
+        blocklist = CommandPublishingBlockList(
             namespace=self.event.payload.namespace,
             system=self.event.payload.system,
             command=self.event.payload.command,
         ).save()
 
-        yield black_list
-        black_list.delete()
+        yield blocklist
+        blocklist.delete()
 
-    def test_command_exists_in_blacklist(self, command_black_list, monkeypatch):
+    def test_command_exists_in_blocklist(self, command_blocklist, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
 
-        assert event_blacklisted(self.event)
+        assert event_blocklisted(self.event)
 
-    def test_command_missing_in_blacklist(self, monkeypatch):
+    def test_command_missing_in_blocklist(self, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
 
-        assert not event_blacklisted(self.event)
+        assert not event_blocklisted(self.event)
 
     def test_event_not_request(self, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
         event = Event(name="ENTRY_STARTED")
 
-        assert not event_blacklisted(event)
+        assert not event_blocklisted(event)
 
     def test_can_send_event_error(self, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
         event = Event(name="REQUEST_CREATE", error=True)
 
-        assert not can_send_event_to_parent(event)
+        assert event_blocklisted(event)
 
     def test_can_send_event_to_parent(self, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
 
-        assert can_send_event_to_parent(self.event)
+        assert not event_blocklisted(self.event)
 
-    def test_can_send_event_to_parent_blacklisted(
-        self, command_black_list, monkeypatch
-    ):
+    def test_can_send_event_to_parent_blocklist(self, command_blocklist, monkeypatch):
         monkeypatch.setattr(config, "get", self.config_get)
 
-        assert not can_send_event_to_parent(self.event)
+        assert event_blocklisted(self.event)

--- a/src/ui/src/js/controllers/request_index.js
+++ b/src/ui/src/js/controllers/request_index.js
@@ -232,14 +232,16 @@ export default function requestIndexController(
   };
 
   EventService.addCallback("request_index", (event) => {
-    switch (event.name) {
-      case "REQUEST_CREATED":
-      case "REQUEST_STARTED":
-      case "REQUEST_COMPLETED":
-        if ($scope.dtInstance) {
-          $("#newData").css("visibility", "visible");
-        }
-        break;
+    if (!event.error) {
+      switch (event.name) {
+        case "REQUEST_CREATED":
+        case "REQUEST_STARTED":
+        case "REQUEST_COMPLETED":
+          if ($scope.dtInstance) {
+            $("#newData").css("visibility", "visible");
+          }
+          break;
+      }
     }
   });
 


### PR DESCRIPTION
closes #1213 

Added check to see if event errors can be sent to parent. It currently blocks error events that name starts with `REQUEST` and have no payload.

## Testing Instructions

- Start a parent and child garden
- Add a raise somewhere in the critical path of request creation. The first line of the remove_bytes_parameter_base64 function in requests.py is a good choice.
- Restart the child garden and attempt to task something from it directly (i.e. don't go through the parent).

Result should be that the Requests page does not show `Updates Detected` and the error event should not be published in the parent logs. 