### PR TITLE
#1225 - Increment job error count in all cases

### DIFF
--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -20,13 +20,8 @@ from brewtils.models import (
     Events,
     FileTrigger,
     Job,
-<<<<<<< HEAD
     Operation,
     Request,
-=======
-    Request,
-    Operation,
->>>>>>> Fix linting
 )
 from mongoengine import ValidationError
 from pathtools.patterns import match_any_paths

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -523,7 +523,7 @@ def run_job(job_id, request_template, **kwargs):
         if updates != {}:
             db.modify(db_job, **updates)
     except Exception as ex:
-        logger.exception(f"Error executing {db_job}: {ex}")
+        logger.error(f"Error executing {db_job}: {ex}")
         db.modify(db_job, {"inc__error_count": 1})
 
     # Be a little careful here as the job could have been removed or paused

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -20,8 +20,13 @@ from brewtils.models import (
     Events,
     FileTrigger,
     Job,
+<<<<<<< HEAD
     Operation,
     Request,
+=======
+    Request,
+    Operation,
+>>>>>>> Fix linting
 )
 from mongoengine import ValidationError
 from pathtools.patterns import match_any_paths

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -524,7 +524,7 @@ def run_job(job_id, request_template, **kwargs):
             db.modify(db_job, **updates)
     except Exception as ex:
         logger.error(f"Error executing {db_job}: {ex}")
-        db.modify(db_job, {"inc__error_count": 1})
+        db.modify(db_job, inc__error_count=1)
 
     # Be a little careful here as the job could have been removed or paused
     job = beer_garden.application.scheduler.get_job(job_id)

--- a/src/app/beer_garden/scheduler.py
+++ b/src/app/beer_garden/scheduler.py
@@ -524,6 +524,7 @@ def run_job(job_id, request_template, **kwargs):
             db.modify(db_job, **updates)
     except Exception as ex:
         logger.exception(f"Error executing {db_job}: {ex}")
+        db.modify(db_job, {"inc__error_count": 1})
 
     # Be a little careful here as the job could have been removed or paused
     job = beer_garden.application.scheduler.get_job(job_id)


### PR DESCRIPTION
Closes #1225 

Change to increment job error count on exception (as opposed to just when the garden returns an error). This should fix issues where the job isn't being run for reasons unrelated to the request, yet the job error count is not incremented.

## To Test
- Create a job using any command from the the `error` system, ensure that the error count increments on each run of the job.
- Create a job that raises an exception at the job level, as opposed to at the request level. In fact, it may even be sufficient to just insert a manual exception into the area the except block covers.