### PR TITLE
#1243 - Add authorization checks to websocket event publishing

### DIFF
--- a/src/app/beer_garden/api/http/authentication/__init__.py
+++ b/src/app/beer_garden/api/http/authentication/__init__.py
@@ -180,7 +180,7 @@ def decode_token(encoded_token: str, expected_type: str = None) -> dict:
     token_type = decoded_token["type"]
     if expected_type and token_type != expected_type:
         raise InvalidTokenException(
-            f"Incorrect token type. Expected {expected_type}," "received {token_type}."
+            f"Incorrect token type. Expected {expected_type} received {token_type}."
         )
 
     return decoded_token

--- a/src/app/beer_garden/api/http/authentication/__init__.py
+++ b/src/app/beer_garden/api/http/authentication/__init__.py
@@ -73,13 +73,16 @@ def refresh_token_pair(refresh_token: str) -> dict:
             { "access": <str>, "refresh": <str> }
 
     Raises:
-        ExpiredTokenException: The supplied refresh token has expired, either due
-            to reaching it's natural expiration or having been revoked.
+        ExpiredTokenException: The supplied refresh token has expired, either due to
+            reaching it's natural expiration or having been revoked.
+        InvalidTokenException: The token could not be decoded or is the incorrect type
+            of token and is therefore invalid
     """
+    decoded_refresh_token = decode_token(refresh_token)
+
     try:
-        decoded_refresh_token = _decode_token(refresh_token)
         refresh_token_obj = UserToken.objects.get(uuid=decoded_refresh_token["jti"])
-    except (jwt.ExpiredSignatureError, UserToken.DoesNotExist):
+    except UserToken.DoesNotExist:
         raise ExpiredTokenException
 
     expiration = datetime.fromtimestamp(decoded_refresh_token["exp"], tz=timezone.utc)
@@ -101,12 +104,86 @@ def revoke_token_pair(refresh_token: str) -> None:
         None
     """
     try:
-        decoded_refresh_token = _decode_token(refresh_token)
+        decoded_refresh_token = decode_token(refresh_token)
         UserToken.objects.get(uuid=decoded_refresh_token["jti"]).delete()
-    except (jwt.ExpiredSignatureError, UserToken.DoesNotExist):
+    except (ExpiredTokenException, UserToken.DoesNotExist):
         # Since we're trying to revoke the token anyway, do nothing if it was already
         # expired or revoked
         pass
+
+
+def get_user_from_token(access_token: dict, revoke_expired=True) -> User:
+    """Gets the User object corresponding to the jwt access token provided in the
+    request.
+
+    Args:
+        access_token: A decoded jwt access token
+        revoke_expired: Bool determining whether an expired token will result in all
+            of a user's tokens being revoked. This should be True when called in a
+            context where an expired token could be a sign of a compromised token.
+
+    Returns:
+        User: The User corresponding to the jwt access token in the request
+
+    Raise:
+        InvalidTokenException: The token is invalid as there is no matching UserToken
+        ExpiredTokenException: The token is valid, but the corresponding User no
+            longer exists.
+    """
+    try:
+        user = User.objects.get(id=access_token["sub"])
+    except User.DoesNotExist:
+        raise InvalidTokenException
+
+    try:
+        _ = UserToken.objects.get(uuid=access_token["jti"])
+    except UserToken.DoesNotExist:
+        if revoke_expired:
+            user.revoke_tokens()
+
+        raise ExpiredTokenException
+
+    user.set_permissions_cache(access_token["permissions"])
+
+    return user
+
+
+def decode_token(encoded_token: str, expected_type: str = None) -> dict:
+    """Decodes an encoded access token string
+
+    Args:
+        encoded_token: The encoded JWT string
+        expected_type: Specify the type of token expecting to be decoded. If specified
+            an exception will be thrown if the decoded type does not match. If not
+            specified, no check will be performed.
+
+    Returns:
+        dict: The decoded access token
+
+    Raises:
+        ExpiredTokenException: The token expiration date has passed
+        InvalidTokenException: The token could not be decoded or is the incorrect type
+            of token and is therefore invalid
+    """
+    secret_key = config.get("auth").token_secret
+
+    try:
+        algorithm = jwt.get_unverified_header(encoded_token)["alg"]
+        decoded_token = jwt.decode(
+            encoded_token, key=secret_key, algorithms=[algorithm]
+        )
+    except (jwt.InvalidSignatureError, jwt.DecodeError, KeyError) as exc:
+        raise InvalidTokenException(exc)
+    except jwt.ExpiredSignatureError:
+        raise ExpiredTokenException
+
+    token_type = decoded_token["type"]
+    if expected_type and token_type != expected_type:
+        raise InvalidTokenException(
+            f"Incorrect token type. Expected {expected_type}," "received {token_type}."
+        )
+
+    return decoded_token
 
 
 def _generate_access_token(user: User, identifier: UUID) -> str:
@@ -157,14 +234,3 @@ def _get_access_token_expiration() -> datetime:
 def _get_refresh_token_expiration() -> datetime:
     """Calculate and return the refresh token expiration time"""
     return datetime.utcnow() + timedelta(hours=12)
-
-
-def _decode_token(token) -> dict:
-    """Decode the supplied token and return the contents as a dict"""
-    secret_key = config.get("auth").token_secret
-
-    try:
-        token_headers = jwt.get_unverified_header(token)
-        return jwt.decode(token, key=secret_key, algorithms=[token_headers["alg"]])
-    except (jwt.DecodeError, jwt.InvalidSignatureError):
-        raise InvalidTokenException

--- a/src/app/beer_garden/api/http/base_handler.py
+++ b/src/app/beer_garden/api/http/base_handler.py
@@ -198,7 +198,7 @@ class BaseHandler(RequestHandler):
                 message = error_dict.get("message", getattr(e, "message", str(e)))
                 code = error_dict.get("status_code", 500)
             elif issubclass(typ3, BaseHTTPError):
-                message = typ3.reason
+                message = self._reason
                 code = typ3.status_code
             elif config.get("ui.debug_mode"):
                 message = str(e)

--- a/src/app/beer_garden/api/http/exceptions.py
+++ b/src/app/beer_garden/api/http/exceptions.py
@@ -46,16 +46,6 @@ class AuthenticationFailed(BaseHTTPError):
     reason: str = "Authentication Failed"
 
 
-class InvalidToken(BaseHTTPError):
-    status_code: int = 401
-    reason: str = "Authorization token invalid"
-
-
-class ExpiredToken(BaseHTTPError):
-    status_code: int = 401
-    reason: str = "Authorization token expired"
-
-
 class RequestForbidden(BaseHTTPError):
     status_code: int = 403
     reason: str = "Access denied"

--- a/src/app/beer_garden/api/http/processors.py
+++ b/src/app/beer_garden/api/http/processors.py
@@ -18,7 +18,7 @@ class EventManager:
 
 
 def websocket_publish(item):
-    """Will serialize an event and publish it to all event websocket endpoints"""
+    """Publish an event to all websocket endpoints"""
     try:
         beer_garden.api.http.io_loop.add_callback(EventSocket.publish, item)
     except Exception as ex:

--- a/src/app/beer_garden/api/http/processors.py
+++ b/src/app/beer_garden/api/http/processors.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from brewtils.schema_parser import SchemaParser
-
 import beer_garden.api.http
 from beer_garden.api.http.handlers.v1.event import EventSocket
 
@@ -22,8 +20,6 @@ class EventManager:
 def websocket_publish(item):
     """Will serialize an event and publish it to all event websocket endpoints"""
     try:
-        beer_garden.api.http.io_loop.add_callback(
-            EventSocket.publish, SchemaParser.serialize(item, to_string=True)
-        )
+        beer_garden.api.http.io_loop.add_callback(EventSocket.publish, item)
     except Exception as ex:
         logger.exception(f"Error publishing event to websocket: {ex}")

--- a/src/app/test/api/http/unit/handlers/v1/event_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/event_test.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+import json
+
+import pytest
+from brewtils.models import Event, System
+from tornado import gen
+from tornado.testing import AsyncHTTPTestCase, gen_test
+from tornado.web import Application
+from tornado.websocket import websocket_connect
+
+from beer_garden.api.http.handlers.v1.event import EventSocket
+
+
+@pytest.fixture
+def eventsocket_mock(monkeypatch):
+    from beer_garden.api.http.handlers.v1 import event
+
+    def get_current_user(self):
+        return "someuser"
+
+    def _user_can_receive_messages_for_event(user, event):
+        return True
+
+    monkeypatch.setattr(EventSocket, "get_current_user", get_current_user)
+    monkeypatch.setattr(
+        event,
+        "_user_can_receive_messages_for_event",
+        _user_can_receive_messages_for_event,
+    )
+
+
+@pytest.fixture
+def user_from_token_mocks(monkeypatch):
+    from beer_garden.api.http.handlers.v1 import event
+
+    def decode_token(encoded_token, expected_type):
+        return {"access": "mytoken"}
+
+    def get_user_from_token(access_token):
+        return "someuser"
+
+    monkeypatch.setattr(event, "decode_token", decode_token)
+    monkeypatch.setattr(event, "get_user_from_token", get_user_from_token)
+
+
+def token_update_message(token):
+    return json.dumps({"name": "UPDATE_TOKEN", "payload": token})
+
+
+class TestEventSocket(AsyncHTTPTestCase):
+    path = "/api/v1/socket/events"
+    event = Event(name="EVENT", payload_type="System", payload=System(name="mysystem"))
+
+    def get_app(self):
+        return Application([(self.path, EventSocket)])
+
+    @gen.coroutine
+    def ws_connect(self):
+        url = f"ws://localhost:{self.get_http_port()}{self.path}"
+        ws = yield websocket_connect(url)
+        return ws
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_enabled")
+    def test_event_socket_requests_authorization_on_connect(self):
+        ws_client = yield self.ws_connect()
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["name"] == "AUTHORIZATION_REQUIRED"
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_enabled", "user_from_token_mocks")
+    def test_event_socket_accepts_valid_token_update(self):
+        ws_client = yield self.ws_connect()
+        yield ws_client.read_message()  # Read the AUTHORIZATION_REQUIRED message
+
+        ws_client.write_message(token_update_message("totallyvalidtoken"))
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["name"] == "TOKEN_UPDATED"
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_enabled")
+    def test_event_socket_rejects_invalid_token_update(self):
+        ws_client = yield self.ws_connect()
+        yield ws_client.read_message()  # Read the AUTHORIZATION_REQUIRED message
+
+        access_token = "invalidtoken"
+        ws_client.write_message(token_update_message(access_token))
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["name"] == "AUTHORIZATION_REQUIRED"
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_enabled")
+    def test_event_socket_rejects_bad_messages(self):
+        ws_client = yield self.ws_connect()
+        yield ws_client.read_message()  # Read the AUTHORIZATION_REQUIRED message
+
+        ws_client.write_message("improperly formatted message")
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["name"] == "BAD_MESSAGE"
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_disabled")
+    def test_publish_auth_disabled(self):
+        ws_client = yield self.ws_connect()
+        EventSocket.publish(self.event)
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["payload"]["name"] == self.event.payload.name
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_enabled")
+    def test_publish_auth_enabled_requests_authorization(self):
+        ws_client = yield self.ws_connect()
+        yield ws_client.read_message()  # Read the AUTHORIZATION_REQUIRED message
+
+        EventSocket.publish(self.event)
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["name"] == "AUTHORIZATION_REQUIRED"
+
+    @gen_test
+    @pytest.mark.usefixtures("app_config_auth_enabled", "eventsocket_mock")
+    def test_publish_auth_enabled_publishes_event_for_authorized_user(self):
+        ws_client = yield self.ws_connect()
+        yield ws_client.read_message()  # Read the AUTHORIZATION_REQUIRED message
+
+        EventSocket.publish(self.event)
+
+        response = yield ws_client.read_message()
+        ws_client.close()
+        response_dict = json.loads(response)
+
+        assert response_dict["payload"]["name"] == self.event.payload.name

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -134,7 +134,7 @@ export default function appRun(
     }
 
     // Connect to the event socket
-    EventService.connect(token);
+    EventService.connect();
 
     // Load theme from local storage
     // REMOVE THIS ONCE THE rootScope.loadUser CALL BELOW IS ENABLED
@@ -266,6 +266,12 @@ export default function appRun(
       removeSystem(event.payload);
     } else if (event.name.startsWith("INSTANCE")) {
       updateInstance(event.payload);
+    }
+  });
+
+  EventService.addCallback("websocket_authorization", (event) => {
+    if (event.name === "AUTHORIZATION_REQUIRED") {
+      EventService.updateToken(TokenService.getToken());
     }
   });
 

--- a/src/ui/src/js/services/event_service.js
+++ b/src/ui/src/js/services/event_service.js
@@ -1,11 +1,8 @@
-eventService.$inject = ["TokenService"];
-
 /**
  * eventService - Service for getting systems from the API.
- * @param  {Object} TokenService      Service for Token information.
  * @return {Object}                   Object for interacting with the event API.
  */
-export default function eventService(TokenService) {
+export default function eventService() {
   let socketConnection = undefined;
   let messageCallbacks = {};
 
@@ -24,7 +21,7 @@ export default function eventService(TokenService) {
     removeCallback: (name) => {
       delete messageCallbacks[name];
     },
-    connect: (token) => {
+    connect: () => {
       // If socket is already open don't do anything
       if (
         _.isUndefined(socketConnection) ||
@@ -35,10 +32,6 @@ export default function eventService(TokenService) {
           window.location.host +
           window.location.pathname +
           `api/v1/socket/events/`;
-
-        if (token) {
-          eventUrl += "?token=" + token;
-        }
 
         socketConnection = new WebSocket(eventUrl);
         socketConnection.onmessage = onMessage;
@@ -54,6 +47,13 @@ export default function eventService(TokenService) {
         return undefined;
       }
       return socketConnection.readyState;
+    },
+    updateToken: (token) => {
+      if (socketConnection.readyState == WebSocket.OPEN) {
+        socketConnection.send(
+            JSON.stringify({name: "UPDATE_TOKEN", payload: token})
+        );
+      }
     },
   };
 }

--- a/src/ui/src/js/services/token_service.js
+++ b/src/ui/src/js/services/token_service.js
@@ -1,14 +1,15 @@
 import _ from "lodash";
 
-tokenService.$inject = ["$http", "localStorageService"];
+tokenService.$inject = ["$http", "localStorageService", "EventService"];
 
 /**
  * tokenService - Service for interacting with the token API.
  * @param  {Object} $http               Angular's $http Object.
  * @param  {Object} localStorageService Storage service
+ * @param  {Object} EventService Websocket event handling service
  * @return {Object}       Service for interacting with the token API.
  */
-export default function tokenService($http, localStorageService) {
+export default function tokenService($http, localStorageService, EventService) {
   const service = {
     getToken: () => {
       return localStorageService.get("token");
@@ -26,6 +27,7 @@ export default function tokenService($http, localStorageService) {
     },
     handleRefresh: (refreshToken) => {
       localStorageService.set("refresh", refreshToken);
+      EventService.updateToken(refreshToken);
     },
     clearRefresh: () => {
       const refreshToken = localStorageService.get("refresh");


### PR DESCRIPTION
Closes #1243 

This PR adds authorization checks to the events that get published on the websocket connections.  Prior to these changes, every connection received every message, regardless of the user's actual permissions.  With this PR, the flow goes like this:

* Client connects to the websocket
* An "AUTHORIZATION_REQUIRED" message is published to the client.
* The UI has a callback to handle this message and send an "UPDATE_TOKEN" message with the current access token.
* The server processes the "UPDATE_TOKEN" message and updates its record of the access token for this connection.  It will also publish an acknowledgement message named "TOKEN_UPDATED".
* Whenever messages would be published on the websocket connection, the user's permissions are checked (using the access token on record from above) against the object that the message is about. If the user has access, the message is published. If they do not, then nothing is published to that client.
* If while checking the user's permissions the token is deemed to be invalid or expired, an "AUTHORIZATION_REQUIRED" message is published **in lieu of the original message**.
  * At least for now, there is no attempt to queue up and deliver missed messages.  If the token on record is allowed to expire (it is not pre-emptively refreshed), messages will be missed while awaiting re-authorization.
  * The UI will pre-emptively publish an "UPDATE_TOKEN" message when a token refresh takes place.  However, this will only happen if another API call resulted in a refresh happening.  In this iteration the UI does not periodically check if the token is due for a refresh.  This means that if a user has not been navigating around the UI and having API calls made, the websocket connection will eventually have an expired token associated with it and no means of refreshing on its own.  Dealing with this specific scenario feels better left to a separate PR.  (Late update: I may have figured out how to accommodate this somewhat easily, so we could potentially tack that on to this PR). 

## Test Instructions
* Make sure auth is enabled on your garden
* Setup at least one user account with read access to systems and requests on your garden
* With the developer pane open in your browser, go to your beer garden instance and login.
* Look at the messages coming through on the `/api/v1/socket/events` websocket. You should see the behavior described above.
* Task something and verify that event messages come through that same websocket connection.

Another useful way to test things is to use the [websocat](https://github.com/vi/websocat) command line tool.  This will let you connect to the websocket and not immediately send the token.  Then if you task something (or do anything that would generate an event), you should see "AUTHORIZATION_REQUIRED" messages come through rather than the actual event messages.  It would look like this:

```shell
$ websocat ws://localhost:8080/api/v1/socket/events
{"name": "AUTHORIZATION_REQUIRED", "payload": "Access token required"}
{"name": "AUTHORIZATION_REQUIRED", "payload": "Valid access token required"}
{"name": "AUTHORIZATION_REQUIRED", "payload": "Valid access token required"}
{"name": "AUTHORIZATION_REQUIRED", "payload": "Valid access token required"}
```
Then you can simple type and press Enter to send a message.  The below alternates between messages entered into the websocat client and responses back from the server:
```shell
{"name": "UPDATE_TOKEN", "payload": "notavalidtoken"}
{"name": "AUTHORIZATION_REQUIRED", "payload": "Access token update message contained an invalid token"}
{"name": "INVALID_TYPE", "data": "dataisnotpayload"}
{"name": "BAD_MESSAGE", "payload": "Invalid message received. Error was: {'payload': ['Missing data for required field.'], 'name': ['Not a valid choice.']}"}
```
This is an easy way to play around with the websocket communications.  If you do send a message with a valid token, you should start getting actual event messages.