### PR TITLE
#1214 - Separate database and entrypoint handling for requests

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -381,7 +381,7 @@ def _event_callback(event):
     for handler in [
         beer_garden.router.handle_event,
         beer_garden.log.handle_event,
-        beer_garden.requests.handle_event,
+        beer_garden.requests.handle_event_for_entrypoints,
     ]:
         try:
             handler(deepcopy(event))

--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -184,7 +184,7 @@ class StompManager(BaseProcessor):
         for handler in [
             beer_garden.router.handle_event,
             beer_garden.log.handle_event,
-            beer_garden.requests.handle_event,
+            beer_garden.requests.handle_event_for_entrypoints,
             self._event_handler,
         ]:
             try:

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -860,7 +860,7 @@ def process_wait(request: Request, timeout: float) -> Request:
     return db.query_unique(Request, id=created_request.id)
 
 
-def handle_event(event):
+def handle_event_for_entrypoints(event):
     # Whenever a request is completed check to see if this process is waiting for it
     if event.name == Events.REQUEST_COMPLETED.name:
         completion_event = request_map.pop(event.payload.id, None)
@@ -877,8 +877,10 @@ def handle_event(event):
             for request_event in request_map:
                 request_map[request_event].set()
 
+
+def handle_event(event):
     # Only care about downstream garden
-    elif event.garden != config.get("garden.name") and not event.error:
+    if event.garden != config.get("garden.name") and not event.error:
         if event.name in (
             Events.REQUEST_CREATED.name,
             Events.REQUEST_STARTED.name,


### PR DESCRIPTION
Closes #1214

This PR splits what was the `beer_garden.requests.handle_event` function into two separate functions that can be called in different contexts:

* `handle_event` is now called only by the main process and does all of the database updates.
* `handle_event_for_entrypoints` is called by the entrypoint (http and stomp) processes and only deals with the internal request map that is used to track wait events (allowing things like nested commands to work correctly).

The result of this change is the following:

* Only one set of database updates occurs during the request lifecycle.  For example, there would be one update for each of the REQUEST_CREATED, IN_PROGRESS, and SUCCESS status changes.  Prior to this change there would be one update for each of those **per process** (main, http, and stomp).
* Duplicate events are handled gracefully as intended and no longer clutter the application log with a bunch of error events that were resulting from the extra processing.

As an example of the changes, here are some profiling queries run against the database:
```
> db.setProfilingLevel(2)
{ "was" : 0, "slowms" : 100, "sampleRate" : 1, "ok" : 1 }
> db.system.profile.find({"ns": "bg-parent1.request", "op": "command"}).count()
0
> // tasked echo on a child garden
> db.system.profile.find({"ns": "bg-parent1.request", "op": "command"}).count()
9
```
9 updates for a single request on develop.  This PR brings that down to 3, since only the main process is doing the work rather than all 3 processes.

Additionally, if you misconfigure a child garden such that it is sending to the parent over both http and stomp, on develop you constantly see errors like this:

```
2022-01-18 22:10:22,913 - [MainProcess] - beer_garden.events.handlers - ERROR - Error event: <Event: namespace=None, garden=parent1, name=REQUEST_UPDATED, timestamp=2022-01-18 22:10:22.911354+00:00, error=True, error_message=Status for a request cannot be updated once it has been completed. Current: SUCCESS, Requested: IN_PROGRESS, metadata={}, payload_type=None, payload=None>
2022-01-18 22:10:22,924 - [MainProcess] - beer_garden.events.handlers - ERROR - Error event: <Event: namespace=None, garden=parent1, name=REQUEST_UPDATED, timestamp=2022-01-18 22:10:22.922324+00:00, error=True, error_message=Status for a request cannot be updated once it has been completed. Current: SUCCESS, Requested: IN_PROGRESS, metadata={}, payload_type=None, payload=None>
```

It was only the combination of the duplicate event publishing and duplicate processing that seems to cause those errors. With the duplicate processing resolved, those errors are cleared up now as well.