### PR TITLE
#1247 - Add preemptive refresh of access tokens to the UI

### DIFF
--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -279,5 +279,9 @@ export default function appRun(
     EventService.connect(TokenService.getToken());
   }, 5000);
 
+  $interval(function () {
+    TokenService.preemptiveRefresh();
+  }, 30000);
+
   $rootScope.initialLoad();
 }

--- a/src/ui/src/js/services/event_service.js
+++ b/src/ui/src/js/services/event_service.js
@@ -49,7 +49,7 @@ export default function eventService() {
       return socketConnection.readyState;
     },
     updateToken: (token) => {
-      if (socketConnection.readyState == WebSocket.OPEN) {
+      if (token && (socketConnection.readyState == WebSocket.OPEN)) {
         socketConnection.send(
             JSON.stringify({name: "UPDATE_TOKEN", payload: token})
         );


### PR DESCRIPTION
Closes #1247 

This PR adds preemptive access token refreshing to the UI.  Every 30 seconds the UI will check the current access token's expiration time and will do a token refresh if the expiration is 2 or fewer minutes away.

There's also a bug fix where the refresh token was being sent to the websocket when the access token was intending to be sent after a refresh.

## Test Instructions
* Start beer-garden with auth enabled
* Open the developer panel in your browser
* Login to the UI
* Look at the `/api/v1/socket/events` connection.
* Leave the tab open until 2 minutes prior to token expiration (13 minutes by default, but see tip below).
* You should see a token update message published from the UI to the server, as well as the "TOKEN_UPDATED" response.

**Tip**: You don't have to wait the full refresh interval.  You can either hand-hack a shorter refresh time in the backend code, or modify your token client-side to have an earlier expiration date ([jwt.io](https://jwt.io/) is useful for this).  Since in this test that token won't be sent to the server again for validation, modifying it and invalidating the signature won't hurt anything.