### PR TITLE
#1214 - Fix job scheduler request handling

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -381,7 +381,7 @@ def _event_callback(event):
     for handler in [
         beer_garden.router.handle_event,
         beer_garden.log.handle_event,
-        beer_garden.requests.handle_event_for_entrypoints,
+        beer_garden.requests.handle_wait_events,
     ]:
         try:
             handler(deepcopy(event))

--- a/src/app/beer_garden/api/http/handlers/v1/event.py
+++ b/src/app/beer_garden/api/http/handlers/v1/event.py
@@ -29,12 +29,11 @@ def _auth_enabled():
 def _user_can_receive_messages_for_event(user: "User", event: "Event"):
     """Check a that a user has access to view the supplied event"""
     user_permitted = True
-    payload_type = event.payload_type.lower()
 
-    if event.payload and not user_has_permission_for_object(
-        user, f"{payload_type}:read", event.payload
-    ):
-        user_permitted = False
+    if event.payload and event.payload_type:
+        user_permitted = user_has_permission_for_object(
+            user, f"{event.payload_type.lower()}:read", event.payload
+        )
 
     return user_permitted
 

--- a/src/app/beer_garden/api/stomp/manager.py
+++ b/src/app/beer_garden/api/stomp/manager.py
@@ -184,7 +184,7 @@ class StompManager(BaseProcessor):
         for handler in [
             beer_garden.router.handle_event,
             beer_garden.log.handle_event,
-            beer_garden.requests.handle_event_for_entrypoints,
+            beer_garden.requests.handle_wait_events,
             self._event_handler,
         ]:
             try:

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -39,6 +39,7 @@ def garden_callbacks(event: Event) -> None:
         beer_garden.garden.handle_event,
         beer_garden.plugin.handle_event,
         beer_garden.requests.handle_event,
+        beer_garden.requests.handle_wait_events,
         beer_garden.router.handle_event,
         beer_garden.systems.handle_event,
         beer_garden.scheduler.handle_event,

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -860,7 +860,7 @@ def process_wait(request: Request, timeout: float) -> Request:
     return db.query_unique(Request, id=created_request.id)
 
 
-def handle_event_for_entrypoints(event):
+def handle_wait_events(event):
     # Whenever a request is completed check to see if this process is waiting for it
     if event.name == Events.REQUEST_COMPLETED.name:
         completion_event = request_map.pop(event.payload.id, None)


### PR DESCRIPTION
This PR fixes the job schedulers request handling so that it can properly keep track of which requests that it has kicked off have finished.  This was done by:

* Renaming `handle_event_for_entrypoints` to `handle_wait_events` to make it slightly more accurately named.
* Adding `handle_wait_events` to the list of processors that the Main process (which runs the scheduler) calls during its event processing.

It also fixes an issue where the auth check for events without a payload type would throw an error because the check function assumed there would always be a payload type.  A unit test has been added for this scenario.

Each of those fixes is isolated to their own commit, so look at the two commits if you're unsure which changes apply to which fix.