### PR TITLE
#1192 - Garden connection UI import/export

### DIFF
--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -50,7 +50,7 @@ def garden_callbacks(event: Event) -> None:
         try:
             handler(deepcopy(event))
         except Exception as ex:
-            logger.exception(
-                f"'{handler_tag}' event handler received an error executing callback"
-                f" for {event!r}: {ex}"
+            logger.error(
+                "'%s' handler received an error executing callback for event %s: %s"
+                % (handler_tag, repr(event), str(ex))
             )

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -34,20 +34,23 @@ def garden_callbacks(event: Event) -> None:
         logger.debug(f"{event!r}")
 
     # These are all the MAIN PROCESS subsystems that care about events
-    for handler in [
-        beer_garden.application.handle_event,
-        beer_garden.garden.handle_event,
-        beer_garden.plugin.handle_event,
-        beer_garden.requests.handle_event,
-        beer_garden.requests.handle_wait_events,
-        beer_garden.router.handle_event,
-        beer_garden.systems.handle_event,
-        beer_garden.scheduler.handle_event,
-        beer_garden.log.handle_event,
-        beer_garden.files.handle_event,
-        beer_garden.local_plugins.manager.handle_event,
+    for handler, handler_tag in [
+        (beer_garden.application.handle_event, "Application"),
+        (beer_garden.garden.handle_event, "Garden"),
+        (beer_garden.plugin.handle_event, "Plugin"),
+        (beer_garden.requests.handle_event, "Requests"),
+        (beer_garden.requests.handle_wait_events, "Requests wait events"),
+        (beer_garden.router.handle_event, "Router"),
+        (beer_garden.systems.handle_event, "System"),
+        (beer_garden.scheduler.handle_event, "Scheduler"),
+        (beer_garden.log.handle_event, "Log"),
+        (beer_garden.files.handle_event, "File"),
+        (beer_garden.local_plugins.manager.handle_event, "Local plugins manager"),
     ]:
         try:
             handler(deepcopy(event))
         except Exception as ex:
-            logger.exception(f"Error executing callback for {event!r}: {ex}")
+            logger.exception(
+                f"'{handler_tag}' event handler received an error executing callback"
+                f" for {event!r}: {ex}"
+            )

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -111,7 +111,10 @@
           >
         </li>
         <!-- Admin Drop Down Menu -->
-        <li class="dropdown" ng-show="hasPermission(user, 'system:update') || hasPermission(user, 'garden:update')">
+        <li
+          class="dropdown"
+          ng-show="hasPermission(user, 'system:update') || hasPermission(user, 'garden:update')"
+        >
           <a href="" data-toggle="dropdown" title="Admin Drop Down">Admin</a>
           <ul class="dropdown-menu">
             <li ng-show="hasPermission(user, 'system:update')">

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -110,6 +110,11 @@ import {
 } from './js/controllers/admin_role.js';
 import adminGardenController from './js/controllers/admin_garden.js';
 import adminGardenViewController from './js/controllers/admin_garden_view.js';
+import {
+  gardenConfigImportController,
+  gardenConfigImportModalController,
+} from './js/controllers/garden/import_garden_config';
+import gardenConfigExportController from './js/controllers/garden/export_garden_config';
 import commandIndexController from './js/controllers/command_index.js';
 import commandViewController from './js/controllers/command_view.js';
 import requestIndexController from './js/controllers/request_index.js';
@@ -220,6 +225,9 @@ angular
     .controller('NewRoleController', newRoleController)
     .controller('AdminGardenController', adminGardenController)
     .controller('AdminGardenViewController', adminGardenViewController)
+    .controller('GardenConfigExportController', gardenConfigExportController)
+    .controller('GardenConfigImportController', gardenConfigImportController)
+    .controller('GardenConfigImportModalController', gardenConfigImportModalController)
     .controller('CommandIndexController', commandIndexController)
     .controller('CommandViewController', commandViewController)
     .controller('RequestIndexController', requestIndexController)

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -56,7 +56,6 @@ export default function adminGardenViewController(
   };
 
   $scope.successCallback = function(response) {
-    console.log('response', response);
     $scope.response = response;
     $scope.data = response.data;
 

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -22,6 +22,7 @@ export default function adminGardenViewController(
 ) {
   $scope.setWindowTitle('Configure Garden');
   $scope.alerts = [];
+  $scope.formErrors = [];
 
   $scope.isLocal = false;
   $scope.gardenSchema = null;
@@ -40,7 +41,22 @@ export default function adminGardenViewController(
     $scope.$broadcast('schemaFormRedraw');
   };
 
+  $scope.updateModelFromImport = (newGardenDefinition) => {
+    const existingData = $scope.data;
+    const newConnType = newGardenDefinition['connection_type'];
+    const newConnParams = newGardenDefinition['connection_params'];
+
+    const newData = {...existingData,
+      connection_type: newConnType,
+      connection_params: newConnParams};
+
+    $scope.data = newData;
+
+    generateGardenSF();
+  };
+
   $scope.successCallback = function(response) {
+    console.log('response', response);
     $scope.response = response;
     $scope.data = response.data;
 
@@ -48,7 +64,8 @@ export default function adminGardenViewController(
       $scope.isLocal = true;
       $scope.alerts.push({
         type: 'info',
-        msg: 'Since this is the local Garden it\'s not possible to modify connection information',
+        msg: 'Since this is the local Garden it\'s not possible to modify ' +
+        'connection information',
       });
     }
 
@@ -74,28 +91,146 @@ export default function adminGardenViewController(
     loadGarden();
   };
 
+  const errorPlaceholder = 'errorPlaceholder';
+
+  const resetAllValidationErrors = () => {
+    const updater = (field) => {
+      $scope.$broadcast(
+          `schemaForm.error.${field}`,
+          errorPlaceholder,
+          true,
+      );
+    };
+
+    // this is brittle because it's a copy/paste from the form code,
+    // but will suffice for now because we expect the form won't
+    // ever be updated in this version of the UI
+    const httpFlds = [
+      'http.host',
+      'http.port',
+      'http.url_prefix',
+      'http.ssl',
+      'http.ca_cert',
+      'http.ca_verify',
+      'http.client_cert',
+    ];
+    const stompFlds = [
+      'stomp.host',
+      'stomp.port',
+      'stomp.send_destination',
+      'stomp.subscribe_destination',
+      'stomp.username',
+      'stomp.password',
+      'stomp.ssl',
+      'stomp.headers',
+    ];
+
+    httpFlds.map(updater);
+    stompFlds.map(updater);
+  };
+
+  const fieldErrorName =
+    (entryPoint, fieldName) => `schemaForm.error.${entryPoint}.${fieldName}`;
+
+  const fieldErrorMessage =
+    (errorObject) => {
+      const error = typeof errorObject === 'string' ?
+        Array(errorObject) : errorObject;
+      return error[0];
+    };
+
+  const updateValidationMessages = (entryPoint, errorsObject) => {
+    for (const fieldName in errorsObject) {
+      if (errorsObject.hasOwnProperty(fieldName)) {
+        $scope.$broadcast(
+            fieldErrorName(entryPoint, fieldName),
+            errorPlaceholder,
+            fieldErrorMessage(errorsObject[fieldName]),
+        );
+      }
+    }
+  };
+
   $scope.addErrorAlert = function(response) {
-    $scope.alerts.push({
-      type: 'danger',
-      msg:
-        'Something went wrong on the backend: ' +
-        _.get(response, 'data.message', 'Please check the server logs'),
-    });
+    /* If we have an error response that indicates that the connection
+     * parameters are incorrect, display a warning alert specifying which of the
+     * entry points are wrong. Then update the validation of the individual
+     * schema fields.
+     *
+     * NOTE: individual field validation is not currently used
+     */
+    if (response['data'] && response['data']['message']) {
+      const messageData = String(response['data']['message']);
+      const singleQuoteRegExp = new RegExp('\'', 'g');
+      const cleanedMessages = messageData.replace(singleQuoteRegExp, '"');
+      const messages = JSON.parse(cleanedMessages);
+
+      if ('connection_params' in messages) {
+        const connParamErrors = messages['connection_params'];
+
+        for (const entryPoint in connParamErrors) {
+          if (connParamErrors.hasOwnProperty(entryPoint)) {
+            updateValidationMessages(entryPoint, connParamErrors[entryPoint]);
+
+            $scope.alerts.push({
+              type: 'warning',
+              msg: `Errors found in ${entryPoint} connection`,
+            });
+          }
+        }
+      }
+    } else {
+      $scope.alerts.push({
+        type: 'danger',
+        msg:
+          'Something went wrong on the backend: ' +
+          _.get(response, 'data.message', 'Please check the server logs'),
+      });
+    }
+  };
+
+  const clearScopeAlerts = () => {
+    while ($scope.alerts.length) {
+      $scope.alerts.pop();
+    }
+  };
+
+  $scope.submitImport = (data) => {
+    GardenService.updateGardenConfig(data).then(
+        () => console.log('Garden updated from import successfully'),
+        $scope.addErrorAlert,
+    );
   };
 
   $scope.submitGardenForm = function(form, model) {
+    clearScopeAlerts();
+    resetAllValidationErrors();
     $scope.$broadcast('schemaFormValidate');
 
     if (form.$valid) {
-      const updatedGarden = GardenService.formToServerModel($scope.data, model);
+      let updatedGarden = undefined;
 
-      GardenService.updateGardenConfig(updatedGarden).then(
-          _.noop,
-          $scope.addErrorAlert,
-      );
+      try {
+        updatedGarden =
+          GardenService.formToServerModel($scope.data, model);
+      } catch (e) {
+        console.log(e);
+
+        $scope.alerts.push({
+          type: 'warning',
+          msg: e,
+        });
+      }
+
+      if (updatedGarden) {
+        GardenService.updateGardenConfig(updatedGarden).then(
+            () => console.log('Garden update saved successfully'),
+            $scope.addErrorAlert,
+        );
+      }
     } else {
       $scope.alerts.push(
-          'Looks like there was an error validating the Garden.',
+          'There was an error validating the Garden.',
       );
     }
   };

--- a/src/ui/src/js/controllers/garden/export_garden_config.js
+++ b/src/ui/src/js/controllers/garden/export_garden_config.js
@@ -1,0 +1,51 @@
+gardenConfigExportController.$inject =
+    ['$scope', '$rootScope', '$filter', 'GardenService'];
+
+/**
+ * gardenConfigExportController - Controller for the garden config export page.
+ * @param  {Object} $scope            Angular's $scope object.
+ * @param  {Object} $rootScope        Angular's $rootScope object.
+ * @param  {Object} $filter           Filter
+ * @param  {Object} GardenService     Beer-Garden's garden service.
+ */
+export default function gardenConfigExportController(
+    $scope,
+    $rootScope,
+    $filter,
+    GardenService,
+) {
+  $scope.response = $rootScope.sysResponse;
+
+  $scope.exportGardenConfig = (gardenName) => {
+    const filename =
+      `GardenExport_${gardenName}_` +
+      $filter('date')(new Date(Date.now()), 'yyyyMMdd_HHmmss');
+
+    const formModel = GardenService.formToServerModel($scope.data, $scope.gardenModel);
+
+    const [newConnectionInfo, newConnectionParams] = [{}, {}];
+    newConnectionInfo['connection_type'] = formModel['connection_type'];
+
+    if (formModel['connection_params']['http']) {
+      newConnectionParams['http'] = formModel['connection_params']['http'];
+    }
+
+    if (formModel['connection_params']['stomp']) {
+      newConnectionParams['stomp'] = formModel['connection_params']['stomp'];
+    }
+
+    newConnectionInfo['connection_params'] = newConnectionParams;
+
+    const blob = new Blob(
+        [JSON.stringify(newConnectionInfo)],
+        {
+          type: 'application/json;charset=utf-8',
+        },
+    );
+    const downloadLink = angular.element('<a></a>');
+
+    downloadLink.attr('href', window.URL.createObjectURL(blob));
+    downloadLink.attr('download', filename);
+    downloadLink[0].click();
+  };
+}

--- a/src/ui/src/js/controllers/garden/import_garden_config.js
+++ b/src/ui/src/js/controllers/garden/import_garden_config.js
@@ -1,0 +1,103 @@
+import template from '../../../templates/import_garden_config.html';
+
+gardenConfigImportController.$inject = [
+  '$scope',
+  '$rootScope',
+  '$uibModal',
+  '$state',
+];
+
+/**
+ * gardenConfigImportController - Controller for garden config import.
+ * @param  {Object} $scope                     Angular's $scope object.
+ * @param  {Object} $rootScope                 Angular's $rootScope object.
+ * @param  {Object} $uibModal                  Angular UI's $uibModal object.
+ * @param  {Object} $state                     State
+ */
+export function gardenConfigImportController(
+    $scope,
+    $rootScope,
+    $uibModal,
+    $state,
+) {
+  $scope.response = $rootScope.sysResponse;
+
+  $scope.openImportGardenConfigPopup = () => {
+    const popupInstance = $uibModal.open({
+      animation: true,
+      controller: 'GardenConfigImportModalController',
+      template: template,
+    });
+
+    popupInstance.result.then((resolvedResponse) => {
+      const jsonFileContents = resolvedResponse.jsonFileContents;
+      const newConfig = JSON.parse(jsonFileContents);
+
+      $scope.updateModelFromImport(newConfig);
+      $scope.submitImport($scope.data);
+      $state.reload();
+    }, () => console.log('Garden import cancelled'));
+  };
+}
+
+gardenConfigImportModalController.$inject =
+    ['$scope', '$window', '$uibModalInstance'];
+
+/**
+ * gardenConfigImportModalController - Controller for the garden config import
+ * popup window.
+ *
+ * @param {Object} $scope Angular's $scope object.
+ * @param {Object} $window Object for the browser window.
+ * @param {Object} $uibModalInstance Object for the modal popup window.
+ */
+export function gardenConfigImportModalController(
+    $scope, $window, $uibModalInstance) {
+  $scope.import = {};
+  $scope.fileName = undefined;
+  $scope.fileContents = undefined;
+  $scope.fileIsGoodJson = true;
+
+  $scope.inputClicker = function() {
+    $window.document.getElementById('fileSelectHiddenControl').click();
+  };
+
+  $scope.doImport = function() {
+    $scope.import['jsonFileContents'] = $scope.fileContents;
+    $uibModalInstance.close($scope.import);
+  };
+
+  $scope.cancelImport = function() {
+    $uibModalInstance.dismiss('cancel');
+  };
+
+  function isParsableJson(string) {
+    try {
+      JSON.parse(string);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
+  $scope.onFileSelected = function(event) {
+    const theFile = event.target.files[0];
+    $scope.fileName = theFile.name;
+
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      $scope.$apply(function() {
+        const result = reader.result;
+        const isGoodJson = isParsableJson(result);
+
+        if (isGoodJson) {
+          $scope.fileContents = result;
+          $scope.fileIsGoodJson = true;
+        } else {
+          $scope.fileIsGoodJson = false;
+        }
+      });
+    };
+    reader.readAsText(theFile);
+  };
+}

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -66,19 +66,6 @@ export default function gardenService($rootScope, $http) {
     });
   };
 
-  GardenService.importGardenConfig = (gardenDefinition, gardenConfigJson) => {
-    const gardenName = encodeURIComponent(gardenDefinition['name']);
-    const url = `api/v1/gardens/${gardenName}`;
-    const gardenConfig = JSON.parse(gardenConfigJson);
-    gardenDefinition['connection_params'] = gardenConfig;
-
-    return $http.patch(url, {
-      operation: 'config',
-      path: '',
-      value: gardenDefinition,
-    });
-  };
-
   GardenService.serverModelToForm = function(model) {
     const values = {};
     const stompHeaders = [];
@@ -279,16 +266,6 @@ export default function gardenService($rootScope, $http) {
         }
       }
       updatedConnectionParams[modelEntryPointName] = updatedEntryPoint;
-    }
-
-    if (emptyConnections['http'] && emptyConnections['stomp']) {
-      throw Error('One of \'http\' or \'stomp\' connection must be defined');
-    } else if (emptyConnections['http'] && modelConnectionType === 'HTTP') {
-      throw Error('Connection type is \'HTTP\' but http connection parameters' +
-        'are blank');
-    } else if (emptyConnections['stomp'] && modelConnectionType === 'STOMP') {
-      throw Error('Connection type is \'STOMP\' but stomp connection ' +
-        'parameters are blank');
     }
 
     newModel = {...newModel, 'connection_params': updatedConnectionParams};

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -149,7 +149,6 @@ export default function gardenService($rootScope, $http) {
             ('key' in entry && isBlank(entry['key'])) ||
             ('value' in entry && isBlank(entry['value'])))
     );
-    console.log('headersAllBlank', headersAllBlank);
 
     return (
       !headersExist ||
@@ -224,8 +223,6 @@ export default function gardenService($rootScope, $http) {
      * model. Throw an error if the entire form is empty (i.e., don't allow
      * empty connection parameters for both entry points on a remote garden).
      */
-    console.log('formToServerModel DATA', data);
-    console.log('formToServerModel MODEL', model);
     const {connection_type: modelConnectionType, ...modelWithoutConxType} = model;
     let newModel = {...data};
     newModel['connection_type'] = modelConnectionType;
@@ -240,9 +237,6 @@ export default function gardenService($rootScope, $http) {
     for (const modelEntryPointName of Object.keys(modelWithoutConxType)) {
       // modelEntryPointName is either 'http' or 'stomp'
       const modelEntryPointMap = modelWithoutConxType[modelEntryPointName];
-      if (modelEntryPointName === 'stomp') {
-        console.log('STOMP modelEntryPointMap', modelEntryPointMap);
-      }
       const isEmpty = emptyChecker[modelEntryPointName](modelEntryPointMap);
 
       if (isEmpty) {
@@ -254,23 +248,12 @@ export default function gardenService($rootScope, $http) {
 
       const updatedEntryPoint = {};
 
-      if (modelEntryPointName === 'stomp') {
-        console.log('STOMP KEYS', Object.keys(modelEntryPointMap));
-      }
-
       for (const modelEntryPointKey of Object.keys(modelEntryPointMap)) {
         const modelEntryPointValue = modelEntryPointMap[modelEntryPointKey];
-        if (modelEntryPointName === 'stomp') {
-          console.log('modelEntryPointName', modelEntryPointName);
-          console.log('modelEntryPointKey', modelEntryPointKey);
-          console.log('modelEntryPointValue', modelEntryPointValue);
-        }
 
         if (modelEntryPointName === 'stomp' && modelEntryPointKey === 'headers') {
-          console.log('STOMP HEADERS');
           // the ugly corner case is the stomp headers
           const formStompHeaders = modelEntryPointValue;
-          console.log('HEADERS', formStompHeaders);
           const modelUpdatedStompHeaderArray = [];
 
           for (const formStompHeader of formStompHeaders) {

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -53,6 +53,32 @@ export default function gardenService($rootScope, $http) {
     return _.find($rootScope.gardens, {name: name});
   };
 
+  GardenService.importGardenConfig = (gardenDefinition, gardenConfigJson) => {
+    const gardenName = encodeURIComponent(gardenDefinition['name']);
+    const url = `api/v1/gardens/${gardenName}`;
+    const gardenConfig = JSON.parse(gardenConfigJson);
+    gardenDefinition['connection_params'] = gardenConfig;
+
+    return $http.patch(url, {
+      operation: 'config',
+      path: '',
+      value: gardenDefinition,
+    });
+  };
+
+  GardenService.importGardenConfig = (gardenDefinition, gardenConfigJson) => {
+    const gardenName = encodeURIComponent(gardenDefinition['name']);
+    const url = `api/v1/gardens/${gardenName}`;
+    const gardenConfig = JSON.parse(gardenConfigJson);
+    gardenDefinition['connection_params'] = gardenConfig;
+
+    return $http.patch(url, {
+      operation: 'config',
+      path: '',
+      value: gardenDefinition,
+    });
+  };
+
   GardenService.serverModelToForm = function(model) {
     const values = {};
     const stompHeaders = [];
@@ -63,13 +89,14 @@ export default function gardenService($rootScope, $http) {
     ) {
       for (const parameter of Object.keys(model['connection_params'])) {
         if (parameter == 'stomp_headers') {
-          for (const key in model['connection_params'][parameter]) {
+          // eslint-disable-next-line guard-for-in
+          for (const key in model['connection_params']['stomp_headers']) {
             stompHeaders[stompHeaders.length] = {
               key: key,
-              value: model['connection_params'][parameter][key],
+              value: model['connection_params']['stomp_headers'][key],
             };
           }
-          values[parameter] = stompHeaders;
+          values['stomp_headers'] = stompHeaders;
         } else {
           // Recursively remove null/empty values from json payload
           const parameterValue = (function filter(obj) {
@@ -89,22 +116,201 @@ export default function gardenService($rootScope, $http) {
     return values;
   };
 
-  GardenService.formToServerModel = function(model, form) {
-    model['connection_type'] = form['connection_type'];
-    model['connection_params'] = {};
-    const stompHeaders = {};
-    for (const field of Object.keys(form)) {
-      if (field == 'stomp_headers') {
-        for (const i in form[field]) {
-          stompHeaders[form[field][i]['key']] = form[field][i]['value'];
-        }
-        model['connection_params'][field] = stompHeaders;
-      } else if (field != 'connection_type') {
-        model['connection_params'][field] = form[field];
-      }
+  const getSimpleFieldPredicate = (entryPointValues) => {
+    // it's better to be explicit because of the inherent stupidity of
+    // Javascript "truthiness"
+    return (
+      (entry) =>
+        typeof entryPointValues[entry] === 'undefined' ||
+            entryPointValues[entry] === null ||
+            entryPointValues[entry] === ''
+    );
+  };
+
+  const isEmptyObject = (obj) => {
+    !!obj && !Object.keys(obj).length;
+  };
+
+  const isBlank = (entry) => !entry;
+
+  const isEmptyStompHeaders = (headerEntry) => {
+    const headersExist = !!headerEntry && 'headers' in headerEntry;
+    const headersZeroLength = (
+      !headersExist ||
+      headerEntry['headers'].length === 0);
+    const headersAllEmpty = (
+      !headersZeroLength &&
+      headerEntry['headers'].every(isEmptyObject)
+    );
+    const headersAllBlank = (
+      !headersAllEmpty &&
+      headerEntry['headers'].every(
+          (entry) =>
+            ('key' in entry && isBlank(entry['key'])) ||
+            ('value' in entry && isBlank(entry['value'])))
+    );
+    console.log('headersAllBlank', headersAllBlank);
+
+    return (
+      !headersExist ||
+      headersZeroLength ||
+      headersAllEmpty ||
+      headersAllBlank
+    );
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  const cleanEmptyStompHeaders = () => 'TODO';
+
+  const isEmptyStompConnection = (entryPointValues) => {
+    /* If every field is missing, then obviously the stomp connection can be
+     * considered empty.
+     *
+     * It gets a little more complicated in other cases because a lot of garbage
+     * data is being passed around (an issue for another day).
+     *
+     * So we do a lot of checking of the corner cases in
+     * isEmptyStompConnection and isEmptyStompHeaders so that the results of
+     * this function is truly representative of whether we would consider the
+     * connection to be "empty".
+     *
+     * (The point of all this is that if the connection meets our common-sense
+     * definition of empty, then the resulting connection parameter object
+     * won't even have a 'stomp' entry at all, which is far preferable to
+     * polluting the database with the cruft that gets picked up in the UI.)
+     */
+    const simpleFieldMissing = getSimpleFieldPredicate(entryPointValues);
+
+    const stompSimpleFields = [
+      'host', 'password', 'port', 'send_destination', 'subscribe_destination',
+      'username',
+    ];
+    const stompSslFields = ['ca_cert', 'client_cert', 'client_key'];
+
+    const allSimpleFieldsMissing = stompSimpleFields.every(simpleFieldMissing);
+    const headersMissing = isEmptyStompHeaders(entryPointValues);
+    const sslIsMissing = typeof entryPointValues['ssl'] === 'undefined' ||
+        !!Object.entries(entryPointValues['ssl']);
+    let nestedFieldsMissing = true;
+
+    if (!sslIsMissing) {
+      nestedFieldsMissing = stompSslFields.every(
+          (entry) =>
+            typeof entryPointValues['ssl'][entry] === 'undefined' ||
+            entryPointValues['ssl'][entry] === null ||
+            entryPointValues['ssl'][entry] === '',
+      );
     }
 
-    return model;
+    const allStompFieldsEmpty = headersMissing && allSimpleFieldsMissing &&
+        nestedFieldsMissing;
+
+    return allStompFieldsEmpty;
+  };
+
+  const isEmptyHttpConnection = (entryPointValues) => {
+    // Simply decide if every field in the http entry is blank.
+    const simpleFieldMissing = getSimpleFieldPredicate(entryPointValues);
+    const httpSimpleFields = [
+      'ca_cert', 'client_cert', 'host', 'port', 'url_prefix',
+    ];
+    const allHttpFieldsEmpty = httpSimpleFields.every(simpleFieldMissing);
+
+    return allHttpFieldsEmpty;
+  };
+
+  GardenService.formToServerModel = function(data, model) {
+    /* Carefully pick apart the form data and translate it to the correct server
+     * model. Throw an error if the entire form is empty (i.e., don't allow
+     * empty connection parameters for both entry points on a remote garden).
+     */
+    console.log('formToServerModel DATA', data);
+    console.log('formToServerModel MODEL', model);
+    const {connection_type: modelConnectionType, ...modelWithoutConxType} = model;
+    let newModel = {...data};
+    newModel['connection_type'] = modelConnectionType;
+
+    const updatedConnectionParams = {};
+    const emptyConnections = {};
+    const emptyChecker = {
+      'stomp': isEmptyStompConnection,
+      'http': isEmptyHttpConnection,
+    };
+
+    for (const modelEntryPointName of Object.keys(modelWithoutConxType)) {
+      // modelEntryPointName is either 'http' or 'stomp'
+      const modelEntryPointMap = modelWithoutConxType[modelEntryPointName];
+      if (modelEntryPointName === 'stomp') {
+        console.log('STOMP modelEntryPointMap', modelEntryPointMap);
+      }
+      const isEmpty = emptyChecker[modelEntryPointName](modelEntryPointMap);
+
+      if (isEmpty) {
+        emptyConnections[modelEntryPointName] = true;
+        continue;
+      } else {
+        emptyConnections[modelEntryPointName] = false;
+      }
+
+      const updatedEntryPoint = {};
+
+      if (modelEntryPointName === 'stomp') {
+        console.log('STOMP KEYS', Object.keys(modelEntryPointMap));
+      }
+
+      for (const modelEntryPointKey of Object.keys(modelEntryPointMap)) {
+        const modelEntryPointValue = modelEntryPointMap[modelEntryPointKey];
+        if (modelEntryPointName === 'stomp') {
+          console.log('modelEntryPointName', modelEntryPointName);
+          console.log('modelEntryPointKey', modelEntryPointKey);
+          console.log('modelEntryPointValue', modelEntryPointValue);
+        }
+
+        if (modelEntryPointName === 'stomp' && modelEntryPointKey === 'headers') {
+          console.log('STOMP HEADERS');
+          // the ugly corner case is the stomp headers
+          const formStompHeaders = modelEntryPointValue;
+          console.log('HEADERS', formStompHeaders);
+          const modelUpdatedStompHeaderArray = [];
+
+          for (const formStompHeader of formStompHeaders) {
+            const formStompKey = formStompHeader['key'];
+            const formStompValue = formStompHeader['value'];
+
+            // assume that we have both a key and a value or neither
+            if (formStompKey && formStompValue) {
+              modelUpdatedStompHeaderArray.push(
+                  {
+                    'key': formStompKey,
+                    'value': formStompValue,
+                  },
+              );
+            }
+          }
+
+          if (modelUpdatedStompHeaderArray.length > 0) {
+            updatedEntryPoint['headers'] = modelUpdatedStompHeaderArray;
+          }
+        } else {
+          updatedEntryPoint[modelEntryPointKey] = modelEntryPointValue;
+        }
+      }
+      updatedConnectionParams[modelEntryPointName] = updatedEntryPoint;
+    }
+
+    if (emptyConnections['http'] && emptyConnections['stomp']) {
+      throw Error('One of \'http\' or \'stomp\' connection must be defined');
+    } else if (emptyConnections['http'] && modelConnectionType === 'HTTP') {
+      throw Error('Connection type is \'HTTP\' but http connection parameters' +
+        'are blank');
+    } else if (emptyConnections['stomp'] && modelConnectionType === 'STOMP') {
+      throw Error('Connection type is \'STOMP\' but stomp connection ' +
+        'parameters are blank');
+    }
+
+    newModel = {...newModel, 'connection_params': updatedConnectionParams};
+
+    return newModel;
   };
 
   GardenService.CONNECTION_TYPES = ['HTTP', 'STOMP'];
@@ -251,8 +457,10 @@ export default function gardenService($rootScope, $http) {
             },
           },
           headers: {
+            title: ' ',
             title: 'Headers',
-            description: 'Headers to be sent with message',
+            title: ' ',
+            description: ' ',
             type: 'array',
             items: {
               title: ' ',
@@ -309,6 +517,12 @@ export default function gardenService($rootScope, $http) {
                 'stomp.username',
                 'stomp.password',
                 'stomp.ssl',
+                {
+                  'type': 'help',
+                  'helpvalue': '<h4>Headers</h4><p>(Refresh browser if keys ' +
+                  'and values are known to exist but are not populated on this' +
+                  ' form)</p>',
+                },
                 'stomp.headers',
               ],
             },
@@ -323,7 +537,7 @@ export default function gardenService($rootScope, $http) {
         {
           type: 'submit',
           style: 'btn-primary w-100',
-          title: 'Save Configurations',
+          title: 'Save Configuration',
           htmlClass: 'col-md-10',
         },
       ],

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -99,7 +99,7 @@
           ng-show="hasGardenPermission(user, 'garden:update', garden)"
           style="..."
         >
-          Edit {{garden.name}} configurations
+          Edit {{garden.name}} configuration
         </button>
         <button
           type="button"

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -70,7 +70,22 @@
   </div>
 
   <div ng-hide="isLocal">
-    <h4>Update Connection</h4>
+    <h4>
+      Update Connection
+      <button type="button"
+            class="btn btn-primary pull-right"
+            ng-controller="GardenConfigImportController"
+            ng-click="openImportGardenConfigPopup()">
+      Import Connection
+    </button>
+    <button type="button"
+            ng-if="responseState(response) === 'success'"
+            class="btn btn-primary pull-right"
+            ng-controller="GardenConfigExportController"
+            ng-click="exportGardenConfig(data.name)">
+      Export Connection
+    </button>
+    </h4>
     <div class="container-fluid">
       <div class="row">
         <form

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -1,18 +1,19 @@
-<h1 class='page-header'>
+<h1 class="page-header">
   <span>Garden View</span>
   <span class="pull-right" ng-show="responseState(response) !== 'loading'">
-    <button type="button"
-            class="btn btn-primary"
-            ng-click="syncGarden()">Sync</button>
+    <button type="button" class="btn btn-primary" ng-click="syncGarden()">
+      Sync
+    </button>
   </span>
 </h1>
 
 <fetch-data response="response"></fetch-data>
 
-<div id="garden-view-container"
-     class="animate-if container-fluid"
-     ng-if="responseState(response) === 'success'">
-
+<div
+  id="garden-view-container"
+  class="animate-if container-fluid"
+  ng-if="responseState(response) === 'success'"
+>
   <div class="row">
     <h4>Garden Info</h4>
     <div class="row">
@@ -41,10 +42,11 @@
   <div class="row">
     <h4>Connected Systems</h4>
     <table
-        datatable="ng"
-        dt-options="dtOptions"
-        class="table table-striped table-bordered"
-        style="width: 100%">
+      datatable="ng"
+      dt-options="dtOptions"
+      class="table table-striped table-bordered"
+      style="width: 100%"
+    >
       <thead>
         <tr>
           <th id="th_job_name">Namespace</th>
@@ -54,48 +56,63 @@
       </thead>
       <tbody>
         <tr ng-repeat="system in data.systems">
-          <td><a ui-sref="base.systems({namespace: system.namespace})">{{system.namespace}}</a></td>
+          <td>
+            <a ui-sref="base.systems({namespace: system.namespace})"
+              >{{system.namespace}}</a
+            >
+          </td>
           <td>{{system.name}}</td>
-          <td><a ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})">{{system.version}}</a></td>
+          <td>
+            <a
+              ui-sref="base.system({namespace: system.namespace, systemName: system.name, systemVersion: system.version})"
+              >{{system.version}}</a
+            >
+          </td>
         </tr>
       </tbody>
     </table>
   </div>
 
-  <div uib-alert
+  <div
+    uib-alert
     ng-repeat="alert in alerts"
     ng-class="'alert-' + alert.type"
-    close="closeAlert($index)">
-      {{alert.msg}}
+    close="closeAlert($index)"
+  >
+    {{alert.msg}}
   </div>
 
   <div ng-hide="isLocal">
     <h4>
       Update Connection
-      <button type="button"
-            class="btn btn-primary pull-right"
-            ng-controller="GardenConfigImportController"
-            ng-click="openImportGardenConfigPopup()">
-      Import Connection
-    </button>
-    <button type="button"
-            ng-if="responseState(response) === 'success'"
-            class="btn btn-primary pull-right"
-            ng-controller="GardenConfigExportController"
-            ng-click="exportGardenConfig(data.name)">
-      Export Connection
-    </button>
+      <button
+        type="button"
+        class="btn btn-primary pull-right"
+        ng-controller="GardenConfigImportController"
+        ng-click="openImportGardenConfigPopup()"
+      >
+        Import Connection
+      </button>
+      <button
+        type="button"
+        ng-if="responseState(response) === 'success'"
+        class="btn btn-primary pull-right"
+        ng-controller="GardenConfigExportController"
+        ng-click="exportGardenConfig(data.name)"
+      >
+        Export Connection
+      </button>
     </h4>
     <div class="container-fluid">
       <div class="row">
         <form
-            name="gardenform"
-            sf-schema="gardenSchema"
-            sf-form="gardenForm"
-            sf-model="gardenModel"
-            ng-submit="submitGardenForm(gardenform, gardenModel)"/>
+          name="gardenform"
+          sf-schema="gardenSchema"
+          sf-form="gardenForm"
+          sf-model="gardenModel"
+          ng-submit="submitGardenForm(gardenform, gardenModel)"
+        />
       </div>
     </div>
   </div>
-
 </div>

--- a/src/ui/src/templates/import_garden_config.html
+++ b/src/ui/src/templates/import_garden_config.html
@@ -4,31 +4,55 @@
   </div>
 
   <div class="modal-body" id="modal-body">
-      <p><span class="glyphicon glyphicon-info-sign fa-2x"></span> The config selected here will update the form, but the <i>Save Configuration</i> button must be pressed to update the Beer Garden server.</p>
+    <p>
+      <span class="glyphicon glyphicon-info-sign fa-2x"></span> The config
+      selected here will update the form, but the
+      <i>Save Configuration</i> button must be pressed to update the Beer Garden
+      server.
+    </p>
     <div class="alert alert-danger" role="alert" ng-hide="fileIsGoodJson">
       <p class="mb-0">Couldn't parse as JSON.</p>
     </div>
-    <input type="file" id="fileSelectHiddenControl" class="file-input" style="visibility:hidden;" custom-on-change="onFileSelected">
+    <input
+      type="file"
+      id="fileSelectHiddenControl"
+      class="file-input"
+      style="visibility: hidden"
+      custom-on-change="onFileSelected"
+    />
 
     <div class="input-group col-xs-12">
-      <input type="text" class="form-control input-lg" disabled placeholder="{{fileName || 'Select File'}}" />
+      <input
+        type="text"
+        class="form-control input-lg"
+        disabled
+        placeholder="{{fileName || 'Select File'}}"
+      />
       <span class="input-group-btn">
-        <button class="btn btn-primary input-lg" type="button" ng-click="inputClicker()">
-          <i class="glyphicon glyphicon-search"></i> Browse</button>
+        <button
+          class="btn btn-primary input-lg"
+          type="button"
+          ng-click="inputClicker()"
+        >
+          <i class="glyphicon glyphicon-search"></i> Browse
+        </button>
       </span>
     </div>
   </div>
 
   <div class="modal-footer">
-    <input type="button"
-            class="btn btn-danger"
-            value="Cancel"
-            ng-click="cancelImport()" />
-    <input type="submit"
-            class="btn btn-success"
-            value="Import"
-            ng-disabled="!(fileContents && fileIsGoodJson)"
-            ng-click="doImport()" />
+    <input
+      type="button"
+      class="btn btn-danger"
+      value="Cancel"
+      ng-click="cancelImport()"
+    />
+    <input
+      type="submit"
+      class="btn btn-success"
+      value="Import"
+      ng-disabled="!(fileContents && fileIsGoodJson)"
+      ng-click="doImport()"
+    />
   </div>
-
 </form>

--- a/src/ui/src/templates/import_garden_config.html
+++ b/src/ui/src/templates/import_garden_config.html
@@ -4,12 +4,6 @@
   </div>
 
   <div class="modal-body" id="modal-body">
-    <p>
-      <span class="glyphicon glyphicon-info-sign fa-2x"></span> The config
-      selected here will update the form, but the
-      <i>Save Configuration</i> button must be pressed to update the Beer Garden
-      server.
-    </p>
     <div class="alert alert-danger" role="alert" ng-hide="fileIsGoodJson">
       <p class="mb-0">Couldn't parse as JSON.</p>
     </div>

--- a/src/ui/src/templates/import_garden_config.html
+++ b/src/ui/src/templates/import_garden_config.html
@@ -1,0 +1,34 @@
+<form ng-submit="doImport()">
+  <div class="modal-header">
+    <h3 class="modal-title" id="modal-title">Select File</h3>
+  </div>
+
+  <div class="modal-body" id="modal-body">
+      <p><span class="glyphicon glyphicon-info-sign fa-2x"></span> The config selected here will update the form, but the <i>Save Configuration</i> button must be pressed to update the Beer Garden server.</p>
+    <div class="alert alert-danger" role="alert" ng-hide="fileIsGoodJson">
+      <p class="mb-0">Couldn't parse as JSON.</p>
+    </div>
+    <input type="file" id="fileSelectHiddenControl" class="file-input" style="visibility:hidden;" custom-on-change="onFileSelected">
+
+    <div class="input-group col-xs-12">
+      <input type="text" class="form-control input-lg" disabled placeholder="{{fileName || 'Select File'}}" />
+      <span class="input-group-btn">
+        <button class="btn btn-primary input-lg" type="button" ng-click="inputClicker()">
+          <i class="glyphicon glyphicon-search"></i> Browse</button>
+      </span>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <input type="button"
+            class="btn btn-danger"
+            value="Cancel"
+            ng-click="cancelImport()" />
+    <input type="submit"
+            class="btn btn-success"
+            value="Import"
+            ng-disabled="!(fileContents && fileIsGoodJson)"
+            ng-click="doImport()" />
+  </div>
+
+</form>


### PR DESCRIPTION
Closes #1192 

#### Testing
Exercise the import and export functionality via the buttons. Note that:
1. There is minimal error checking and almost no validation. If an exported JSON file is mangled, the code makes a best-effort to avoid importing it. But if it's just augmented with garbage (that is otherwise legal JSON), or if it's entirely empty, it will import the garbage into the database. Caveat emptor. 
2. As a note on the STOMP tab says, if there are supposed to be headers but the fields are empty, the page must be refreshed. They should show up then. This is related to a shortcoming with angular-schema-forms and nested structures.