### PR TITLE
#1263 - Show username on requests in the UI if auth is enabled

### DIFF
--- a/src/ui/src/js/controllers/request_index.js
+++ b/src/ui/src/js/controllers/request_index.js
@@ -1,6 +1,7 @@
 import {formatDate} from '../services/utility_service.js';
 
 requestIndexController.$inject = [
+  '$rootScope',
   '$scope',
   '$compile',
   'localStorageService',
@@ -12,6 +13,7 @@ requestIndexController.$inject = [
 
 /**
  * requestIndexController - Angular controller for viewing all requests.
+ * @param  {Object} $rootScope        Angular's $rootScope object.
  * @param  {Object} $scope            Angular's $scope object.
  * @param  {Object} $compile          Angular's $compile object.
  * @param  {Object} localStorageService  Storage service
@@ -21,6 +23,7 @@ requestIndexController.$inject = [
  * @param  {Object} EventService      Beer-Garden Event Service.
  */
 export default function requestIndexController(
+    $rootScope,
     $scope,
     $compile,
     localStorageService,
@@ -106,6 +109,11 @@ export default function requestIndexController(
           attr: {class: 'form-inline form-control', title: 'Instance Filter'},
         },
         5: {
+          html: 'input',
+          type: 'text',
+          attr: {class: 'form-inline form-control', title: 'Requester Filter'},
+        },
+        6: {
           html: 'select',
           type: 'text',
           cssClass: 'form-inline form-control',
@@ -119,7 +127,7 @@ export default function requestIndexController(
             {value: 'ERROR', label: 'ERROR'},
           ],
         },
-        6: {
+        7: {
           html: 'range',
           type: 'text',
           attr: {
@@ -140,7 +148,7 @@ export default function requestIndexController(
             useCurrent: false,
           },
         },
-        7: {
+        8: {
           html: 'input',
           type: 'text',
           attr: {class: 'form-inline form-control', title: 'Comment Filter'},
@@ -211,17 +219,24 @@ export default function requestIndexController(
           >${data}</a>`;
         }),
     DTColumnBuilder.newColumn('instance_name').withTitle('Instance'),
-    DTColumnBuilder.newColumn('status').withTitle('Status'),
-    DTColumnBuilder.newColumn('created_at')
-        .withTitle('Created')
-        .withOption('type', 'date')
-        .withOption('width', '22%')
-        .renderWith(function(data, type, full) {
-          return formatDate(data);
-        }),
-    DTColumnBuilder.newColumn('comment').withTitle('Comment'),
-    DTColumnBuilder.newColumn('metadata').notVisible(),
   ];
+
+  if ($rootScope.authEnabled()) {
+    $scope.dtColumns.push(DTColumnBuilder.newColumn('requester').withTitle('Requester'));
+  }
+
+  $scope.dtColumns.push(
+      DTColumnBuilder.newColumn('status').withTitle('Status'),
+      DTColumnBuilder.newColumn('created_at')
+          .withTitle('Created')
+          .withOption('type', 'date')
+          .withOption('width', '22%')
+          .renderWith(function(data, type, full) {
+            return formatDate(data);
+          }),
+      DTColumnBuilder.newColumn('comment').withTitle('Comment'),
+      DTColumnBuilder.newColumn('metadata').notVisible(),
+  );
 
   $scope.instanceCreated = function(_instance) {
     $scope.dtInstance = _instance;

--- a/src/ui/src/partials/request_view.html
+++ b/src/ui/src/partials/request_view.html
@@ -48,6 +48,7 @@
           <th scope="col">System</th>
           <th scope="col">System Version</th>
           <th scope="col">Instance Name</th>
+          <th scope="col" ng-show="authEnabled()">Requester</th>
           <th scope="col">
             Status<span
               uib-popover="{{statusDescriptions[request.status]}}"
@@ -102,6 +103,7 @@
             </div>
           </td>
           <td>{{request.instance_name}}</td>
+          <td ng-show="authEnabled()">{{request.requester}}</td>
           <td>{{request.status}}</td>
           <td ng-show="showErrorColumn(request, children)">
             {{request.error_class}}
@@ -136,6 +138,7 @@
           </td>
           <td><div>{{child.system_version}}</div></td>
           <td><div>{{child.instance_name}}</div></td>
+          <td ng-show="authEnabled()"><div>{{child.requester}}</div></td>
           <td><div>{{child.status}}</div></td>
           <td ng-show="showErrorColumn(request, children)">
             <div>{{child.error_class}}</div>


### PR DESCRIPTION
Closes #1263 

This PR adds the "requester" column to the request index and view pages if auth is enabled.  The requester is also visible on child requests that spawn (such as on the `nested-calls` example plugin).

The original issue (as written) was for recording the username on the request, but it turned out that was already happening.  So surfacing that info in the UI was all that was needed.

Test Instructions:
* With auth disabled, go to the requests page.  It should not show a requester column.
* With auth enabled, task something and go to the requests page.  You should see a requester column with the username of the user that spawned the request listed.