### PR TITLE
#1264 - Allow implicit access to a user's own requests

### DIFF
--- a/src/app/test/auth_test.py
+++ b/src/app/test/auth_test.py
@@ -6,6 +6,7 @@ from mongoengine import connect
 from mongomock.gridfs import enable_gridfs_integration
 
 from beer_garden.authorization import (
+    OBJECT_OWNER_PERMISSIONS,
     permissions_for_user,
     user_has_permission_for_object,
     user_permitted_objects,
@@ -352,6 +353,23 @@ class TestAuth:
         assert user_has_permission_for_object(
             user_with_role_assignments, "system:read", test_system_1_0_0
         )
+
+    def test_user_has_permission_for_object_request_through_user(
+        self,
+        test_request,
+    ):
+        """user_has_permission_for_object returns true for a System in which the
+        user has Garden level access for the required permission
+        """
+        # Set the requester of the request to be our "owner" test user
+        owner = User(username="owner")
+        test_request.requester = owner.username
+        test_request.save()
+
+        assert user_has_permission_for_object(
+            owner, OBJECT_OWNER_PERMISSIONS[0], test_request
+        )
+        assert not user_has_permission_for_object(owner, "noaccess", test_request)
 
     def test_user_has_permission_for_object_supports_brewtils_models(
         self,


### PR DESCRIPTION
Closes #1264 

This PR allows users to view requests where they are the requester, even if they do not have a role assignment explicitly granting access to the request.

This is done by defining a list of `OBJECT_OWNER_PERMISSIONS` that are conferred to users for any object where they are the owner.  This permission list is currently just `request:read`, and only requests are considered to have an owner, but this implementation allows for the potential expansion of both the eligible object types and the conferred permissions.

## Test Instructions
* Remove the "request:read" permission from the roles it is assigned to.
* Create requests as multiple users.
* Verify that each user can see their own requests, and only their own requests, since none of them will actually have "request:read" granted through any of their role assignments.