### PR TITLE
#1262 - Add password management

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -55,7 +55,10 @@ from beer_garden.api.http.schemas.v1.token import (
     TokenRefreshInputSchema,
     TokenResponseSchema,
 )
-from beer_garden.api.http.schemas.v1.user import UserPatchSchema
+from beer_garden.api.http.schemas.v1.user import (
+    UserPasswordChangeSchema,
+    UserPatchSchema,
+)
 from beer_garden.events import publish
 
 io_loop: IOLoop = None
@@ -204,6 +207,7 @@ def _setup_tornado_app() -> Application:
         (rf"{prefix}api/v1/gardens/(.*)/?", v1.garden.GardenAPI),
         (rf"{prefix}api/v1/export/jobs/?", v1.job.JobExportAPI),
         (rf"{prefix}api/v1/import/jobs/?", v1.job.JobImportAPI),
+        (rf"{prefix}api/v1/password/change/?", v1.user.UserPasswordChangeAPI),
         (rf"{prefix}api/v1/token/?", v1.token.TokenAPI),
         (rf"{prefix}api/v1/token/revoke/?", v1.token.TokenRevokeAPI),
         (rf"{prefix}api/v1/token/refresh/?", v1.token.TokenRefreshAPI),
@@ -311,6 +315,7 @@ def _load_swagger(url_specs, title=None):
     api_spec.definition("UserCreate", schema=UserCreateSchema)
     api_spec.definition("UserList", schema=UserListSchema)
     api_spec.definition("UserPatch", schema=UserPatchSchema)
+    api_spec.definition("UserPasswordChange", schema=UserPasswordChangeSchema)
     api_spec.definition("Role", schema=LegacyRoleSchema)
     api_spec.definition("RoleList", schema=RoleListSchema)
     api_spec.definition("Queue", schema=QueueSchema)

--- a/src/app/beer_garden/api/http/schemas/v1/user.py
+++ b/src/app/beer_garden/api/http/schemas/v1/user.py
@@ -1,5 +1,5 @@
 from brewtils.schemas import RoleAssignmentDomainSchema
-from marshmallow import Schema, ValidationError, fields, post_load
+from marshmallow import Schema, ValidationError, fields, post_load, validate
 
 from beer_garden.db.mongo.models import Role, RoleAssignment, RoleAssignmentDomain
 
@@ -44,3 +44,12 @@ class UserPatchSchema(Schema):
 
     password = fields.Str()
     role_assignments = fields.List(fields.Nested(RoleAssignmentPatchSchema))
+
+
+class UserPasswordChangeSchema(Schema):
+    """Schema for changing a user's password"""
+
+    current_password = fields.Str(required=True)
+    new_password = fields.Str(
+        required=True, validate=validate.Length(min=1, error="Password required")
+    )

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -968,6 +968,9 @@ class User(Document):
 
     _permissions_cache: Optional[dict] = None
 
+    def __str__(self) -> str:
+        return self.username
+
     @property
     def permissions(self) -> dict:
         """Return the user's permissions organized by permission name. This is

--- a/src/app/test/api/http/unit/conftest.py
+++ b/src/app/test/api/http/unit/conftest.py
@@ -31,7 +31,11 @@ from beer_garden.api.http.handlers.v1.token import (
     TokenRefreshAPI,
     TokenRevokeAPI,
 )
-from beer_garden.api.http.handlers.v1.user import UserAPI, UserListAPI
+from beer_garden.api.http.handlers.v1.user import (
+    UserAPI,
+    UserListAPI,
+    UserPasswordChangeAPI,
+)
 from beer_garden.db.mongo.models import User
 
 # TODO: Load this from conftest using the actual _setup_application call
@@ -52,6 +56,7 @@ application = tornado.web.Application(
         (r"/api/v1/jobs/(\w+)/?", JobAPI),
         (r"/api/v1/jobs/(\w+)/execute/?", JobExecutionAPI),
         (r"/api/v1/logging/?", LoggingAPI),
+        (r"/api/v1/password/change/?", UserPasswordChangeAPI),
         (r"/api/v1/token/?", TokenAPI),
         (r"/api/v1/token/revoke/?", TokenRevokeAPI),
         (r"/api/v1/token/refresh/?", TokenRefreshAPI),

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -146,6 +146,9 @@
             ng-click="setMenuPage('main')"
           ></a>
           <ul class="dropdown-menu">
+            <li ng-show="checkMenuPage('main') && authEnabled()">
+              <a href="" ng-click="doChangePassword()">Change Password</a>
+            </li>
             <li ng-show="checkMenuPage('main')">
               <a ui-sref="base.about" ui-sref-active="active">About</a>
             </li>

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -137,6 +137,7 @@ import jobCreateCommandController from './js/controllers/job/create_command.js';
 import jobCreateRequestController from './js/controllers/job/create_request.js';
 import jobCreateTriggerController from './js/controllers/job/create_trigger.js';
 import loginController from './js/controllers/login.js';
+import changePasswordController from './js/controllers/change_password.js';
 
 // Partials
 import './partials/about.html';
@@ -247,4 +248,5 @@ angular
     .controller('JobExportController', jobExportController)
     .controller('JobImportController', jobImportController)
     .controller('JobImportModalController', jobImportModalController)
-    .controller('LoginController', loginController);
+    .controller('LoginController', loginController)
+    .controller('ChangePasswordController', changePasswordController);

--- a/src/ui/src/js/controllers/admin_user_index.js
+++ b/src/ui/src/js/controllers/admin_user_index.js
@@ -30,7 +30,7 @@ export function adminUserIndexController($scope, $uibModal, UserService) {
 
     modalInstance.result.then(
         (create) => {
-          if (create.password === create.verify) {
+          if (create.password === create.confirm) {
             UserService.createUser(create.username, create.password).then(
                 loadUsers,
             );

--- a/src/ui/src/js/controllers/change_password.js
+++ b/src/ui/src/js/controllers/change_password.js
@@ -1,0 +1,120 @@
+changePasswordController.$inject = ['$scope', '$uibModalInstance', 'UserService'];
+
+/**
+ * changePasswordController - Controller for change password modal.
+ * @param  {Object} $scope             Angular's $scope object.
+ * @param  {$scope} $uibModalInstance  Angular UI's $uibModalInstance object.
+ * @param  {Object} UserService        Beer-Garden's user service.
+ */
+export default function changePasswordController($scope, $uibModalInstance, UserService) {
+  $scope.cancel = function() {
+    $uibModalInstance.close();
+  };
+
+  $scope.submitChangePasswordForm = function(form, model) {
+    // Clear previously set errors
+    $scope.$broadcast('schemaForm.error.current', 'incorrectPassword', true);
+    $scope.$broadcast('schemaForm.error.confirm', 'passwordMatch', true);
+
+    // Run required fields validation
+    $scope.$broadcast('schemaFormValidate');
+
+    if (form.$valid) {
+      if (model.new === model.confirm) {
+        UserService.changePassword(model.current, model.new).then(
+            $uibModalInstance.close,
+            incorrectPasswordError,
+        );
+      } else {
+        $scope.$broadcast('schemaForm.error.confirm', 'passwordMatch', false);
+      }
+    }
+  };
+
+  const incorrectPasswordError = function() {
+    $scope.$broadcast('schemaForm.error.current', 'incorrectPassword', false);
+  };
+
+  const changePasswordSchema = {
+    type: 'object',
+    required: ['current', 'new', 'confirm'],
+    properties: {
+      current: {
+        title: 'Current Password',
+        type: 'string',
+      },
+      new: {
+        title: 'New Password',
+        type: 'string',
+      },
+      confirm: {
+        title: 'Confirm Password',
+        type: 'string',
+      },
+    },
+  };
+
+  const changePasswordForm = [
+    {
+      type: 'password',
+      key: 'current',
+      placeholder: 'current password',
+      validationMessage: {
+        incorrectPassword: 'Current password is incorrect',
+      },
+    },
+    {
+      type: 'password',
+      key: 'new',
+      placeholder: 'new password',
+    },
+    {
+      type: 'password',
+      key: 'confirm',
+      notitle: true,
+      placeholder: 'confirm password',
+      validationMessage: {
+        passwordMatch: 'Passwords do not match',
+      },
+    },
+    {
+      type: 'section',
+      htmlClass: 'row',
+      items: [
+        {
+          type: 'section',
+          htmlClass: 'col-xs-3 col-md-offset-5',
+          items: [
+            {
+              type: 'button',
+              style: 'btn-danger w-10',
+              title: 'Cancel',
+              onClick: 'cancel()',
+            },
+          ],
+        },
+        {
+          type: 'section',
+          htmlClass: 'col-xs-4',
+          items: [
+            {
+              type: 'submit',
+              style: 'btn-success w-10',
+              title: 'Submit',
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const generateChangePasswordForm = function() {
+    $scope.changePasswordSchema = changePasswordSchema;
+    $scope.changePasswordForm = changePasswordForm;
+    $scope.changePasswordModel = {};
+
+    $scope.$broadcast('schemaFormRedraw');
+  };
+
+  generateChangePasswordForm();
+}

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import {responseState} from './services/utility_service.js';
 
+import changePasswordTemplate from '../templates/change_password.html';
 import loginTemplate from '../templates/login.html';
 
 window.$ = $;
@@ -249,6 +250,17 @@ export default function appRun(
 
   $rootScope.checkMenuPage = function(page) {
     return $rootScope.menu_page == page;
+  };
+
+  $rootScope.doChangePassword = function() {
+    return $uibModal.open({
+      controller: 'ChangePasswordController',
+      size: 'sm',
+      template: changePasswordTemplate,
+    }).result.then(
+        _.noop,
+        _.noop,
+    );
   };
 
   function upsertSystem(system) {

--- a/src/ui/src/js/services/user_service.js
+++ b/src/ui/src/js/services/user_service.js
@@ -30,6 +30,12 @@ export default function userService($http, GardenService, SystemService) {
         password: password,
       });
     },
+    changePassword: (currentPassword, newPassword) => {
+      return $http.post('api/v1/password/change/', {
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+    },
     hasPermission: (user, permission) => {
       // True if the user has the permission for any objects at all
       return (

--- a/src/ui/src/templates/change_password.html
+++ b/src/ui/src/templates/change_password.html
@@ -1,0 +1,13 @@
+<div class="modal-header">
+  <h3 class="modal-title" id="modal-title">Change Password</h3>
+</div>
+
+<div class="modal-body" id="modal-body">
+  <form
+    name="changepasswordform"
+    sf-schema="changePasswordSchema"
+    sf-form="changePasswordForm"
+    sf-model="changePasswordModel"
+    ng-submit="submitChangePasswordForm(changepasswordform, changePasswordModel)"
+  />
+</div>

--- a/src/ui/src/templates/new_user.html
+++ b/src/ui/src/templates/new_user.html
@@ -30,7 +30,7 @@
           type="password"
           class="w-100"
           placeholder="confirm password"
-          ng-model="create.verify"
+          ng-model="create.confirm"
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #1262 

This PR adds password management to the UI.  There are two different places that this appears:

1) For all users, there is a new "Change Password" option in the top right ☰ dropdown menu.  This brings up a modal window where the user can change their own password.
2) On the admin only user management page where users' roles are managed, it is now also possible to change the user's password.

A new `/api/v1/password/change` API endpoint was also added to facilitate `#1`.

## Testing Instructions
* Try to change a password using the two methods described above.