### PR TITLE
#1265 - Add user syncing across gardens (backend-only)

### DIFF
--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -79,6 +79,7 @@ __all__ = [
     "Role",
     "RoleAssignment",
     "User",
+    "RemoteUser",
     "CommandPublishingBlockList",
 ]
 
@@ -1069,3 +1070,20 @@ class UserToken(Document):
             {"fields": ["expires_at"], "expireAfterSeconds": 0},
         ]
     }
+
+
+class RemoteUser(Document):
+    username = StringField(required=True)
+    garden = StringField(required=True)
+    role_assignments = ListField(field=DictField(), required=False)
+    updated_at = DateTimeField(required=True, default=datetime.datetime.utcnow)
+
+    meta = {
+        "indexes": [
+            {"fields": ["username"]},
+            {"fields": ["garden", "username"], "unique": True},
+        ],
+    }
+
+    def __str__(self):
+        return f"{self.garden}:{self.username}"

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -46,6 +46,7 @@ def garden_callbacks(event: Event) -> None:
         (beer_garden.log.handle_event, "Log"),
         (beer_garden.files.handle_event, "File"),
         (beer_garden.local_plugins.manager.handle_event, "Local plugins manager"),
+        (beer_garden.user.handle_event, "User event handler"),
     ]:
         try:
             handler(deepcopy(event))

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -21,6 +21,7 @@ from yapconf import YapconfSpec
 
 import beer_garden.config as config
 import beer_garden.db.api as db
+from beer_garden.db.mongo.models import RemoteUser
 from beer_garden.events import publish, publish_event
 from beer_garden.namespace import get_namespaces
 from beer_garden.systems import get_systems, remove_system
@@ -162,6 +163,9 @@ def remove_garden(garden_name: str) -> None:
 
     for system in systems:
         remove_system(system.id)
+
+    # Cleanup any RemoteUser entries
+    RemoteUser.objects.filter(garden=garden_name).delete()
 
     db.delete(garden)
 

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -40,6 +40,7 @@ import beer_garden.queues
 import beer_garden.requests
 import beer_garden.scheduler
 import beer_garden.systems
+import beer_garden.user
 from beer_garden.api.stomp.transport import Connection, consolidate_headers, process
 from beer_garden.errors import (
     ForwardException,
@@ -59,6 +60,7 @@ routable_operations = [
     "REQUEST_CREATE",
     "SYSTEM_DELETE",
     "GARDEN_SYNC",
+    "USER_SYNC",
 ]
 
 # Executor used to run REQUEST_CREATE operations in an async context
@@ -153,6 +155,7 @@ route_functions = {
     "RUNNER_RELOAD": beer_garden.local_plugins.manager.reload,
     "RUNNER_RESCAN": beer_garden.local_plugins.manager.rescan,
     "PUBLISH_EVENT": beer_garden.events.publish,
+    "USER_SYNC": beer_garden.user.user_sync,
 }
 
 
@@ -616,6 +619,9 @@ def _target_from_type(operation: Operation) -> str:
         return _system_name_lookup(
             System(namespace=parts[0], name=parts[1], version=version)
         )
+
+    if "USER" in operation.operation_type:
+        return operation.target_garden_name
 
     raise Exception(f"Bad operation type {operation.operation_type}")
 

--- a/src/app/beer_garden/user.py
+++ b/src/app/beer_garden/user.py
@@ -1,4 +1,15 @@
-from beer_garden.db.mongo.models import User
+import logging
+from copy import copy
+from typing import List, Optional
+
+from brewtils.models import Event, Events, Operation
+from marshmallow import ValidationError
+
+from beer_garden import config
+from beer_garden.db.mongo.models import Garden, RemoteUser, User
+from beer_garden.events import publish
+
+logger = logging.getLogger(__name__)
 
 
 def create_user(**kwargs) -> User:
@@ -21,23 +32,214 @@ def create_user(**kwargs) -> User:
     return user
 
 
-def update_user(user: User, **kwargs) -> User:
+def update_user(user: User, hashed_password: Optional[str] = None, **kwargs) -> User:
     """Updates the provided User by setting its attributes to those provided by kwargs.
     The updated user object is then saved to the database and returned.
 
     Args:
         user: The User instance to be updated
+        hashed_password: A pre-hashed password that should be stored as is. This will
+            override a password kwarg if one is supplied.
         **kwargs: Keyword arguments corresponding to User model attributes
 
     Returns:
         User: the updated User instance
     """
     for key, value in kwargs.items():
-        if key == "password":
+        if key == "password" and hashed_password is None:
             user.set_password(value)
         else:
             setattr(user, key, value)
 
+    if hashed_password:
+        user.password = hashed_password
+
     user.save()
 
     return user
+
+
+def initiate_user_sync() -> None:
+    """Syncs all users from this garden down to all remote gardens. Only the role
+    assignments relevant to each remote garden will be included in the sync.
+
+    Returns:
+        None
+    """
+    # Avoiding circular imports
+    from beer_garden.api.http.schemas.v1.user import UserSyncSchema
+    from beer_garden.router import route
+
+    users = User.objects.all()
+    gardens = Garden.objects.filter(connection_type__nin=["LOCAL", None])
+
+    for garden in gardens:
+        filtered_users = [
+            _filter_role_assigments_by_garden(user, garden) for user in users
+        ]
+        serialized_users = (
+            UserSyncSchema(many=True, strict=True).dump(filtered_users).data
+        )
+        operation = Operation(
+            operation_type="USER_SYNC",
+            target_garden_name=garden.name,
+            kwargs={"serialized_users": serialized_users},
+        )
+
+        route(operation)
+
+
+def user_sync(serialized_users: List[dict]) -> None:
+    """Function called for the USER_SYNC operation type. This imports the supplied list
+    of serialized_users and then initiates a USER_SYNC on any remote gardens. The
+    serialized_users dicts are expected to have been generated via UserSyncSchema.
+    NOTE: Existing users (matched by username) will be updated if present in the
+    serialized_users list.
+
+    Args:
+        serialized_users: Serialized list of users
+
+    Returns:
+        None
+    """
+    imported_users = _import_users(serialized_users)
+    _publish_import_results(imported_users)
+
+    initiate_user_sync()
+
+
+def user_synced_with_garden(user: User, garden: Garden) -> bool:
+    """Checks if the supplied user is currently synced to the supplied garden, based
+    on the corresponding RemoteUser entry. A user is considered synced if there is a
+    RemoteUser entry for the specified garden and the role assignments of that entry
+    match those of the User (for the relevant gardens).
+
+    Args:
+        user: The user for which we are checking the sync status
+        garden: The remote garden to check the status against
+
+    Returns:
+        bool: True if the user is currently synced. False otherwise.
+    """
+    # Avoiding circular imports
+    from beer_garden.api.http.schemas.v1.user import UserSyncSchema
+
+    try:
+        remote_user = RemoteUser.objects.get(username=user.username, garden=garden.name)
+    except RemoteUser.DoesNotExist:
+        return False
+
+    user = _filter_role_assigments_by_garden(user, garden)
+    role_assignments = UserSyncSchema().dump(user).data["role_assignments"]
+
+    return role_assignments == remote_user.role_assignments
+
+
+def handle_event(event: Event) -> None:
+    # Only handle events from downstream gardens
+    if event.garden == config.get("garden.name"):
+        return
+
+    if event.name == "USERS_IMPORTED":
+        _handle_users_imported_event(event)
+
+
+def _import_users(serialized_users: List[dict]) -> List[User]:
+    """Imports users from a list of dictionaries."""
+    # Avoiding circular import. Schemas should probably be moved outside of the http
+    # heirarchy.
+    from beer_garden.api.http.schemas.v1.user import UserPatchSchema
+
+    imported_users = []
+
+    for serialized_user in serialized_users:
+        username = serialized_user["username"]
+
+        try:
+            updated_user_data = UserPatchSchema(strict=True).load(serialized_user).data
+
+            try:
+                user = User.objects.get(username=username)
+            except User.DoesNotExist:
+                if len(updated_user_data["role_assignments"]) > 0:
+                    user = User(username=username)
+                    user.save()
+                else:
+                    continue
+
+            imported_users.append(update_user(user, **updated_user_data))
+
+        except ValidationError as exc:
+            logger.info(f"Failed to import user {username} due to error: {exc}")
+
+    return imported_users
+
+
+def _handle_users_imported_event(event):
+    """Handling for USER_IMPORTED events"""
+    # NOTE: This event stores its data in the metadata field as a workaround to the
+    # brewtils models dependency inherent in the more typical event publishing flow
+    try:
+        garden = event.metadata["garden"]
+        imported_users = event.metadata["imported_users"]
+        updated_at = event.timestamp
+
+        for user in imported_users:
+            username = user["username"]
+            role_assignments = user["role_assignments"]
+
+            try:
+                remote_user = RemoteUser.objects.get(garden=garden, username=username)
+            except RemoteUser.DoesNotExist:
+                remote_user = RemoteUser(garden=garden, username=username)
+
+            remote_user.role_assignments = role_assignments
+            remote_user.updated_at = updated_at
+
+            remote_user.save()
+    except KeyError:
+        logger.error("Error parsing %s event from garden %s", event.name, event.garden)
+
+
+def _filter_role_assigments_by_garden(user, garden) -> User:
+    """Filters the role assignments of the supplied user down to those that apply to
+    the namespaces of the supplied garden"""
+    namespaces = garden.namespaces
+    filtered_user = copy(user)
+
+    filtered_user.role_assignments = [
+        assignment
+        for assignment in filtered_user.role_assignments
+        if (assignment.domain.scope == "Global")
+        or (
+            assignment.domain.scope == "Garden"
+            and assignment.domain.identifiers.get("name") in namespaces
+        )
+        or (
+            assignment.domain.scope == "System"
+            and assignment.domain.identifiers.get("namespace") in namespaces
+        )
+    ]
+
+    return filtered_user
+
+
+def _publish_import_results(users):
+    """Publish an event back upstream with the results of the import"""
+    # Avoiding circular imports
+    from beer_garden.api.http.schemas.v1.user import UserSyncSchema
+
+    imported_users = UserSyncSchema(many=True).dump(users).data
+
+    # We use publish rather than publish_event here so that we can hijack the metadata
+    # field to store our actual data. This is done to avoid needing to deal in brewtils
+    # models, which the publish_event decorator requires us to do.
+    publish(
+        Event(
+            name=Events.USERS_IMPORTED.name,
+            metadata={
+                "garden": config.get("garden.name"),
+                "imported_users": imported_users,
+            },
+        )
+    )

--- a/src/app/test/conftest.py
+++ b/src/app/test/conftest.py
@@ -13,6 +13,7 @@ from beer_garden.db.mongo.models import (
     Garden,
     Job,
     RawFile,
+    RemoteUser,
     Request,
     Role,
     System,
@@ -38,6 +39,7 @@ def data_cleanup():
     Job.drop_collection()
     RawFile.drop_collection()
     Request.drop_collection()
+    RemoteUser.drop_collection()
     Role.drop_collection()
     System.drop_collection()
     User.drop_collection()

--- a/src/app/test/user_test.py
+++ b/src/app/test/user_test.py
@@ -1,9 +1,22 @@
 # -*- coding: utf-8 -*-
 import pytest
+from brewtils.models import Event, Events
+from mock import Mock
 from mongoengine import connect
 
-from beer_garden.db.mongo.models import User
-from beer_garden.user import create_user, update_user
+import beer_garden.events
+import beer_garden.router
+import beer_garden.user
+from beer_garden.api.http.schemas.v1.user import UserSyncSchema
+from beer_garden.db.mongo.models import Garden, RemoteUser, Role, RoleAssignment, User
+from beer_garden.user import (
+    create_user,
+    handle_event,
+    initiate_user_sync,
+    update_user,
+    user_sync,
+    user_synced_with_garden,
+)
 
 
 class TestUser:
@@ -13,7 +26,39 @@ class TestUser:
 
     @pytest.fixture(autouse=True)
     def drop_users(self):
+        yield
         User.drop_collection()
+
+    @pytest.fixture
+    def gardens(self):
+        garden1 = Garden(name="garden1", connection_type="HTTP").save()
+        garden2 = Garden(name="garden2", connection_type="HTTP").save()
+
+        yield [garden1, garden2]
+        garden1.delete()
+        garden2.delete()
+
+    @pytest.fixture
+    def user_to_sync(self):
+        role = Role(name="role1").save()
+        role_assignment = RoleAssignment(role=role, domain={"scope": "Global"})
+        user = User(
+            username="testuser", password="password", role_assignments=[role_assignment]
+        )
+
+        yield user
+        role.delete()
+
+    @pytest.fixture
+    def remote_user(self, user_to_sync, gardens):
+        remote_user = RemoteUser(username=user_to_sync.username, garden=gardens[0].name)
+        remote_user.role_assignments = (
+            UserSyncSchema().dump(user_to_sync).data["role_assignments"]
+        )
+        remote_user.save()
+
+        yield remote_user
+        remote_user.delete()
 
     def test_create_user(self):
         user = create_user(username="testuser", password="password")
@@ -44,3 +89,73 @@ class TestUser:
         # 2) It is not the plaintext password we provided
         assert updated_user.password != prev_password
         assert updated_user.password != "badpassword"
+
+    def test_initiate_user_sync_routes_to_each_garden(self, monkeypatch, gardens):
+        monkeypatch.setattr(beer_garden.router, "route", Mock())
+        User(username="testuser").save()
+        initiate_user_sync()
+
+        assert beer_garden.router.route.call_count == len(gardens)
+
+    def test_user_sync_creates_user(self, monkeypatch, user_to_sync):
+        monkeypatch.setattr(beer_garden.user, "initiate_user_sync", Mock())
+        monkeypatch.setattr(beer_garden.user, "publish", Mock())
+        serialized_user = UserSyncSchema().dump(user_to_sync).data
+
+        assert len(User.objects.filter(username=user_to_sync.username)) == 0
+
+        user_sync([serialized_user])
+
+        assert len(User.objects.filter(username=user_to_sync.username)) == 1
+        assert beer_garden.user.publish.called is True
+
+    def test_user_sync_updates_user(self, monkeypatch, user_to_sync):
+        monkeypatch.setattr(beer_garden.user, "initiate_user_sync", Mock())
+        monkeypatch.setattr(beer_garden.user, "publish", Mock())
+        serialized_user = UserSyncSchema().dump(user_to_sync).data
+        user_to_sync.role_assignments = []
+        user_to_sync.save()
+
+        user_sync([serialized_user])
+        user_to_sync.reload()
+        assert len(user_to_sync.role_assignments) == 1
+
+    def test_user_synced_with_garden_returns_false_for_no_remote_user(
+        self, user_to_sync, gardens
+    ):
+        assert user_synced_with_garden(user_to_sync, gardens[0]) is False
+
+    def test_user_synced_with_garden_returns_false_for_non_matching_role_assignments(
+        self, user_to_sync, remote_user
+    ):
+        garden = Garden.objects.get(name=remote_user.garden)
+        user_to_sync.role_assignments = []
+
+        assert user_synced_with_garden(user_to_sync, garden) is False
+
+    def test_user_synced_with_garden_returns_true_for_matching_role_assignments(
+        self, user_to_sync, remote_user
+    ):
+        garden = Garden.objects.get(name=remote_user.garden)
+
+        assert user_synced_with_garden(user_to_sync, garden) is True
+
+    def test_handle_event_for_users_imported(self):
+        role_assignments = [{"role_name": "role1", "domain": {"scope": "Global"}}]
+        import_results = {
+            "garden": "garden1",
+            "imported_users": [
+                {"username": "user1", "role_assignments": role_assignments}
+            ],
+        }
+
+        event = Event(
+            name=Events.USERS_IMPORTED.name, garden="garden1", metadata=import_results
+        )
+
+        assert len(RemoteUser.objects.filter(username="user1", garden="garden1")) == 0
+
+        handle_event(event)
+        remote_user = RemoteUser.objects.get(username="user1", garden="garden1")
+
+        assert remote_user.role_assignments == role_assignments

--- a/src/app/test/user_test.py
+++ b/src/app/test/user_test.py
@@ -140,17 +140,17 @@ class TestUser:
 
         assert user_synced_with_garden(user_to_sync, garden) is True
 
-    def test_handle_event_for_users_imported(self):
+    def test_handle_event_for_user_updated(self):
         role_assignments = [{"role_name": "role1", "domain": {"scope": "Global"}}]
-        import_results = {
+        user_updated_result = {
             "garden": "garden1",
-            "imported_users": [
-                {"username": "user1", "role_assignments": role_assignments}
-            ],
+            "user": {"username": "user1", "role_assignments": role_assignments},
         }
 
         event = Event(
-            name=Events.USERS_IMPORTED.name, garden="garden1", metadata=import_results
+            name=Events.USER_UPDATED.name,
+            garden="garden1",
+            metadata=user_updated_result,
         )
 
         assert len(RemoteUser.objects.filter(username="user1", garden="garden1")) == 0


### PR DESCRIPTION
This is the backend portion of #1265.  A separate PR will be opened for the UI changes.

This PR adds backend support for syncing users from a local garden down to all remote gardens. As implemented it is an all or nothing proposition.  Doing a user sync will sync **all** users on the local garden with **all** remote gardens. Support for limiting the scope of the sync would not be difficult, but feels unnecessary at this time given the intended use case.

The workflow does something like this:
**NOTE:** other than the first bullet, all referenced functions are in `beer_garden/user.py`
* The `/api/v1/gardens` endpoint now supports a "sync_users" PATCH operation, which is used to initiate the user sync. This felt like the appropriate home both because of the all or nothing nature described earlier and because this feels conceptually like another for of the garden sync, which is kicked off the same way.
* The "sync_users" operation results in a call to `initiate_user_sync`, which goes through each remote garden, filters each user's role assignments down to the ones appropriate for that garden, and then routes a `USER_SYNC` operation to it.
* The remote garden handles the `USER_SYNC` operation by calling the `user_sync` function, which updates the user entries on that garden and then calls `initiate_user_sync` itself so that the process can continue to any gardens that are further downstream (what we often refer to as "grandchildren").
* The `update_user` function has been updated so that ever time a user is updated (such as via `user_sync`), a `USER_UPDATED` event gets published.  This is what will inform the local garden that the user sync was actually successful on the remote.
* The `USER_UPDATED` event is handled by `_handle_user_updated_event`, which creates a `RemoteUser` entry for the updated user.  `RemoteUser` tracks a simply serialized version of a a user's role assignments, per garden.
* The `user_synced_with_garden` function is not used yet, but it takes a `User` and `Garden` and checks the User's role assignments against those of the corresponding `RemoteUser`.  The idea is that rather than showing the full details for the RemoteUser entries in the UI, I think we'll just show the results of the `user_synced_with_garden` check for each remote garden, since all we really care about right now is if the remote garden's role assignments are up to date with the local user or not.


## Test Instructions
There's a lot of setup for this one.  The unit tests coverage should be pretty good, but here's the high level of how to manually test it:
* Setup some users with role assignments on a local garden.
* Setup multiple remote gardens.  You may want a "grandchild" garden as well.  Either don't setup users on those remote gardens, or at least make sure they have role assignments that differ from the local garden.
* Execute a `PATCH` on `/api/v1/gardens` with a body of `{"operation": "sync_users"}`.
* Check that the remote gardens' users have had their role assignment updated appropriately.
* The local garden should have `RemoteUser` entries created for the users on the remote gardens now.  You'll have to check this either via the model in a shell or in the database directly.