### PR TITLE
#1265 - UI updates for user syncing

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/user.py
+++ b/src/app/beer_garden/api/http/handlers/v1/user.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
-from brewtils.schemas import UserCreateSchema, UserListSchema, UserSchema
+from brewtils.schemas import UserCreateSchema
 from marshmallow import ValidationError
 
 from beer_garden.api.authorization import Permissions
 from beer_garden.api.http.exceptions import BadRequest
 from beer_garden.api.http.handlers import AuthorizationHandler
 from beer_garden.api.http.schemas.v1.user import (
+    UserListSchema,
     UserPasswordChangeSchema,
     UserPatchSchema,
+    UserSchema,
 )
 from beer_garden.db.mongo.models import User
 from beer_garden.user import create_user, update_user

--- a/src/app/beer_garden/api/http/processors.py
+++ b/src/app/beer_garden/api/http/processors.py
@@ -17,9 +17,9 @@ class EventManager:
         beer_garden.api.http.io_loop.add_callback(self._conn.send, event)
 
 
-def websocket_publish(item):
+def websocket_publish(event):
     """Publish an event to all websocket endpoints"""
     try:
-        beer_garden.api.http.io_loop.add_callback(EventSocket.publish, item)
+        beer_garden.api.http.io_loop.add_callback(EventSocket.publish, event)
     except Exception as ex:
         logger.exception(f"Error publishing event to websocket: {ex}")

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -706,6 +706,8 @@ def _forward_http(operation: Operation, target_garden: Garden) -> None:
         ca_cert=conn_info.get("ca_cert"),
         ca_verify=conn_info.get("ca_verify"),
         client_cert=conn_info.get("client_cert"),
+        username=conn_info.get("username"),
+        password=conn_info.get("password"),
     )
 
     try:

--- a/src/app/test/api/http/unit/handlers/v1/garden_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/garden_test.py
@@ -5,6 +5,7 @@ import pytest
 from mock import Mock
 from tornado.httpclient import HTTPError, HTTPRequest
 
+import beer_garden.api.http.handlers.v1.garden
 import beer_garden.events
 import beer_garden.router
 import beer_garden.user
@@ -418,7 +419,9 @@ class TestGardenListAPI:
         user,
         garden_admin_role,
     ):
-        monkeypatch.setattr(beer_garden.user, "initiate_user_sync", Mock())
+        monkeypatch.setattr(
+            beer_garden.api.http.handlers.v1.garden, "initiate_user_sync", Mock()
+        )
 
         user.role_assignments.append(
             RoleAssignment(
@@ -445,7 +448,7 @@ class TestGardenListAPI:
         response = yield http_client.fetch(request)
 
         assert response.code == 204
-        assert beer_garden.user.initiate_user_sync.called is True
+        assert beer_garden.api.http.handlers.v1.garden.initiate_user_sync.called is True
 
     @pytest.mark.gen_test
     def test_auth_enabled_rejects_sync_users_patch_without_permissions_to_all_gardens(
@@ -456,7 +459,9 @@ class TestGardenListAPI:
         app_config_auth_enabled,
         access_token,
     ):
-        monkeypatch.setattr(beer_garden.user, "initiate_user_sync", Mock())
+        monkeypatch.setattr(
+            beer_garden.api.http.handlers.v1.garden, "initiate_user_sync", Mock()
+        )
 
         url = f"{base_url}/api/v1/gardens"
         headers = {
@@ -475,4 +480,6 @@ class TestGardenListAPI:
             yield http_client.fetch(request)
 
         assert excinfo.value.code == 403
-        assert beer_garden.user.initiate_user_sync.called is False
+        assert (
+            beer_garden.api.http.handlers.v1.garden.initiate_user_sync.called is False
+        )

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -99,10 +99,7 @@ import adminQueueController from './js/controllers/admin_queue.js';
 import adminSystemController from './js/controllers/admin_system.js';
 import adminSystemLogsController from './js/controllers/admin_system_logs.js';
 import adminSystemForceDeleteController from './js/controllers/admin_system_force_delete.js';
-import {
-  adminUserIndexController,
-  newUserController,
-} from './js/controllers/admin_user_index.js';
+import adminUserIndexController from './js/controllers/admin_user_index.js';
 import adminUserViewController from './js/controllers/admin_user_view.js';
 import {
   adminRoleController,
@@ -138,6 +135,8 @@ import jobCreateRequestController from './js/controllers/job/create_request.js';
 import jobCreateTriggerController from './js/controllers/job/create_trigger.js';
 import loginController from './js/controllers/login.js';
 import changePasswordController from './js/controllers/change_password.js';
+import newUserController from './js/controllers/user/new_user.js';
+import syncUsersController from './js/controllers/user/sync_users.js';
 
 // Partials
 import './partials/about.html';
@@ -223,6 +222,7 @@ angular
     .controller('AdminUserIndexController', adminUserIndexController)
     .controller('AdminUserViewController', adminUserViewController)
     .controller('NewUserController', newUserController)
+    .controller('SyncUsersController', syncUsersController)
     .controller('AdminRoleController', adminRoleController)
     .controller('NewRoleController', newRoleController)
     .controller('AdminGardenController', adminGardenController)

--- a/src/ui/src/js/controllers/admin_garden_view.js
+++ b/src/ui/src/js/controllers/admin_garden_view.js
@@ -112,6 +112,8 @@ export default function adminGardenViewController(
       'http.ca_cert',
       'http.ca_verify',
       'http.client_cert',
+      'http.username',
+      'http.password',
     ];
     const stompFlds = [
       'stomp.host',

--- a/src/ui/src/js/controllers/admin_user_index.js
+++ b/src/ui/src/js/controllers/admin_user_index.js
@@ -67,17 +67,19 @@ export default function adminUserIndexController($scope, $uibModal, UserService)
     $scope.users.forEach((user) => {
       user.fullySynced = true;
 
-      Object.values(user.sync_status).forEach((synced) => {
-        // If we get here at all, then there is sync data and we'll want
-        // to render it, so set that here. If we never get here, that means
-        // there are no remote gardens, so showing the sync status would be
-        // meaningless.
-        $scope.displaySyncStatus = true;
+      if (user.sync_status) {
+        Object.values(user.sync_status).forEach((synced) => {
+          // If we get here at all, then there is sync data and we'll want
+          // to render it, so set that here. If we never get here, that means
+          // there are no remote gardens, so showing the sync status would be
+          // meaningless.
+          $scope.displaySyncStatus = true;
 
-        if (!synced) {
-          user.fullySynced = false;
-        }
-      });
+          if (!synced) {
+            user.fullySynced = false;
+          }
+        });
+      }
     });
   };
 

--- a/src/ui/src/js/controllers/admin_user_view.js
+++ b/src/ui/src/js/controllers/admin_user_view.js
@@ -87,7 +87,11 @@ export default function adminUserViewController(
   const successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
-    $scope.displaySyncStatus = (Object.keys($scope.data.sync_status).length > 0);
+    $scope.displaySyncStatus = false;
+
+    if ($scope.data.sync_status) {
+      $scope.displaySyncStatus = (Object.keys($scope.data.sync_status).length > 0);
+    }
 
     generateUserSF();
   };

--- a/src/ui/src/js/controllers/admin_user_view.js
+++ b/src/ui/src/js/controllers/admin_user_view.js
@@ -73,7 +73,7 @@ export default function adminUserViewController(
     // identifiers for us anyway.
     model.role_assignments.forEach((assignment) => {
       if (assignment.domain.scope === 'Global') {
-        assignment.domain.identifiers.name = '';
+        assignment.domain.identifiers = {name: ''};
       }
       if (assignment.domain.scope !== 'System') {
         assignment.domain.identifiers.namespace = '';
@@ -87,6 +87,7 @@ export default function adminUserViewController(
   const successCallback = function(response) {
     $scope.response = response;
     $scope.data = response.data;
+    $scope.displaySyncStatus = (Object.keys($scope.data.sync_status).length > 0);
 
     generateUserSF();
   };

--- a/src/ui/src/js/controllers/user/new_user.js
+++ b/src/ui/src/js/controllers/user/new_user.js
@@ -1,0 +1,18 @@
+newUserController.$inject = ['$scope', '$uibModalInstance'];
+
+/**
+ * newUserController - New User controller.
+ * @param  {$scope} $scope                        Angular's $scope object.
+ * @param  {$uibModalInstance} $uibModalInstance  Angular UI's $uibModalInstance object.
+ */
+export default function newUserController($scope, $uibModalInstance) {
+  $scope.create = {};
+
+  $scope.ok = function() {
+    $uibModalInstance.close($scope.create);
+  };
+
+  $scope.cancel = function() {
+    $uibModalInstance.dismiss('cancel');
+  };
+}

--- a/src/ui/src/js/controllers/user/sync_users.js
+++ b/src/ui/src/js/controllers/user/sync_users.js
@@ -1,0 +1,94 @@
+import _ from 'lodash';
+
+syncUsersController.$inject = [
+  '$scope',
+  '$uibModalInstance',
+  'EventService',
+  'GardenService',
+];
+
+/**
+ * syncUsersController - Sync Users controller.
+ * @param  {$scope} $scope                        Angular's $scope object.
+ * @param  {$uibModalInstance} $uibModalInstance  Angular UI's $uibModalInstance object.
+ * @param  {Object} EventService                  Beer-Garden's event service.
+ * @param  {Object} GardenService                 Beer-Garden's garden service.
+ */
+export default function syncUsersController(
+    $scope,
+    $uibModalInstance,
+    EventService,
+    GardenService,
+) {
+  $scope.gardens = [];
+
+  $scope.sync = function() {
+    $scope.gardens.forEach((garden) => {
+      if (garden.status === 'RUNNING') {
+        garden.syncStatus = 'IN_PROGRESS';
+      }
+    });
+
+    GardenService.syncUsers();
+  };
+
+  $scope.cancel = function() {
+    $uibModalInstance.close();
+  };
+
+  $scope.disableSubmit = function() {
+    return (
+      _.filter($scope.gardens, function(garden) {
+        return garden.syncStatus === 'IN_PROGRESS';
+      }).length > 0
+    );
+  };
+
+  EventService.addCallback('sync_users', (event) => {
+    if (event.name === 'USERS_IMPORTED') {
+      $scope.$apply(() => {
+        handleUsersImportedEvent(event);
+      });
+    }
+  });
+
+  $scope.$on('$destroy', function() {
+    EventService.removeCallback('sync_users');
+  });
+
+  const handleUsersImportedEvent = function(event) {
+    $scope.gardens.forEach((garden) => {
+      if (garden.name === event.metadata.garden) {
+        garden.syncStatus = 'COMPLETE';
+      }
+    });
+  };
+
+  const successCallback = function(response) {
+    $scope.response = response;
+    $scope.gardens = [];
+
+    response.data.forEach((garden) => {
+      if (garden.connection_type !== 'LOCAL') {
+        if (garden.status !== 'RUNNING') {
+          garden.syncStatus = 'NOT RUNNING';
+        } else {
+          garden.syncStatus = 'PENDING';
+        }
+
+        $scope.gardens.push(garden);
+      }
+    });
+  };
+
+  const failureCallback = function(response) {
+    $scope.response = response;
+    $scope.gardens = [];
+  };
+
+  const loadGardens = function() {
+    GardenService.getGardens().then(successCallback, failureCallback);
+  };
+
+  loadGardens();
+}

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -30,8 +30,16 @@ export default function gardenService($rootScope, $http) {
   };
 
   GardenService.syncGardens = function() {
-    return $http.patch('api/v1/gardens', {
+    return $http.patch('api/v1/gardens/', {
       operation: 'sync',
+      path: '',
+      value: '',
+    });
+  };
+
+  GardenService.syncUsers = function() {
+    return $http.patch('api/v1/gardens/', {
+      operation: 'sync_users',
       path: '',
       value: '',
     });

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -206,7 +206,7 @@ export default function gardenService($rootScope, $http) {
     // Simply decide if every field in the http entry is blank.
     const simpleFieldMissing = getSimpleFieldPredicate(entryPointValues);
     const httpSimpleFields = [
-      'ca_cert', 'client_cert', 'host', 'port', 'url_prefix',
+      'ca_cert', 'client_cert', 'host', 'port', 'url_prefix', 'username', 'password',
     ];
     const allHttpFieldsEmpty = httpSimpleFields.every(simpleFieldMissing);
 
@@ -328,6 +328,16 @@ export default function gardenService($rootScope, $http) {
               'URL path that will be used as a prefix when communicating ' +
               'with Beer-garden. Useful if Beer-garden is running on a URL ' +
               'other than \'/\'.',
+            type: 'string',
+          },
+          username: {
+            title: 'Username',
+            description: 'Required if auth is enabled on the remote garden.',
+            type: 'string',
+          },
+          password: {
+            title: 'Password',
+            description: 'Required if auth is enabled on the remote garden.',
             type: 'string',
           },
           ca_cert: {
@@ -469,6 +479,8 @@ export default function gardenService($rootScope, $http) {
                 'http.host',
                 'http.port',
                 'http.url_prefix',
+                'http.username',
+                'http.password',
                 'http.ssl',
                 'http.ca_cert',
                 'http.ca_verify',

--- a/src/ui/src/partials/admin_user_index.html
+++ b/src/ui/src/partials/admin_user_index.html
@@ -1,13 +1,23 @@
 <h1 class="page-header">
   User Management
   <div class="pull-right">
-    <input
-      type="submit"
-      class="btn btn-primary w-100"
+    <button
+      type="button"
+      class="btn btn-primary"
       ng-click="doCreate()"
       ng-show="hasPermission(user, 'user:create')"
-      value="Create User"
-    />
+    >
+      Create User
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      ng-if="displaySyncStatus"
+      ng-click="doSync()"
+      ng-show="hasPermission(user, 'garden:update')"
+    >
+      Sync Users
+    </button>
   </div>
 </h1>
 
@@ -33,14 +43,32 @@
       <thead>
         <tr>
           <th id="th_username" scope="col">Username</th>
+          <th ng-if="displaySyncStatus" id="th_fullysynced" scope="col">
+            Fully Synced
+          </th>
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="user in data.users | filter:query">
+        <tr ng-repeat="user in users | filter:query">
           <td>
             <a ui-sref="base.user_view({username: user.username})"
               >{{user.username}}</a
             >
+          </td>
+          <td ng-if="displaySyncStatus">
+            <i
+              ng-if="user.fullySynced"
+              class="glyphicon glyphicon-ok"
+              style="color: green"
+              title="true"
+            ></i>
+            <i
+              ng-if="!user.fullySynced"
+              class="glyphicon glyphicon-remove"
+              style="color: red"
+              title="false"
+            ></i>
+            <span hidden>{{user.fullySynced}}</span>
           </td>
         </tr>
       </tbody>

--- a/src/ui/src/partials/admin_user_view.html
+++ b/src/ui/src/partials/admin_user_view.html
@@ -20,6 +20,42 @@
 >
   {{alert.msg}}
 </div>
+<div ng-if="displaySyncStatus">
+  <b>Sync Status</b>
+  <table
+    datatable="ng"
+    dt-options="{paging: false, searching: false, info: false}"
+    class="table table-striped table-bordered"
+    style="width: 25%"
+  >
+    <thead>
+      <th>Garden</th>
+      <th>Synced</th>
+    </thead>
+    <tbody>
+      <tr ng-repeat="(garden, synced) in data.sync_status">
+        <td>{{garden}}</td>
+        <td>
+          <i
+            ng-if="synced"
+            class="glyphicon glyphicon-ok"
+            style="color: green"
+            title="true"
+          ></i>
+          <i
+            ng-if="!synced"
+            class="glyphicon glyphicon-remove"
+            style="color: red"
+            title="false"
+          ></i>
+          <span hidden>{{synced}}</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr />
+</div>
 
 <div
   id="user-view-container"

--- a/src/ui/src/templates/sync_users.html
+++ b/src/ui/src/templates/sync_users.html
@@ -1,0 +1,40 @@
+<form ng-submit="sync()">
+  <div class="modal-header">
+    <h3 class="modal-title" id="modal-title">Sync Users</h3>
+    This will sync all users from this garden to all remote gardens, making the
+    role assignments and password for each user on the remote garden match those
+    of the the users for this garden. Any role assignments that were granted
+    directly on the remote gardens will be overwritten by this process.
+  </div>
+
+  <div class="modal-body" id="modal-body">
+    <table id="syncStatus" class="table">
+      <thead>
+        <tr>
+          <th scope="col">Garden</th>
+          <th scope="col">Sync Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="garden in gardens">
+          <td>{{garden.name}}</td>
+          <td ng-show="garden.syncStatus!=='IN_PROGRESS'">
+            {{garden.syncStatus}}
+          </td>
+          <td ng-show="garden.syncStatus==='IN_PROGRESS'">
+            <i class="fa fa-spinner fa-pulse"></i>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="modal-footer" ng-if="responseState(response) === 'success'">
+    <button type="button" class="btn btn-danger" ng-click="cancel()">
+      Cancel
+    </button>
+    <button type="submit" class="btn btn-success" ng-disabled="disableSubmit()">
+      Sync
+    </button>
+  </div>
+</form>


### PR DESCRIPTION
Closes #1265 

This PR adds the UI components (and the API changes to drive the UI) for the user syncing.  With this PR the following changes are present in the UI:

* On the User admin index page there is a "Sync Users" button next to the "Create Users" button.  Clicking this brings up a modal that explains what the syncing is all about and lets you click "Sync" to start the process.
  * The "Sync Status" for each garden is initially listed as "PENDING" if the garden is in a "RUNNING" state.  If the garden is not running, the sync status is just listed as "NOT RUNNING", indicating that we can't actually sync to that garden right now.
  * Once "Sync" is clicked, a spinner will be shown in place of "PENDING" to denote that the sync is in progress.  Once the sync is done, it will change to "COMPLETE".  **NOTE:** There is currently no timeout and no error reporting, so if the sync does not work for some reason, the spinner will currently just spin indefinitely.
  * When the sync finishes for each garden, the status will update in the modal.  Once they are all complete, you can either click outside of the modal to dismiss it or just click "Cancel".
* Also on the User index page, there is a new column labeled "Fully Synced" which will show either a ✓ (the user is synced with all remote gardens) or an X (they are not).
* On the individual User view page, there is a "Sync Status" table at the top which shows the breakdown of if the user is synced to each remote garden.  The idea being that if someone saw an X on the index page for a user, they could drill down and see the specifics of where they aren't synced.

All of the above items only show up if there are remote gardens for a user to be synced to.  If there are no remote gardens then  all of that sync information would just be clutter, so it is instead not displayed.

Some backend changes made to facilitate some of this new functionality:

* The API response for users now returns a "sync_status" attribute, which lists whether the user is synced to each remote garden.
* Some new websocket event publishing checks have been put in place.  Specifically:
  * USER_UPDATED events do not get published at all.  There's no reason for anyone to see those right now.
  * USERS_IMPORTED events require global "garden:update" access (the access required to do the sync in the first place).  This is to ensure that the existence of a remote garden is not inadvertently leaked through a websocket event that someone has no use for.

## Test Instructions
For testing, you'll basically want to setup some users and some remote gardens and play around with the new features described above, ensuring that they behave as you'd hope / expect.