### PR TITLE
#1274 - Create admin user and superuser role on new garden startup

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -115,6 +115,17 @@ Available settings:
 - **username_header:** The name of the header that will contain the username.
   Default: `bg-username`
 
+### default_admin
+
+Allows you to specify the username and password for the default admin account.
+This account will be created the first time the garden is started and will be
+assigned superuser access to the garden.
+
+Available settings:
+
+- **username:** The username of the admin account. Default: admin
+- **password:** The password of the admin account. Default: password
+
 ### enabled
 
 When `true`, users will be required to authenticate via one of the enabled

--- a/src/app/beer_garden/api/http/handlers/misc.py
+++ b/src/app/beer_garden/api/http/handlers/misc.py
@@ -21,7 +21,6 @@ class ConfigHandler(BaseHandler):
             "debug_mode": ui_config.debug_mode,
             "execute_javascript": ui_config.execute_javascript,
             "garden_name": config.get("garden.name"),
-            "guest_login_enabled": auth_config.guest_login_enabled,
             "metrics_url": config.get("metrics.prometheus.url"),
             "url_prefix": config.get("entry.http.url_prefix"),
         }

--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -220,7 +220,7 @@ class Application(StoppableThread):
 
         self.logger.debug("Setting up database...")
         db.create_connection(db_config=config.get("db"))
-        db.initial_setup(config.get("auth.guest_login_enabled"))
+        db.initial_setup()
 
         self.logger.debug("Setting up message queues...")
         queue.initial_setup()

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -639,6 +639,25 @@ _AUTHENTICATION_HANDLERS_SPEC = {
     },
 }
 
+
+_DEFAULT_ADMIN_SPEC = {
+    "type": "dict",
+    "items": {
+        "username": {
+            "type": "str",
+            "default": "admin",
+            "description": "The username for the default admin account that will "
+            "be created when initializing a new environment",
+        },
+        "password": {
+            "type": "str",
+            "default": "password",
+            "description": "The password for the default admin account that will "
+            "be created when initializing a new environment",
+        },
+    },
+}
+
 _AUTH_SPEC = {
     "type": "dict",
     "items": {
@@ -647,14 +666,7 @@ _AUTH_SPEC = {
             "default": False,
             "description": "Use role-based authentication / authorization",
         },
-        "guest_login_enabled": {
-            "type": "bool",
-            "default": True,
-            "description": (
-                "Only applicable if auth is enabled. If set to "
-                "true, guests can login without username/passwords."
-            ),
-        },
+        "default_admin": _DEFAULT_ADMIN_SPEC,
         "token_secret": {
             "type": "str",
             "required": False,

--- a/src/app/beer_garden/db/mongo/api.py
+++ b/src/app/beer_garden/db/mongo/api.py
@@ -169,7 +169,7 @@ def create_connection(connection_alias: str = "default", db_config: Box = None) 
     )
 
 
-def initial_setup(guest_login_enabled):
+def initial_setup():
     """Do everything necessary to ensure the database is in a 'good' state"""
 
     ensure_model_migration()
@@ -186,7 +186,7 @@ def initial_setup(guest_login_enabled):
 
     ensure_local_garden()
     ensure_roles()
-    ensure_users(guest_login_enabled)
+    ensure_users()
 
 
 def get_pruner():

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -1,6 +1,5 @@
 auth:
   enabled: false
-  guest_login_enabled: true
   role_definition_file: null
   group_definition_file: null
   token_secret: IAMSUPERSECRET
@@ -12,6 +11,9 @@ auth:
       username_header: bg-username
       user_groups_header: bg-user-groups
       create_users: True
+  default_admin:
+    password: password
+    username: admin
 db:
   connection:
     host: localhost


### PR DESCRIPTION
Closes #1274 

This PR adds steps to the garden initialization process that will create a default admin user, and create a default superuser role with all permissions that can be assigned to the admin user.

Some notes:
* The admin username and password can be customized via the app config.
* The admin user will not be created if any other users already exist
* The superuser role be created if it does not exist and there are no existing users.  Users existing indicates some setup has been done already and we preserve that setup.  An existing superuser role will never be modified.
* The code I touched had some references to the "guest_login_enabled" configuration option.  That option didn't do anything in the current iteration of beergarden, so I just opted to remove all references to it throughout the code.

## Test Instructions
Start a fresh instance of beergarden.  You should see log messages indicating that the admin user and superuser role are created.  Without any other setup, you should be able to login to the UI as admin / password (unless you changed the defaults in your config).