### PR TITLE
#1276 - Add authorization to the swagger docs

### DIFF
--- a/src/app/beer_garden/api/http/__init__.py
+++ b/src/app/beer_garden/api/http/__init__.py
@@ -301,6 +301,10 @@ def _load_swagger(url_specs, title=None):
         title=title,
         version="1.0",
         plugins=("apispec.ext.marshmallow", "apispec.ext.tornado"),
+        securityDefinitions={
+            "Bearer": {"type": "apiKey", "name": "Authorization", "in": "header"},
+        },
+        security=[{"Bearer": []}],
     )
 
     # Schemas from Marshmallow


### PR DESCRIPTION
Closes #1276 

This PR adds the authorization button to the swagger docs.  With this, you can use the swagger docs with auth enabled by doing the following:

* Use the /api/v1/token endpoint to login and get an access token.
* Click the authorization button at the top of the swagger page.  In the field for the api key, put "Bearer <token>".  The **Bearer** part is required because OpenAPI 2 (which we are stuck on for now) does not have native support for bearer auth.