### PR TITLE
#1280 - Improve login process

### DIFF
--- a/src/app/beer_garden/api/http/exceptions.py
+++ b/src/app/beer_garden/api/http/exceptions.py
@@ -42,7 +42,7 @@ class AuthorizationRequired(BaseHTTPError):
 
 
 class AuthenticationFailed(BaseHTTPError):
-    status_code: int = 401
+    status_code: int = 400
     reason: str = "Authentication Failed"
 
 

--- a/src/app/beer_garden/api/http/handlers/misc.py
+++ b/src/app/beer_garden/api/http/handlers/misc.py
@@ -12,11 +12,13 @@ class ConfigHandler(BaseHandler):
     async def get(self):
         """Subset of configuration options that the frontend needs"""
         auth_config = config.get("auth")
+        trusted_header_config = auth_config.authentication_handlers.trusted_header
         ui_config = config.get("ui")
 
         configs = {
             "application_name": ui_config.name,
             "auth_enabled": auth_config.enabled,
+            "trusted_header_auth_enabled": trusted_header_config.enabled,
             "icon_default": ui_config.icon_default,
             "debug_mode": ui_config.debug_mode,
             "execute_javascript": ui_config.execute_javascript,

--- a/src/app/beer_garden/api/http/handlers/v1/token.py
+++ b/src/app/beer_garden/api/http/handlers/v1/token.py
@@ -35,7 +35,7 @@ class TokenAPI(BaseHandler):
                          token.
             schema:
               $ref: '#/definitions/TokenResponse'
-          401:
+          400:
             description: Authentication failed.
         tags:
           - Token

--- a/src/app/test/api/http/unit/handlers/v1/token_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/token_test.py
@@ -57,24 +57,24 @@ class TestTokenAPI:
         assert decoded_access_token["jti"] == decoded_refresh_token["jti"]
 
     @pytest.mark.gen_test
-    def test_post_returns_401_on_invalid_login(self, http_client, base_url, user):
+    def test_post_returns_400_on_invalid_login(self, http_client, base_url, user):
         url = f"{base_url}/api/v1/token"
         body = json.dumps({"username": user.username, "password": "notmypassword"})
 
         with pytest.raises(HTTPError) as excinfo:
             yield http_client.fetch(url, method="POST", body=body)
 
-        assert excinfo.value.code == 401
+        assert excinfo.value.code == 400
 
     @pytest.mark.gen_test
-    def test_post_returns_401_when_user_not_found(self, http_client, base_url):
+    def test_post_returns_400_when_user_not_found(self, http_client, base_url):
         url = f"{base_url}/api/v1/token"
         body = json.dumps({"username": "cantfindme", "password": "doesntmatter"})
 
         with pytest.raises(HTTPError) as excinfo:
             yield http_client.fetch(url, method="POST", body=body)
 
-        assert excinfo.value.code == 401
+        assert excinfo.value.code == 400
 
 
 class TestTokenRefreshAPI:

--- a/src/ui/src/js/controllers/login.js
+++ b/src/ui/src/js/controllers/login.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import angular from 'angular';
 
 loginController.$inject = [
@@ -10,10 +9,10 @@ loginController.$inject = [
 
 /**
  * loginController - Login controller
- * @param  {Object} $scope                        Angular's $scope object.
- * @param  {Object} $timeout                        Angular's $timeout object.
+ * @param  {Object} $scope             Angular's $scope object.
+ * @param  {Object} $timeout           Angular's $timeout object.
  * @param  {Object} $uibModalInstance  Angular UI's $uibModalInstance object.
- * @param  {Object} TokenService  TokenService object.
+ * @param  {Object} TokenService       TokenService object.
  */
 export default function loginController(
     $scope,
@@ -24,23 +23,11 @@ export default function loginController(
   $scope.model = {};
 
   $scope.doLogin = function() {
-    $scope.badUsername = false;
-    $scope.badPassword = false;
+    $scope.loginFailed = false;
 
     TokenService.doLogin($scope.model.username, $scope.model.password).then(
-        (response) => {
-          $uibModalInstance.close();
-        },
-        () => {
-          if (_.isUndefined($scope.model.username)) {
-            $scope.badUsername = true;
-            angular.element('input[type="text"]').focus();
-          } else {
-            $scope.badPassword = true;
-            $scope.model.password = undefined;
-            angular.element('input[type="password"]').focus();
-          }
-        },
+        loginSuccess,
+        loginFailure,
     );
   };
 
@@ -48,7 +35,16 @@ export default function loginController(
     $uibModalInstance.dismiss();
   };
 
+  const loginSuccess = function() {
+    $uibModalInstance.close();
+  };
+
+  const loginFailure = function() {
+    $scope.loginFailed = true;
+    angular.element('input[id="password"]').focus();
+  };
+
   $timeout(() => {
-    angular.element('input[type="text"]').focus();
+    angular.element('input[id="username"]').focus();
   });
 }

--- a/src/ui/src/templates/login.html
+++ b/src/ui/src/templates/login.html
@@ -7,23 +7,28 @@
     <div class="row m-b-1">
       <div class="col-md-12">
         <input
+          id="username"
           type="text"
           class="w-100"
           placeholder="username"
           ng-model="model.username"
-          ng-class="{'red-border': badUsername}"
         />
       </div>
     </div>
     <div class="row m-b-1">
       <div class="col-md-12">
         <input
+          id="password"
           type="password"
           class="w-100"
           placeholder="password"
           ng-model="model.password"
-          ng-class="{'red-border': badPassword}"
         />
+      </div>
+    </div>
+    <div class="row m-b-1" ng-if="loginFailed">
+      <div class="col-md-12" style="color: red">
+        Invalid username or password
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #1280 

This PR does the following:

* Provides feedback on the login form when authentication fails by displaying a message that reads "Invalid username or password".
* Attempts to auto-login a user if trusted header authentication is enabled.  This makes for a smoother experience where a user is not required to click the login button if they have already authenticated via their a proxy server that is passing along trusted headers.

Work on these changes highlighted the fact that the HTTP response code for failed logins had been incorrect (it was 401).  This PR changes that to 400 so that it failed login responses do not get caught up in the http interceptor code intended for handling actual data returning endpoints.

## Testing instructions
* In the login dialog, enter an incorrect username or password.  You should see a message indicating the failure.
* Access beergarden through a trusted proxy.  It should automatically log you in.

