### PR TITLE
#1284 - Make namespace the fallback field for _get_garden_name_field

### DIFF
--- a/src/app/beer_garden/authorization.py
+++ b/src/app/beer_garden/authorization.py
@@ -231,11 +231,9 @@ def _get_garden_name_field(model: Type[Document]):
     field_name_map = {
         "Garden": "name",
         "Job": "request_template__namespace",
-        "Request": "namespace",
-        "System": "namespace",
     }
 
-    return field_name_map.get(model.__name__)
+    return field_name_map.get(model.__name__, "namespace")
 
 
 def _get_object_ids_from_domain(domain: RoleAssignmentDomain) -> list:


### PR DESCRIPTION
Closes #1284 

This PR makes the `user_permitted_objects` helper function work with the CommandPublishingBlockList model.  It does this by making "namespace" the default garden name field for the `_get_garden_name_field` function so that models that use that field don't explicitly need to be present in the model field map.