### PR TITLE
#1288 - Fix to allow local plugins to connect to rabbitmq over TLS

### DIFF
--- a/docker/docker-compose/tls/docker-compose.yml
+++ b/docker/docker-compose/tls/docker-compose.yml
@@ -100,7 +100,7 @@ services:
         restart: always
 
     rabbitmq:
-        image: rabbitmq:management-alpine
+        image: rabbitmq:3.8-management-alpine
         restart: always
         hostname: rabbitmq
         networks:
@@ -112,14 +112,14 @@ services:
             RABBITMQ_SSL_CACERTFILE: /certs/ca_certificate.pem
             RABBITMQ_SSL_CERTFILE: /certs/combined_server.pem
             RABBITMQ_SSL_DEPTH: 2
-            RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT: "false"
+            RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT: "true"
             RABBITMQ_SSL_KEYFILE: /certs/combined_server.pem
             RABBITMQ_SSL_VERIFY: verify_peer
 
             RABBITMQ_MANAGEMENT_SSL_CACERTFILE: /certs/ca_certificate.pem
             RABBITMQ_MANAGEMENT_SSL_CERTFILE: /certs/combined_server.pem
             RABBITMQ_MANAGEMENT_SSL_DEPTH: 2
-            RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT: "false"
+            RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT: "true"
             RABBITMQ_MANAGEMENT_SSL_KEYFILE: /certs/combined_server.pem
             RABBITMQ_MANAGEMENT_SSL_VERIFY: verify_peer
         ports:

--- a/src/app/beer_garden/queue/rabbit.py
+++ b/src/app/beer_garden/queue/rabbit.py
@@ -95,7 +95,7 @@ def create(instance: Instance, system: System) -> dict:
         "user": mq_config.connections.message.user,
         "password": mq_config.connections.message.password,
         "virtual_host": mq_config.virtual_host,
-        "ssl": {"enabled": mq_config.connections.message.ssl.enabled},
+        "ssl": mq_config.connections.message.ssl,
     }
 
     return {


### PR DESCRIPTION
Closes #1288 

This PR makes changes to allow local plugins to properly connect to rabbitmq when it is setup to require client certificates.  Specifically, it now includes the full set of `mq_config.connections.message.ssl` settings instead of just `mq_config.connections.message.ssl.enabled` so that local plugins receive the location of the certificate file to use when connecting.

## Test Instructions
This should be tested in together with [brewtils/pull/390](https://github.com/beer-garden/brewtils/pull/390).

To test, you must setup rabbitmq to accept TLS connections and require client certificates.  You must then ensure that your `mq.message.ssl` and `mq.admin.ssl` settings are configured, with the client cert specifically pointing to a cert / key bundle.  With all of that configured, start up beergarden and make sure everything connects okay.