### PR TITLE
#1290 - Add type enforcement to user_has_permission_for_object

### DIFF
--- a/src/app/beer_garden/authorization.py
+++ b/src/app/beer_garden/authorization.py
@@ -101,7 +101,13 @@ def user_has_permission_for_object(
     Returns:
         bool: True if the user has the specified permission for the object.
               False otherwise.
+
+    Raises:
+        TypeError: The provided object is of an unsupported type
     """
+    if not (isinstance(obj, Document) or isinstance(obj, BrewtilsModel)):
+        raise TypeError("obj must be of a type derived from Document or BrewtilsModel")
+
     if permission in user.global_permissions or _user_has_object_owner_permission(
         user, permission, obj
     ):

--- a/src/app/test/auth_test.py
+++ b/src/app/test/auth_test.py
@@ -399,6 +399,17 @@ class TestAuth:
             user_with_role_assignments, "system:read", brewtils_system
         )
 
+    def test_user_has_permission_for_object_raises_error_for_unsupported_type(
+        self, user_with_role_assignments
+    ):
+        """user_has_permission_for_object raises TypeError if an unsupported object
+        type is passed in"""
+
+        with pytest.raises(TypeError):
+            user_has_permission_for_object(
+                user_with_role_assignments, "garden:read", []
+            )
+
     def test_user_permitted_objects_returns_permitted_gardens(
         self, user_with_role_assignments, test_garden
     ):


### PR DESCRIPTION
Closes #1290 

This PR adds type enforcement to `user_has_permission_for_object` to avoid scenarios where an unsupported type could be passed in, resulting in undefined behavior.