### PR TITLE
#1292 - List and pin missing requirements in setup.py

### DIFF
--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -44,7 +44,9 @@ packaging==20.9
 passlib==1.7.4
     # via beer-garden (setup.py)
 pathtools==0.1.2
-    # via watchdog
+    # via
+    #   beer-garden (setup.py)
+    #   watchdog
 pika==1.2.0
     # via brewtils
 prometheus-client==0.13.1
@@ -98,7 +100,9 @@ tzlocal==4.1
 urllib3==1.26.9
     # via requests
 watchdog==0.10.4
-    # via yapconf
+    # via
+    #   beer-garden (setup.py)
+    #   yapconf
 wrapt==1.12.1
     # via brewtils
 yapconf==0.3.7

--- a/src/app/setup.py
+++ b/src/app/setup.py
@@ -36,6 +36,7 @@ setup(
         "more-itertools<9",
         "motor<3",
         "passlib<1.8",
+        "pathtools==0.1.2",
         "prometheus-client<1",
         "pyyaml<6",
         "pyrabbit2<2",
@@ -43,7 +44,8 @@ setup(
         "ruamel.yaml<0.17",
         "stomp.py<6.2.0",
         "tornado<7",
-        "yapconf>=0.3.7",
+        "watchdog<1",
+        "yapconf==0.3.7",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Closes #1292 

This PR pins the version of yapconf and explicitly lists watchdog and pathtools, both of which were being used without being listed as direct dependencies.

A follow-up issue will be opened to look at updating yapconf and then updating or removing the dependency on watchdog and pathtools.