### PR TITLE
Make debian docker image more like alpine image

### DIFF
--- a/src/app/Makefile
+++ b/src/app/Makefile
@@ -154,6 +154,7 @@ docker-build-debian:
 
 docker-build-unstable: package clean-python ## build nightly docker image
 	docker build -t $(DOCKER_NAME):unstable -f docker/Dockerfile.unstable .
+	docker build -t $(DOCKER_NAME):unstable-debian -f docker/Dockerfile.unstable-debian .
 
 
 # Publishing
@@ -172,3 +173,4 @@ publish-docker: docker-build ## push the docker images
 
 publish-docker-unstable: docker-build-unstable ## push the unstable docker image
 	docker push $(DOCKER_NAME):unstable
+	docker push $(DOCKER_NAME):unstable-debian

--- a/src/app/docker/Dockerfile.debian
+++ b/src/app/docker/Dockerfile.debian
@@ -1,26 +1,20 @@
 FROM python:3.10-slim
 ARG VERSION
 
-ENV BG_LOG_CONFIG_FILE=/etc/beer-garden/app-logging.yaml \
-    BG_PLUGIN_LOCAL_LOGGING_CONFIG_FILE=/etc/beer-garden/local-plugin-logging.yaml \
-    BG_PLUGIN_REMOTE_LOGGING_CONFIG_FILE=/etc/beer-garden/remote-plugin-logging.yaml \
-    BG_PLUGIN_LOCAL_DIRECTORY=/var/lib/beer-garden/plugins
-
-ADD example_configs/* /etc/beer-garden/
-ADD docker/docker-entrypoint.sh /usr/local/bin/
+ENV BG_LOG_CONFIG_FILE=/conf/app-logging.yaml \
+    BG_PLUGIN_LOCAL_LOGGING_CONFIG_FILE=/conf/local-plugin-logging.yaml \
+    BG_PLUGIN_REMOTE_LOGGING_CONFIG_FILE=/conf/remote-plugin-logging.yaml \
+    BG_PLUGIN_LOCAL_DIRECTORY=/plugins
 
 RUN set -ex \
-    && useradd --no-log-init -m beergarden \
     && apt-get -y update \
-    && apt-get install -y gosu \
     && pip install --upgrade pip \
-    && pip install --no-cache-dir beer-garden==$VERSION \
-    && mkdir /var/log/beer-garden \
-    && mkdir -p /var/lib/beer-garden/plugins \
-    && generate_app_logging_config \
-       --config-file /etc/beer-garden/app-logging.yaml \
-    && chown beergarden:beergarden /var/log/beer-garden \
-    && chown beergarden:beergarden /var/lib/beer-garden/plugins
+    && pip install --no-cache-dir beer-garden==$VERSION
+
+ADD example_configs/app-logging.yaml /conf/
+ADD example_configs/local-plugin-logging.yaml /conf/
+ADD example_configs/remote-plugin-logging.yaml /conf/
+ADD docker/docker-entrypoint.sh /usr/local/bin/
 
 EXPOSE 2337/tcp
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/src/app/docker/Dockerfile.unstable-debian
+++ b/src/app/docker/Dockerfile.unstable-debian
@@ -1,0 +1,23 @@
+FROM python:3.10-slim
+WORKDIR /src
+
+ENV BG_LOG_CONFIG_FILE=/src/conf/app-logging.yaml \
+    BG_PLUGIN_LOCAL_LOGGING_CONFIG_FILE=/src/conf/local-plugin-logging.yaml \
+    BG_PLUGIN_REMOTE_LOGGING_CONFIG_FILE=/src/conf/remote-plugin-logging.yaml \
+    BG_PLUGIN_LOCAL_DIRECTORY=/plugins
+
+ADD ./example_configs/app-logging.yaml /conf/
+ADD ./example_configs/local-plugin-logging.yaml /conf/
+ADD ./example_configs/remote-plugin-logging.yaml /conf/
+ADD ./docker/docker-entrypoint.sh /usr/local/bin/
+ADD ./requirements.txt .
+ADD ./dist/*.whl ./
+
+RUN set -ex \
+    && apt-get -y update \
+    && pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./*.whl
+
+EXPOSE 2337/tcp
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/src/app/docker/README.md
+++ b/src/app/docker/README.md
@@ -90,9 +90,9 @@ You can also mount in a configuration file and instruct beer-garden to use it:
 
 ```shell
 $ docker run --name beergarden \
-    -v /path/to/config.yaml:/etc/beergarden/config.yaml \
+    -v /path/to/config.yaml:/conf/config.yaml \
     -d bgio/beer-garden:<tag> \
-    --configuration-file /etc/beergarden/config.yaml
+    --configuration-file /conf/config.yaml
 ```
 
 The beer-garden repo has an
@@ -101,9 +101,9 @@ that can be used as a reference for starting out.
 
 ## Local plugins
 
-By default, beer-garden will look in `/var/lib/beer-garden/plugins`. If you wish
-to run local plugins, you should mount the directory containing the plugins on
-the host to that directory on the container.
+By default, beer-garden will look in `/plugins`. If you wish to run local
+plugins, you should mount the directory containing the plugins on the host to
+that directory on the container.
 
 > **NOTE**: Currently local plugins can only be configured via a configuration
 > file, as described above. Plugins will not be able to read required
@@ -113,10 +113,10 @@ the host to that directory on the container.
 ### Adding plugin dependencies
 
 When the beer-garden container starts, it will install any python dependencies
-listed in `/etc/beer-garden/requirements.txt`. If your local plugins have
-dependencies beyond what is required to run beer-garden itself, you can volume
-mount your own `requirements.txt` to that location to have them installed during
-container startup.
+listed in `/conf/requirements.txt`. If your local plugins have dependencies
+beyond what is required to run beer-garden itself, you can volume mount your own
+`requirements.txt` to that location to have them installed during container
+startup.
 
 > **NOTE**: The ability to install additional dependencies is provided as a
 > convenience, but is **not recommended** due to the inherent risks involved.

--- a/src/app/docker/docker-entrypoint.sh
+++ b/src/app/docker/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ -f /etc/beer-garden/requirements.txt ]; then
-    pip install -r /etc/beer-garden/requirements.txt
+if [ -f /conf/requirements.txt ]; then
+    pip install -r /conf/requirements.txt
 fi
 
-exec gosu beergarden beergarden $@
+beergarden $@


### PR DESCRIPTION
This PR brings the debian docker image more in line with the configuration of alpine image, specifically in terms of the directories where things are stored and the user that the process runs under.