### PR TITLE
Issue/1302 role sync

### DIFF
--- a/src/app/beer_garden/api/http/schemas/v1/role.py
+++ b/src/app/beer_garden/api/http/schemas/v1/role.py
@@ -1,5 +1,15 @@
-from brewtils.schemas import RoleSchema
-from marshmallow import Schema, fields
+from brewtils.schemas import RoleSchema as BrewtilsRoleSchema
+from marshmallow import Schema, fields, pre_dump
+
+
+class RoleSchema(BrewtilsRoleSchema):
+    sync_status = fields.Dict(dump_only=True)
+
+    @pre_dump
+    def get_sync_status(self, role):
+        from beer_garden.role import role_sync_status
+
+        role.sync_status = role_sync_status(role)
 
 
 class RoleListSchema(Schema):

--- a/src/app/beer_garden/events/handlers.py
+++ b/src/app/beer_garden/events/handlers.py
@@ -11,9 +11,11 @@ import beer_garden.local_plugins.manager
 import beer_garden.log
 import beer_garden.plugin
 import beer_garden.requests
+import beer_garden.role
 import beer_garden.router
 import beer_garden.scheduler
 import beer_garden.systems
+import beer_garden.user
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,7 @@ def garden_callbacks(event: Event) -> None:
         (beer_garden.files.handle_event, "File"),
         (beer_garden.local_plugins.manager.handle_event, "Local plugins manager"),
         (beer_garden.user.handle_event, "User event handler"),
+        (beer_garden.role.handle_event, "Role event handler"),
     ]:
         try:
             handler(deepcopy(event))

--- a/src/app/beer_garden/role.py
+++ b/src/app/beer_garden/role.py
@@ -1,7 +1,17 @@
+import logging
+from typing import List
+
+from brewtils.models import Event as BrewtilsEvent
+from brewtils.models import Events as BrewtilsEvents
+from brewtils.models import Operation as BrewtilsOperation
 from marshmallow import Schema, fields
 from mongoengine import DoesNotExist
 
-from beer_garden.db.mongo.models import Role, User
+from beer_garden import config
+from beer_garden.db.mongo.models import Garden, RemoteRole, Role, User
+from beer_garden.events import publish
+
+logger = logging.getLogger(__name__)
 
 
 class RoleSyncSchema(Schema):
@@ -95,3 +105,140 @@ def _delete_roles_not_in_list(roles: list) -> int:
         remove_role(role)
 
     return len(roles_to_remove)
+
+
+def initiate_role_sync() -> None:
+    """Syncs all roles from this garden down to all remote gardens.
+
+    Returns:
+        None
+    """
+    # Avoiding circular imports
+    from beer_garden.router import route
+
+    roles = Role.objects.all()
+    serialized_roles = RoleSyncSchema(many=True).dump(roles).data
+
+    gardens = Garden.objects.filter(
+        connection_type__nin=["LOCAL", None], status="RUNNING"
+    )
+
+    for garden in gardens:
+        operation = BrewtilsOperation(
+            operation_type="ROLE_SYNC",
+            target_garden_name=garden.name,
+            kwargs={"serialized_roles": serialized_roles},
+        )
+
+        route(operation)
+
+
+def role_sync(serialized_roles: List[dict]) -> None:
+    """Function called for the ROLE_SYNC operation type. This imports the supplied list
+    of serialized_roles and then initiates a ROLE_SYNC on any remote gardens. The
+    serialized_roles dicts are expected to have been generated via the RoleSyncSchema.
+
+    Args:
+        serialized_roles: Serialized list of roles
+
+    Returns:
+        None
+    """
+    sync_roles(serialized_roles)
+    _publish_roles_imported()
+    initiate_role_sync()
+
+
+def role_synced_with_garden(role: Role, garden: Garden) -> bool:
+    """Checks if the supplied role is currently synced to the supplied garden, based
+    on the corresponding RemoteRole entry. A role is considered synced if there is a
+    RemoteRole entry for the specified garden and the permissions and description of
+    that entry match those of the Role.
+
+    Args:
+        role: The role for which we are checking the sync status
+        garden: The remote garden to check the status against
+
+    Returns:
+        bool: True if the role is currently synced. False otherwise.
+    """
+    try:
+        remote_role = RemoteRole.objects.get(name=role.name, garden=garden.name)
+    except RemoteRole.DoesNotExist:
+        return False
+
+    return (set(role.permissions) == set(remote_role.permissions)) and (
+        role.description == remote_role.description
+    )
+
+
+def role_sync_status(role: Role) -> dict:
+    """Provides the sync status of the provided Role with each remote garden. The
+    resulting dict formatting os:
+
+    { "remote_garden_name": bool }
+
+    Args:
+        role: The role for which we are checking the sync status
+
+    Returns:
+        dict: Sync status by garden name
+    """
+    sync_status = {}
+
+    for garden in Garden.objects.filter(connection_type__nin=["LOCAL"]):
+        sync_status[garden.name] = role_synced_with_garden(role, garden)
+
+    return sync_status
+
+
+def handle_event(event: BrewtilsEvent) -> None:
+    """Processes the provided event by calling the correct handler function(s) for the
+    given event type.
+
+    Args:
+        event: The BrewtilsEvent to process
+
+    Returns:
+        None
+    """
+    # Only handle events from downstream gardens
+    if event.garden == config.get("garden.name"):
+        return
+
+    if event.name == "ROLE_UPDATED":
+        _handle_role_updated_event(event)
+
+
+def _handle_role_updated_event(event: BrewtilsEvent) -> None:
+    """Handling for ROLE_UPDATED events"""
+    # NOTE: This event stores its data in the metadata field as a workaround to the
+    # brewtils models dependency inherent in the more typical event publishing flow
+    try:
+        garden = event.metadata["garden"]
+        updated_role = event.metadata["role"]
+        name = updated_role["name"]
+
+        try:
+            remote_role = RemoteRole.objects.get(garden=garden, name=name)
+        except RemoteRole.DoesNotExist:
+            remote_role = RemoteRole(garden=garden, name=name)
+
+        remote_role.permissions = updated_role.get("permissions")
+        remote_role.description = updated_role.get("description")
+        remote_role.updated_at = event.timestamp
+        remote_role.save()
+    except KeyError:
+        logger.error("Error parsing %s event from garden %s", event.name, event.garden)
+
+
+def _publish_roles_imported() -> None:
+    """Publish an invent indicating that a role sync was completed"""
+    publish(
+        BrewtilsEvent(
+            name=BrewtilsEvents.ROLES_IMPORTED.name,
+            metadata={
+                "garden": config.get("garden.name"),
+            },
+        )
+    )

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -39,6 +39,7 @@ import beer_garden.namespace
 import beer_garden.plugin
 import beer_garden.queues
 import beer_garden.requests
+import beer_garden.role
 import beer_garden.scheduler
 import beer_garden.systems
 import beer_garden.user
@@ -64,6 +65,7 @@ routable_operations = [
     "COMMAND_BLOCKLIST_ADD",
     "COMMAND_BLOCKLIST_REMOVE",
     "USER_SYNC",
+    "ROLE_SYNC",
 ]
 
 # Executor used to run REQUEST_CREATE operations in an async context
@@ -159,6 +161,7 @@ route_functions = {
     "RUNNER_RESCAN": beer_garden.local_plugins.manager.rescan,
     "PUBLISH_EVENT": beer_garden.events.publish,
     "USER_SYNC": beer_garden.user.user_sync,
+    "ROLE_SYNC": beer_garden.role.role_sync,
     "COMMAND_BLOCKLIST_ADD": beer_garden.command_publishing_blocklist.command_publishing_blocklist_save,
     "COMMAND_BLOCKLIST_REMOVE": beer_garden.command_publishing_blocklist.command_publishing_blocklist_remove,
 }
@@ -635,7 +638,7 @@ def _target_from_type(operation: Operation) -> str:
             System(namespace=parts[0], name=parts[1], version=version)
         )
 
-    if "USER" in operation.operation_type:
+    if operation.operation_type in ["USER_SYNC", "ROLE_SYNC"]:
         return operation.target_garden_name
 
     raise Exception(f"Bad operation type {operation.operation_type}")

--- a/src/app/test/role_test.py
+++ b/src/app/test/role_test.py
@@ -1,11 +1,22 @@
 # -*- coding: utf-8 -*-
 import pytest
+from brewtils.models import Event, Events
 from marshmallow import ValidationError
+from mock import Mock
 from mongoengine import DoesNotExist, connect
 
+import beer_garden.role
+import beer_garden.router
 from beer_garden import config
-from beer_garden.db.mongo.models import Role, RoleAssignment, User
-from beer_garden.role import sync_roles
+from beer_garden.db.mongo.models import Garden, RemoteRole, Role, RoleAssignment, User
+from beer_garden.role import (
+    RoleSyncSchema,
+    handle_event,
+    initiate_role_sync,
+    role_sync,
+    role_synced_with_garden,
+    sync_roles,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -31,6 +42,25 @@ def role_sync_data():
 
 
 @pytest.fixture
+def role_to_sync(role_sync_data):
+    return Role(**role_sync_data[0])
+
+
+@pytest.fixture
+def remote_role(role_to_sync, gardens):
+    remote_role = RemoteRole(
+        name=role_to_sync.name,
+        garden=gardens[0].name,
+        description=role_to_sync.description,
+        permissions=role_to_sync.permissions,
+    )
+    remote_role.save()
+
+    yield remote_role
+    remote_role.delete()
+
+
+@pytest.fixture
 def role_sync_data_missing_fields():
     role_data = [
         {
@@ -53,6 +83,18 @@ def user_with_role_assignments():
     yield user
     user.delete()
     role.delete()
+
+
+@pytest.fixture
+def gardens():
+    garden1 = Garden(name="garden1", connection_type="HTTP", status="RUNNING").save()
+    garden2 = Garden(name="garden2", connection_type="HTTP", status="RUNNING").save()
+    garden3 = Garden(name="garden2", connection_type="HTTP", status="STOPPED").save()
+
+    yield [garden1, garden2, garden3]
+    garden1.delete()
+    garden2.delete()
+    garden3.delete()
 
 
 class TestRole:
@@ -116,3 +158,79 @@ class TestRole:
         user_with_role_assignments.reload()
 
         assert len(user_with_role_assignments.role_assignments) == 0
+
+    def test_initiate_role_sync_routes_to_each_running_garden(
+        self, monkeypatch, gardens
+    ):
+        monkeypatch.setattr(beer_garden.router, "route", Mock())
+        Role(name="testrole").save()
+        initiate_role_sync()
+
+        assert beer_garden.router.route.call_count == len(
+            Garden.objects.filter(status="RUNNING")
+        )
+
+    def test_role_sync_creates_role(self, monkeypatch, role_to_sync):
+        monkeypatch.setattr(beer_garden.role, "initiate_role_sync", Mock())
+        monkeypatch.setattr(beer_garden.role, "publish", Mock())
+        serialized_role = RoleSyncSchema().dump(role_to_sync).data
+
+        assert len(Role.objects.filter(name=role_to_sync.name)) == 0
+
+        role_sync([serialized_role])
+
+        assert len(Role.objects.filter(name=role_to_sync.name)) == 1
+        assert beer_garden.role.publish.called is True
+
+    def test_role_sync_updates_role(self, monkeypatch, role_to_sync):
+        monkeypatch.setattr(beer_garden.role, "initiate_role_sync", Mock())
+        monkeypatch.setattr(beer_garden.role, "publish", Mock())
+        serialized_role = RoleSyncSchema().dump(role_to_sync).data
+        expected_permissions = role_to_sync.permissions
+        role_to_sync.permissions = []
+        role_to_sync.save()
+
+        role_sync([serialized_role])
+        role_to_sync.reload()
+
+        assert set(role_to_sync.permissions) == set(expected_permissions)
+
+    def test_role_synced_with_garden_returns_false_for_no_remote_role(
+        self, role_to_sync, gardens
+    ):
+        assert role_synced_with_garden(role_to_sync, gardens[0]) is False
+
+    def test_role_synced_with_garden_returns_false_for_non_matching_permissions(
+        self, role_to_sync, remote_role
+    ):
+        garden = Garden.objects.get(name=remote_role.garden)
+        role_to_sync.permissions = []
+
+        assert role_synced_with_garden(role_to_sync, garden) is False
+
+    def test_role_synced_with_garden_returns_true_for_matching_permissions(
+        self, role_to_sync, remote_role
+    ):
+        garden = Garden.objects.get(name=remote_role.garden)
+
+        assert role_synced_with_garden(role_to_sync, garden) is True
+
+    def test_handle_event_for_role_updated(self):
+        permissions = ["queue:read", "queue:delete"]
+        role_updated_result = {
+            "garden": "garden1",
+            "role": {"name": "role1", "permissions": permissions},
+        }
+
+        event = Event(
+            name=Events.ROLE_UPDATED.name,
+            garden="garden1",
+            metadata=role_updated_result,
+        )
+
+        assert len(RemoteRole.objects.filter(name="role1", garden="garden1")) == 0
+
+        handle_event(event)
+        remote_role = RemoteRole.objects.get(name="role1", garden="garden1")
+
+        assert remote_role.permissions == permissions

--- a/src/ui/src/js/services/garden_service.js
+++ b/src/ui/src/js/services/garden_service.js
@@ -37,11 +37,21 @@ export default function gardenService($rootScope, $http) {
     });
   };
 
-  GardenService.syncUsers = function() {
+  GardenService.syncUsers = function(syncRoles = false) {
+    const patchOps = [
+      {
+        operation: 'sync_users',
+      },
+    ];
+
+    if (syncRoles) {
+      patchOps.push({
+        operation: 'sync_roles',
+      });
+    }
+
     return $http.patch('api/v1/gardens/', {
-      operation: 'sync_users',
-      path: '',
-      value: '',
+      operations: patchOps,
     });
   };
 

--- a/src/ui/src/templates/sync_users.html
+++ b/src/ui/src/templates/sync_users.html
@@ -1,10 +1,19 @@
 <form ng-submit="sync()">
   <div class="modal-header">
     <h3 class="modal-title" id="modal-title">Sync Users</h3>
-    This will sync all users from this garden to all remote gardens, making the
-    role assignments and password for each user on the remote garden match those
-    of the the users for this garden. Any role assignments that were granted
-    directly on the remote gardens will be overwritten by this process.
+    <p>
+      This will sync all users from this garden to all remote gardens, making
+      the role assignments and password for each user on the remote garden match
+      those of the the users for this garden. Any role assignments that were
+      granted directly on the remote gardens will be overwritten by this
+      process.
+    </p>
+
+    <p>
+      By default, roles will be synced along with the users to ensure consistent
+      permissions across all gardens. If you do not wish to include the roles in
+      this sync, uncheck the box labeled "sync roles."
+    </p>
   </div>
 
   <div class="modal-body" id="modal-body">
@@ -27,6 +36,7 @@
         </tr>
       </tbody>
     </table>
+    <input type="checkbox" ng-model="syncRoles" /> sync roles
   </div>
 
   <div class="modal-footer" ng-if="responseState(response) === 'success'">


### PR DESCRIPTION
Closes #1302 

This PR adds functionality for role syncing across gardens.  The backend portion very closely mirrors the workflow for the user syncing.  The `PATCH` method on the `/api/v1/gardens` endpoint now accepts a `sync_roles` operation, which sends the role definitions down to all known remote gardens.  The remote gardens import the roles and repeat the process for their own downstream gardens.

The models. functions, and eventing exist for checking the sync status of the roles on downstream gardens, but that information is not used anywhere at the moment.  If / when we create a dedicated role management UI, the information needed to display the sync status will already be present.

For the UI, the role syncing is bundled together with the user syncing, with a check box available to opt out of the role syncing.  Verbiage has been added to the user sync modal to explain the role sync behavior.

## Test Instructions
The easiest way to test is to use the user sync option in the UI.

* Stand up a local and remote garden.  Make sure auth is enabled.
* Make some changes to the remote garden so that the users and roles are not in sync with the local garden.
* Use the user sync functionality in the UI and keep the "sync roles" box checked.
* Check the remote garden and ensure that the users and roles are now in sync with the local.
* Repeat this exercise, but uncheck the "sync_roles" checkbox.
* The Users should be synced on the remote garden, but the roles should remain untouched.