### PR TITLE
#1304 - Remove gitter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Beer Garden
 =================================
 
-[![Gitter](https://img.shields.io/badge/gitter-Join%20Us!-ff69b4.svg)](https://gitter.im/beer-garden-io/Lobby)
 [![PyPi Version](https://img.shields.io/pypi/v/beer-garden.svg)](https://pypi.python.org/pypi/beer-garden/)
 [![Integration Tests](https://github.com/beer-garden/beer-garden/actions/workflows/integration_tests.yml/badge.svg)](https://github.com/beer-garden/beer-garden/actions/workflows/integration_tests.yml)
 [![CodeCov](https://codecov.io/gh/beer-garden/beer-garden/branch/develop/graph/badge.svg)](https://codecov.io/gh/beer-garden/beer-garden)

--- a/src/app/README.rst
+++ b/src/app/README.rst
@@ -5,11 +5,7 @@ Beer-Garden App
 
 This is the Beer-garden application backend.
 
-|gitter| |pypi| |travis| |codecov|
-
-.. |gitter| image:: https://img.shields.io/badge/gitter-Join%20Us!-ff69b4.svg
-   :target: https://gitter.im/beer-garden-io/Lobby
-   :alt: Gitter
+|pypi| |travis| |codecov|
 
 .. |pypi| image:: https://img.shields.io/pypi/v/beer-garden.svg
    :target: https://pypi.python.org/pypi/beer-garden


### PR DESCRIPTION
Closes #1304 

This PR removes the gitter badge from the two READMEs in which it was present.