### PR TITLE
#1299 - Add visual feedback to garden sync actions

### DIFF
--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -19,6 +19,7 @@ export default function adminGardenController(
     EventService,
 ) {
   $scope.setWindowTitle('gardens');
+  $scope.alerts = [];
   $scope.gardenCreateSchema = GardenService.CreateSCHEMA;
   $scope.gardenCreateForm = GardenService.CreateFORM;
   $scope.successCallback = function(response) {
@@ -45,7 +46,20 @@ export default function adminGardenController(
   };
 
   $scope.syncGardens = function() {
-    GardenService.syncGardens();
+    GardenService.syncGardens().then((resp)=>{
+      $scope.alerts.push({
+        type: 'success',
+        msg: 'Server accepted request to sync all gardens',
+      });
+    }).catch((err) => {
+      if (err.data && err.data.message) {
+        $scope.alerts.push({
+          type: 'danger',
+          msg: err.data.message,
+        });
+        console.log('error', err.data.message);
+      }
+    });
   };
 
   $scope.closeCreateGardenForm = function() {

--- a/src/ui/src/partials/admin_garden_index.html
+++ b/src/ui/src/partials/admin_garden_index.html
@@ -19,6 +19,15 @@
     </button>
   </span>
 </h1>
+<div id="garden-management-view-alert-list">
+  <div uib-alert
+    ng-repeat="alert in alerts"
+    ng-class="'alert-' + alert.type"
+    close="closeAlert($index)"
+  >
+    <div class="alert-item">{{alert.msg}}</div>
+  </div>
+</div>
 <div class="pull-right">
   <div class="form-popup" ng-hide="createGardenFormHide">
     <form ng-submit="createGarden()" class="form-container">

--- a/src/ui/src/partials/admin_garden_view.html
+++ b/src/ui/src/partials/admin_garden_view.html
@@ -7,6 +7,16 @@
   </span>
 </h1>
 
+<div id="garden-view-alert-list">
+  <div uib-alert
+    ng-repeat="alert in alerts"
+    ng-class="'alert-' + alert.type"
+    close="closeAlert($index)"
+  >
+    <div class="alert-item">{{alert.msg}}</div>
+  </div>
+</div>
+
 <fetch-data response="response"></fetch-data>
 
 <div
@@ -26,7 +36,7 @@
     </div>
     <div class="row">
       <div class="col-md-2">Known Namespaces:</div>
-      <div class="col-md-2">
+      <div class="col-md-2" ng-if="data.status === 'RUNNING'">
         <ul>
           <li ng-repeat="ns in data.namespaces">{{ns}}</li>
         </ul>
@@ -35,17 +45,24 @@
 
     <div class="row">
       <div class="col-md-2">Connection Type:</div>
-      <div class="col-md-2">{{data.connection_type}}</div>
+      <div ng-if="data.status === 'RUNNING'">
+        <div class="col-md-2">{{data.connection_type}}</div>
+      </div>
     </div>
   </div>
 
   <div class="row">
     <h4>Connected Systems</h4>
-    <table
+    <div ng-if="data.status !== 'RUNNING'">
+      <h5>Unable to display systems when status is {{data.status}}</h5>
+    </div>
+    <div ng-if="data.status === 'RUNNING'">
+      <table
       datatable="ng"
       dt-options="dtOptions"
       class="table table-striped table-bordered"
       style="width: 100%"
+      ng-if="data.status === 'RUNNING'"
     >
       <thead>
         <tr>
@@ -71,15 +88,7 @@
         </tr>
       </tbody>
     </table>
-  </div>
-
-  <div
-    uib-alert
-    ng-repeat="alert in alerts"
-    ng-class="'alert-' + alert.type"
-    close="closeAlert($index)"
-  >
-    {{alert.msg}}
+    </div>
   </div>
 
   <div ng-hide="isLocal">

--- a/src/ui/src/styles/custom.css
+++ b/src/ui/src/styles/custom.css
@@ -303,3 +303,19 @@ table.dataTable {
 .animate-fix.ng-animate {
   -webkit-animation: none 0s;
 }
+
+.alert-item.ng-enter,
+.alert-item.ng-leave {
+  -webkit-transition: 3.5s linear all;
+  transition: 3.5s linear all;
+}
+
+.alert-item.ng-enter,
+.alert-item.ng-leave.ng-leave-active {
+  opacity: 0;
+}
+
+.alert-item.ng-leave,
+.alert-item.ng-enter.ng-enter-active {
+  opacity: 1;
+}


### PR DESCRIPTION
Closes #1299 

Added visual feedback in the form of alerts to garden sync and garden connection update on individual garden page. Informational alerts will disappear after 30 s, whereas error alerts must be manually dismissed. The garden management page also has alerts displayed for both success and error associated with the 'sync all' action.