### PR TITLE
#1301 - Remove queue connection info from system responses

### DIFF
--- a/src/app/beer_garden/api/authorization.py
+++ b/src/app/beer_garden/api/authorization.py
@@ -18,6 +18,11 @@ class Permissions(Enum):
     GARDEN_UPDATE = "garden:update"
     GARDEN_DELETE = "garden:delete"
 
+    INSTANCE_CREATE = "instance:create"
+    INSTANCE_READ = "instance:read"
+    INSTANCE_UPDATE = "instance:update"
+    INSTANCE_DELETE = "instance:delete"
+
     QUEUE_CREATE = "queue:create"
     QUEUE_READ = "queue:read"
     QUEUE_UPDATE = "queue:update"

--- a/src/app/beer_garden/api/http/handlers/v1/instance.py
+++ b/src/app/beer_garden/api/http/handlers/v1/instance.py
@@ -14,8 +14,8 @@ from beer_garden.api.http.base_handler import event_wait
 from beer_garden.api.http.handlers import AuthorizationHandler
 from beer_garden.db.mongo.models import System
 
-SYSTEM_READ = Permissions.SYSTEM_READ.value
-SYSTEM_UPDATE = Permissions.SYSTEM_UPDATE.value
+INSTANCE_READ = Permissions.INSTANCE_READ.value
+INSTANCE_UPDATE = Permissions.INSTANCE_UPDATE.value
 QUEUE_READ = Permissions.QUEUE_READ.value
 
 
@@ -42,7 +42,7 @@ class InstanceAPI(AuthorizationHandler):
         tags:
           - Instances
         """
-        _ = self.get_or_raise(System, SYSTEM_READ, instances__id=instance_id)
+        _ = self.get_or_raise(System, INSTANCE_READ, instances__id=instance_id)
 
         response = await self.client(
             Operation(operation_type="INSTANCE_READ", args=[instance_id])
@@ -71,7 +71,7 @@ class InstanceAPI(AuthorizationHandler):
         tags:
           - Instances
         """
-        _ = self.get_or_raise(System, SYSTEM_UPDATE, instances__id=instance_id)
+        _ = self.get_or_raise(System, INSTANCE_UPDATE, instances__id=instance_id)
 
         await self.client(
             Operation(operation_type="INSTANCE_DELETE", args=[instance_id])
@@ -124,7 +124,7 @@ class InstanceAPI(AuthorizationHandler):
         tags:
           - Instances
         """
-        _ = self.get_or_raise(System, SYSTEM_UPDATE, instances__id=instance_id)
+        _ = self.get_or_raise(System, INSTANCE_UPDATE, instances__id=instance_id)
 
         patch = SchemaParser.parse_patch(self.request.decoded_body, from_string=True)
 
@@ -230,7 +230,7 @@ class InstanceLogAPI(AuthorizationHandler):
         tags:
           - Instances
         """
-        _ = self.get_or_raise(System, SYSTEM_READ, instances__id=instance_id)
+        _ = self.get_or_raise(System, INSTANCE_READ, instances__id=instance_id)
 
         start_line = self.get_query_argument("start_line", default=None)
         if start_line == "":

--- a/src/app/beer_garden/api/http/schemas/v1/system.py
+++ b/src/app/beer_garden/api/http/schemas/v1/system.py
@@ -1,0 +1,6 @@
+from brewtils.schemas import SystemSchema as BrewtilsSystemSchema
+
+
+class SystemSansQueueSchema(BrewtilsSystemSchema):
+    class Meta:
+        exclude = ("instances.queue_type", "instances.queue_info")

--- a/src/app/test/api/http/unit/handlers/v1/instance_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/instance_test.py
@@ -44,7 +44,8 @@ def system(garden):
 @pytest.fixture
 def system_admin_role():
     role = Role(
-        name="system_admin", permissions=["system:read", "system:update", "queue:read"]
+        name="system_admin",
+        permissions=["instance:read", "instance:update", "queue:read"],
     ).save()
 
     yield role


### PR DESCRIPTION
Closes #1301 

This PR does the following:

* Removes the `queue_type` and `queue_info` properties from Instances in responses from the /systems endpoints
* Changes the permissions needed to access the /instances endpoints from `SYSTEM_*` to `INSTANCE_*`.

This is done to make it so that the /systems endpoints no longer needlessly provide sensitive message queue connection information.  Meanwhile, access to the /instances endpoints which do include the sensitive connection information (specifically needed by a plugin registering itself with the garden), can be separately provisioned.

**NOTE**: As explained in the docstring for `_remove_queue_info`, the solution applied here is fairly unfortunate, but is by far the least intrusive solution.  Anything more involved is pretty hard to justify in terms of time, effort, and risk.

## Test Instructions
* Verify that the /systems endpoints no longer include the `queue_type` and `queue_info` properties in the instances portion of the response (there are new unit tests that check for this).
* Beer garden should otherwise continue to function as expected, with plugins able to register themselves, be tasked, etc.