### PR TITLE
Issue #1118

### DIFF
--- a/src/app/beer_garden/api/http/handlers/misc.py
+++ b/src/app/beer_garden/api/http/handlers/misc.py
@@ -35,8 +35,6 @@ class VersionHandler(BaseHandler):
         self.write(
             {
                 "beer_garden_version": beer_garden.__version__,
-                "brew_view_version": beer_garden.__version__,
-                "bartender_version": beer_garden.__version__,
                 "current_api_version": "v1",
                 "supported_api_versions": ["v1"],
             }

--- a/src/ui/src/partials/about.html
+++ b/src/ui/src/partials/about.html
@@ -46,34 +46,9 @@
             <div class="panel-heading">Version Information</div>
             <div class="panel-body">
               <p>
-                {{config.applicationName}} is made up of multiple components.
-                Their versions are listed below.
+                {{config.applicationName}} is currently on version <b>{{ data.beer_garden_version }}</b>
               </p>
             </div>
-            <table class="table table-hover">
-              <tr>
-                <th scope="col">Component Name</th>
-                <th scope="col">Version</th>
-              </tr>
-              <tr>
-                <td>Beer Garden</td>
-                <td>{{ data.beer_garden_version }}</td>
-              </tr>
-            </table>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Component Status</div>
-            <div class="panel-body">
-              <p>Listed below is the current status of the components</p>
-            </div>
-            <table class="table table-hover">
-              <tr>
-                <td>Beer Garden</td>
-                <td><span class="label label-success">RUNNING</span></td>
-              </tr>
-            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #1118 

I don't think deleting the mentions of the old components in `beer_garden/src/app/beer_garden/api/http/handlers/misc.py` breaks anything, but let me know if it does.


In the actual About.html, I have removed the components section and simply made the Version Information section into one line of text. If we need something more there, just let me know.