### PR TITLE
#1295 - Remove file triggers and explicit dependency on pathtools

### DIFF
--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -254,9 +254,6 @@ class Application(StoppableThread):
         if config.get("plugin.local.logging.config_file"):
             self.plugin_local_log_config_observer.start()
 
-        self.logger.debug("Loading jobs from database")
-        self.scheduler.initialize_from_db()
-
         self.logger.info("All set! Let me know if you need anything else!")
 
     def _shutdown(self):

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -74,7 +74,6 @@ __all__ = [
     "DateTrigger",
     "CronTrigger",
     "IntervalTrigger",
-    "FileTrigger",
     "Garden",
     "File",
     "FileChunk",
@@ -705,27 +704,6 @@ class CronTrigger(MongoModel, EmbeddedDocument):
     jitter = IntField(required=False)
 
 
-class FileTrigger(MongoModel, EmbeddedDocument):
-    brewtils_model = brewtils.models.FileTrigger
-
-    pattern = ListField()
-    path = StringField(default=".")
-    recursive = BooleanField(default=False)
-    callbacks = DictField()
-
-    def clean(self):
-        """Validate before saving to the database"""
-        if not list(filter(lambda i: i != "", self.pattern)):
-            raise ModelValidationError(
-                "Cannot save FileTrigger. Must have at least one non-empty pattern."
-            )
-
-        if True not in self.callbacks.values():
-            raise ModelValidationError(
-                "Cannot save FileTrigger. Must have at least one callback selected."
-            )
-
-
 class Job(MongoModel, Document):
     brewtils_model = brewtils.models.Job
 
@@ -753,7 +731,6 @@ class Job(MongoModel, Document):
         "date": DateTrigger,
         "cron": CronTrigger,
         "interval": IntervalTrigger,
-        "file": FileTrigger,
     }
 
     name = StringField(required=True)

--- a/src/app/beer_garden/db/mongo/parser.py
+++ b/src/app/beer_garden/db/mongo/parser.py
@@ -26,7 +26,6 @@ class MongoParser(SchemaParser):
             "DateTriggerSchema": beer_garden.db.mongo.models.DateTrigger,
             "IntervalTriggerSchema": beer_garden.db.mongo.models.IntervalTrigger,
             "CronTriggerSchema": beer_garden.db.mongo.models.CronTrigger,
-            "FileTriggerSchema": beer_garden.db.mongo.models.FileTrigger,
             "GardenSchema": beer_garden.db.mongo.models.Garden,
             "FileSchema": beer_garden.db.mongo.models.File,
             "FileChunkSchema": beer_garden.db.mongo.models.FileChunk,

--- a/src/app/beer_garden/db/mongo/util.py
+++ b/src/app/beer_garden/db/mongo/util.py
@@ -110,6 +110,21 @@ def ensure_users():
         admin.save()
 
 
+def ensure_trigger_migration():
+    """File Triggers didn't work all the time, they were removed in 3.14.
+    Remove any file trigger jobs."""
+
+    database = get_db()
+
+    for doc in database["job"].find():
+        try:
+            if doc["trigger_type"] == "file":
+                database["job"].delete_one({"_id": doc["_id"]})
+
+        except Exception:
+            logger.error(f"Error deleting file trigger {doc['_id']}")
+
+
 def ensure_owner_collection_migration():
     """We ran into an issue with 3.0.5 where Requests and Jobs got migrated over to
     the Owner collection. This is in place to resolve that."""
@@ -214,6 +229,7 @@ def ensure_model_migration():
 
     ensure_v2_to_v3_model_migration()
     ensure_owner_collection_migration()
+    ensure_trigger_migration()
 
 
 def check_indexes(document_class):

--- a/src/app/requirements-dev.txt
+++ b/src/app/requirements-dev.txt
@@ -118,10 +118,6 @@ pyflakes==2.4.0
     # via flake8
 pygments==2.11.2
     # via sphinx
-pyjwt==1.7.1
-    # via
-    #   -c requirements.txt
-    #   brewtils
 pyparsing==3.0.8
     # via
     #   -c requirements.txt

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -44,9 +44,7 @@ packaging==20.9
 passlib==1.7.4
     # via beer-garden (setup.py)
 pathtools==0.1.2
-    # via
-    #   beer-garden (setup.py)
-    #   watchdog
+    # via watchdog
 pika==1.2.0
     # via brewtils
 prometheus-client==0.14.1

--- a/src/app/setup.py
+++ b/src/app/setup.py
@@ -36,7 +36,6 @@ setup(
         "more-itertools<9",
         "motor<3",
         "passlib<1.8",
-        "pathtools==0.1.2",
         "prometheus-client<1",
         "pyyaml<6",
         "pyrabbit2<2",

--- a/src/ui/src/js/controllers/job/create_trigger.js
+++ b/src/ui/src/js/controllers/job/create_trigger.js
@@ -84,29 +84,6 @@ export default function jobCreateTriggerController(
       }
     }
 
-    if (triggerType === 'file') {
-      if (
-        angular.isDefined(model['file_pattern']) &&
-        model['file_pattern'] === ['']
-      ) {
-        $scope.alerts.push('At least one pattern is required.');
-        valid = false;
-      }
-      if (
-        angular.isDefined(model['file_callbacks']) &&
-        model['file_callbacks'] !== null
-      ) {
-        let temp = false;
-        for (const k in model['file_callbacks']) {
-          if (model['file_callbacks'][k] == true) temp = true;
-        }
-        if (!temp) {
-          $scope.alerts.push('At least one callback is required.');
-          valid = temp;
-        }
-      }
-    }
-
     return valid;
   };
 

--- a/src/ui/src/js/services/job_service.js
+++ b/src/ui/src/js/services/job_service.js
@@ -118,13 +118,6 @@ export default function jobService($http, NamespaceService) {
         timezone: formModel['interval_timezone'],
         reschedule_on_finish: formModel['interval_reschedule_on_finish'],
       };
-    } else if (triggerType === 'file') {
-      return {
-        pattern: formModel['file_pattern'],
-        path: formModel['file_path'],
-        recursive: formModel['file_recursive'],
-        callbacks: formModel['file_callbacks'],
-      };
     } else {
       return {
         minute: formModel['minute'],
@@ -187,11 +180,6 @@ export default function jobService($http, NamespaceService) {
       formModel['interval_timezone'] = job['trigger']['timezone'];
       formModel['interval_reschedule_on_finish'] =
         job['trigger']['reschedule_on_finish'];
-    } else if (job['trigger_type'] === 'file') {
-      formModel['file_pattern'] = job['trigger']['pattern'];
-      formModel['file_path'] = job['trigger']['path'];
-      formModel['file_recursive'] = job['trigger']['recursive'];
-      formModel['file_callbacks'] = job['trigger']['callbacks'];
     } else {
       formModel['minute'] = job['trigger']['minute'];
       formModel['hour'] = job['trigger']['hour'];
@@ -224,7 +212,7 @@ export default function jobService($http, NamespaceService) {
     return serviceModel;
   };
 
-  JobService.TRIGGER_TYPES = ['cron', 'date', 'interval', 'file'];
+  JobService.TRIGGER_TYPES = ['cron', 'date', 'interval'];
   JobService.CRON_KEYS = [
     'minute',
     'hour',
@@ -249,12 +237,6 @@ export default function jobService($http, NamespaceService) {
     'interval_reschedule_on_finish',
   ];
   JobService.DATE_KEYS = ['run_date', 'date_timezone'];
-  JobService.FILE_KEYS = [
-    'file_pattern',
-    'file_path',
-    'file_recursive',
-    'file_callbacks',
-  ];
 
   JobService.getRequiredKeys = function(triggerType) {
     if (triggerType === 'cron') {
@@ -274,8 +256,6 @@ export default function jobService($http, NamespaceService) {
       return requiredKeys;
     } else if (triggerType === 'date') {
       return JobService.DATE_KEYS;
-    } else if (triggerType === 'file') {
-      return [];
     } else {
       const requiredKeys = [];
       for (const key of JobService.INTERVAL_KEYS) {
@@ -464,36 +444,6 @@ export default function jobService($http, NamespaceService) {
         description: 'Reset the interval timer when the job finishes.',
         type: 'boolean',
       },
-      file_pattern: {
-        title: 'Pattern',
-        description:
-          'File name patterns to match, supports non-extended shell-style glob pattern matching',
-        type: 'array',
-        items: {
-          type: 'string',
-        },
-      },
-      file_path: {
-        title: 'Path',
-        description: 'Directory to watch.',
-        type: 'string',
-      },
-      file_recursive: {
-        title: 'Recursive',
-        description: 'Look more than one level deep in the directory.',
-        type: 'boolean',
-      },
-      file_callbacks: {
-        title: 'Callbacks',
-        description: 'What file events should trigger the plugins?',
-        type: 'object',
-        properties: {
-          on_created: {type: 'boolean'},
-          on_modified: {type: 'boolean'},
-          on_moved: {type: 'boolean'},
-          on_deleted: {type: 'boolean'},
-        },
-      },
     },
   };
 
@@ -588,21 +538,6 @@ export default function jobService($http, NamespaceService) {
                   items: [
                     {key: 'run_date', htmlClass: 'col-md-6'},
                     {key: 'date_timezone', htmlClass: 'col-md-2'},
-                  ],
-                },
-              ],
-            },
-            {
-              title: 'File Trigger',
-              items: [
-                {
-                  type: 'section',
-                  htmlClass: 'row',
-                  items: [
-                    {key: 'file_pattern', htmlClass: 'col-md-4'},
-                    {key: 'file_path', htmlClass: 'col-md-2'},
-                    {key: 'file_recursive', htmlClass: 'col-md-2'},
-                    {key: 'file_callbacks', htmlClass: 'col-md-2'},
                   ],
                 },
               ],


### PR DESCRIPTION
Closes https://github.com/beer-garden/beer-garden/issues/1295

This PR does the following:
- Removes the File Trigger from the UI
- Removes the file/async scheduled task processing from the server.
- Removes the direct beer-garden dependency on pathtools

*Note*: The watchdog lib is still used to load the logging configuration files and to watch for changes, so there is still the watchdog code in the server.

Test Instructions:
- Check the UI, make sure that the File Trigger isn't a trigger type and doesn't have settings to set
- Create a scheduled job, make sure that the request is executed as expected.
- Touch the `plugin.logging.config_file`, make sure the server still reloads the file.