### PR TITLE
Issue/1294 update yapconf and watchdog

### DIFF
--- a/src/app/requirements-dev.txt
+++ b/src/app/requirements-dev.txt
@@ -98,10 +98,6 @@ packaging==20.9
     #   sphinx
 pathspec==0.9.0
     # via black
-pathtools==0.1.2
-    # via
-    #   -c requirements.txt
-    #   watchdog
 pika==1.2.0
     # via
     #   -c requirements.txt
@@ -192,7 +188,7 @@ urllib3==1.26.9
     # via
     #   -c requirements.txt
     #   requests
-watchdog==0.10.4
+watchdog==2.1.8
     # via
     #   -c requirements.txt
     #   yapconf
@@ -202,7 +198,7 @@ wrapt==1.12.1
     # via
     #   -c requirements.txt
     #   brewtils
-yapconf==0.3.7
+yapconf==1.0.0
     # via
     #   -c requirements.txt
     #   brewtils

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -43,8 +43,6 @@ packaging==20.9
     # via brewtils
 passlib==1.7.4
     # via beer-garden (setup.py)
-pathtools==0.1.2
-    # via watchdog
 pika==1.2.0
     # via brewtils
 prometheus-client==0.14.1
@@ -97,13 +95,13 @@ tzlocal==4.2
     # via apscheduler
 urllib3==1.26.9
     # via requests
-watchdog==0.10.4
+watchdog==2.1.8
     # via
     #   beer-garden (setup.py)
     #   yapconf
 wrapt==1.12.1
     # via brewtils
-yapconf==0.3.7
+yapconf==1.0.0
     # via
     #   beer-garden (setup.py)
     #   brewtils

--- a/src/app/setup.py
+++ b/src/app/setup.py
@@ -43,8 +43,8 @@ setup(
         "ruamel.yaml<0.17",
         "stomp.py<6.2.0",
         "tornado<7",
-        "watchdog<1",
-        "yapconf==0.3.7",
+        "watchdog>2.1.0",
+        "yapconf>=1.0.0",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Closes https://github.com/beer-garden/beer-garden/issues/1294

This PR upgrades yapconf to 1.0.0 and watchdog to > 2.1.0(currently 2.1.8).

Watchdog is currently only used for re-reading the `plugin.logging.config.file`. The plugins will *not* be updated at this time, but if the plugin is reloaded or a new one is started, it will get the updated configuration without having to restart BeerGarden. 

*Note*: This PR requires https://github.com/beer-garden/beer-garden/pull/1324 to be merged first.

Test Instructions:
- Remove the old pathtools, watchdog and yapconf python packages (or make a new virtualenv)
- Reinstall the deps
- Make sure that BeerGarden still starts as expected
- Touch the local plugin logging config file(may be example_configs/local-plugin-logging.yaml). Verify that a message gets printed indicating the file was modified.