### PR TITLE
#242 - Add newlines to individual request view

### DIFF
--- a/src/ui/src/partials/request_view.html
+++ b/src/ui/src/partials/request_view.html
@@ -111,7 +111,7 @@
           <td>{{formatDate(request.created_at)}}</td>
           <td>{{formatDate(request.status_updated_at)}}</td>
           <td>{{formatDate(request.updated_at)}}</td>
-          <td>{{request.comment}}</td>
+          <td style="white-space: pre-line;">{{request.comment}}</td>
         </tr>
 
         <tr class="child-row slide" ng-repeat="child in childrenDisplay">


### PR DESCRIPTION
Closes #242 

Throwing style="white-space: pre-line;" in the html element with the comment fixes this in the individual request view. Test by running one of the plugins with a multiline comment then opening up the single request view. Didn't add this to the multi request table based on the comments in the issue