### PR TITLE
#1309 - Create plugin user and role on new garden startup

### DIFF
--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1221,6 +1221,7 @@ _PLUGIN_SPEC = {
                     "items": {
                         "username": {
                             "type": "str",
+                            "default": "plugin_admin",
                             "description": (
                                 "Username that local plugins will use for "
                                 "authentication (needs bg-plugin role)"
@@ -1229,6 +1230,7 @@ _PLUGIN_SPEC = {
                         },
                         "password": {
                             "type": "str",
+                            "default": "password",
                             "description": (
                                 "Password that local plugins will use for "
                                 "authentication (needs bg-plugin role)"

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -129,7 +129,7 @@ plugin:
   local:
     auth:
       password: password
-      username: admin
+      username: plugin_admin
     directory: ./plugins
     host_env_vars: []
     logging:

--- a/src/app/test/db/mongo/util_test.py
+++ b/src/app/test/db/mongo/util_test.py
@@ -9,7 +9,12 @@ import beer_garden.db.mongo.util
 from beer_garden import config
 from beer_garden.api.authorization import Permissions
 from beer_garden.db.mongo.models import Garden, Role, User
-from beer_garden.db.mongo.util import ensure_local_garden, ensure_roles, ensure_users
+from beer_garden.db.mongo.util import (
+    PLUGIN_ROLE_PERMISSIONS,
+    ensure_local_garden,
+    ensure_roles,
+    ensure_users,
+)
 from beer_garden.errors import ConfigurationError
 
 
@@ -74,7 +79,7 @@ class TestEnsureUsers(object):
         monkeypatch.setattr(User, "save", Mock())
         ensure_users()
 
-        assert User.save.called is True
+        assert User.save.call_count == 2  # Default Admin, Plugin
 
     def test_admin_not_created_if_users_exist(
         self, monkeypatch, existing_user, roles, config_mock_value
@@ -365,3 +370,15 @@ class TestEnsureRoles:
         superuser = Role.objects.get(name="superuser")
 
         assert len(superuser.permissions) == len(Permissions)
+
+    def test_ensure_roles_creates_bg_plugin_role_if_none_exists(self, monkeypatch):
+        """A plugin role with all permissions should be created if none exists"""
+        monkeypatch.setattr(
+            beer_garden.db.mongo.util, "_sync_roles_from_role_definition_file", Mock()
+        )
+
+        assert len(Role.objects.filter(name="plugin")) == 0
+        ensure_roles()
+        plugin_role = Role.objects.get(name="plugin")
+
+        assert plugin_role.permissions == PLUGIN_ROLE_PERMISSIONS


### PR DESCRIPTION
Closes https://github.com/beer-garden/beer-garden/issues/1309

This PR adds steps to the garden initialization process that will create a plugin_admin user, and create a default plugin role with limited permissions necessary to start and run a plugin.

Some notes:

The plugin_admin username and password can be customized via the app config.
The plugin_admin user will not be created if any other users already exist
The plugin role will be created if it does not exist. 

### Test Instructions
- Start a fresh instance of beergarden. 
  - You should see log messages indicating that the plugin_admin user and plugin role are created.
- Without any other setup, you should be able to login to the UI as plugin_admin / password (unless you changed the defaults in your config).
  - You will have limited permissions, for example, you cannot clear all queues in Admin->Systems