### PR TITLE
Fixes Unclosable Alert on Garden Admin Page

### DIFF
--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -45,6 +45,10 @@ export default function adminGardenController(
     );
   };
 
+  $scope.closeAlert = function(index) {
+    $scope.alerts.splice(index, 1);
+  };
+
   $scope.syncGardens = function() {
     GardenService.syncGardens().then((resp)=>{
       $scope.alerts.push({


### PR DESCRIPTION
Closes #1333

Fixes the close functionality of alerts on the garden admin page.

For testing click the sync all button on the garden admin page then try to close the alert