### PR TITLE
issue #1338 - large output override

### DIFF
--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -225,7 +225,7 @@ export default function requestViewController(
           ' crash the page. Downloading File might take a minute for UI to prepare. To ' +
           'display the output anyway, <i>click here</i>. <b>NOTE:</b> Displaying large ' +
           'request output could result in your browser crashing or hanging indefinitely.';
-      } else if (sizeOf($scope.request.output) > 50) {
+      } else if (sizeOf($scope.request.output) > 5000000) {
         $scope.formatErrorTitle = 'Output is too large';
         $scope.formatErrorMsg =
           'The output for this request is too large to display, please download instead. To ' +

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -148,18 +148,9 @@ export default function requestViewController(
         try {
           const parsedOutput = JSON.parse(rawOutput);
           rawOutput = $scope.stringify(parsedOutput);
-          if ($scope.countNodes($scope.formattedOutput) < 1000) {
-            $scope.jsonOutput = rawOutput;
-            $scope.formattedAvailable = true;
-            $scope.showFormatted = true;
-          } else {
-            $scope.formatErrorTitle =
-              'Output is too large for collapsible view';
-            $scope.formatErrorMsg =
-              'This output is valid JSON, but it\'s so big that ' +
-              'displaying it in the collapsible viewer would crash the ' +
-              'page. Downloading File might take a minute for UI to prepare.';
-          }
+          $scope.jsonOutput = rawOutput;
+          $scope.formattedAvailable = true;
+          $scope.showFormatted = true;
         } catch (err) {
           $scope.formatErrorTitle = 'This JSON didn\'t parse correctly';
           $scope.formatErrorMsg =
@@ -223,7 +214,18 @@ export default function requestViewController(
         }
       }
 
-      if (sizeOf($scope.request.output) > 5000000) {
+      if (
+        $scope.request.output_type == 'JSON' &&
+        $scope.countNodes($scope.formattedOutput) >= 1000
+      ) {
+        $scope.formatErrorTitle =
+          'Output is too large for collapsible view';
+        $scope.formatErrorMsg =
+          'This output is valid JSON, but it\'s so big that displaying it in the viewer would' +
+          ' crash the page. Downloading File might take a minute for UI to prepare. To ' +
+          'display the output anyway, <i>click here</i>. <b>NOTE:</b> Displaying large ' +
+          'request output could result in your browser crashing or hanging indefinitely.';
+      } else if (sizeOf($scope.request.output) > 50) {
         $scope.formatErrorTitle = 'Output is too large';
         $scope.formatErrorMsg =
           'The output for this request is too large to display, please download instead. To ' +

--- a/src/ui/src/js/controllers/request_view.js
+++ b/src/ui/src/js/controllers/request_view.js
@@ -226,7 +226,9 @@ export default function requestViewController(
       if (sizeOf($scope.request.output) > 5000000) {
         $scope.formatErrorTitle = 'Output is too large';
         $scope.formatErrorMsg =
-          'The output for this request is too large to display, please download instead';
+          'The output for this request is too large to display, please download instead. To ' +
+          'display the output anyway, <i>click here</i>. <b>NOTE:</b> Displaying large ' +
+          'request output could result in your browser crashing or hanging indefinitely.';
       } else {
         $scope.formatOutput();
       }

--- a/src/ui/src/partials/request_view.html
+++ b/src/ui/src/partials/request_view.html
@@ -210,7 +210,7 @@
           </span>
           <span ng-mouseover="popoverIsOpen = true" 
             ng-mouseleave="popoverIsOpen = false"
-            ng-click="formatErrorTitle === 'Output is too large' ? formatOutput() : null">
+            ng-click="formatErrorTitle.contains('Output is too large') ? formatOutput() : null">
             <span
               ng-show="formatErrorTitle !== undefined"
               class="pull-right"

--- a/src/ui/src/partials/request_view.html
+++ b/src/ui/src/partials/request_view.html
@@ -208,20 +208,24 @@
               switch-off-text="Raw"
             />
           </span>
-          <span
-            ng-show="formatErrorTitle !== undefined"
-            class="pull-right"
-            uib-popover="{{formatErrorMsg}}"
-            popover-animation="true"
-            popover-placement="left"
-            popover-trigger="'mouseenter'"
-            popover-title="{{formatErrorTitle}}"
-            style="color: gray; padding-top: 5px"
-          >
+          <span ng-mouseover="popoverIsOpen = true" 
+            ng-mouseleave="popoverIsOpen = false"
+            ng-click="formatErrorTitle === 'Output is too large' ? formatOutput() : null">
             <span
-              class="glyphicon glyphicon-info-sign"
-              style="font-size: 26px"
-            ></span>
+              ng-show="formatErrorTitle !== undefined"
+              class="pull-right"
+              uib-popover-html="formatErrorMsg"
+              popover-animation="true"
+              popover-placement="left"
+              popover-is-open="popoverIsOpen"
+              popover-title="{{formatErrorTitle}}"
+              style="color: gray; padding-top: 5px"
+            >
+              <span
+                class="glyphicon glyphicon-info-sign"
+                style="font-size: 26px"
+              ></span>
+            </span>
           </span>
         </div>
         <div style="position: relative">


### PR DESCRIPTION
Closes #1338 

User can click error pop-up or icon to choose to display large outputs. Added warning in pop-up text to do so at your own risk. Consolidated size checks for better handling.