### PR TITLE
Issue 249: Tests written and passing

### DIFF
--- a/src/app/beer_garden/app.py
+++ b/src/app/beer_garden/app.py
@@ -82,11 +82,16 @@ class Application(StoppableThread):
         ]
 
         # Only want to run the MongoPruner if it would do anything
-        tasks, run_every = db.prune_tasks(**config.get("db.ttl"))
+        ttl_config = config.get("db.ttl")
+
+        tasks, run_every = db.prune_tasks(**ttl_config)
         if run_every:
             self.helper_threads.append(
                 HelperThread(
-                    db.get_pruner(), tasks=tasks, run_every=timedelta(minutes=run_every)
+                    db.get_pruner(),
+                    tasks=tasks,
+                    run_every=timedelta(minutes=run_every),
+                    cancel_threshold=ttl_config.in_progress,
                 )
             )
 

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -757,6 +757,15 @@ _DB_SPEC = {
                     "previous_names": ["info_request_ttl"],
                     "alt_env_names": ["INFO_REQUEST_TTL"],
                 },
+                "in_progress": {
+                    "type": "int",
+                    "default": -1,
+                    "description": (
+                        "Number of minutes to wait for a request in CREATED or IN_PROGRESS"
+                        "to complete before considering timed out and marking as CANCELLED"
+                        "(negative number for never)"
+                    ),
+                },
                 "file": {
                     "type": "int",
                     "default": 15,

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -24,6 +24,7 @@ db:
   ttl:
     action: -1
     file: 15
+    in_progress: 15
     info: 15
 entry:
   http:


### PR DESCRIPTION
Closes #249 
This PR gives the MongoPruner the ability to mark any requests that have been sitting in CREATED or IN_PROGRESS for longer than a specified amount of time as cancelled. There is now a setting in the configs called in_progress that holds that value