### PR TITLE
Fix linting errors

### DIFF
--- a/src/app/setup.cfg
+++ b/src/app/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203, E501, W503
 exclude = test/api
 
 [tool:pytest]

--- a/src/app/test/local_plugins/runner_test.py
+++ b/src/app/test/local_plugins/runner_test.py
@@ -170,8 +170,8 @@ class TestCheckIo(object):
 
         plugin.run()
 
-        for logger_name, logger_calls in logger_calls.items():
-            for logger_call in logger_calls:
+        for logger_name, _logger_calls in logger_calls.items():
+            for logger_call in _logger_calls:
                 assert logger_call in getattr(plugin, logger_name).log.mock_calls
 
     def test_check_io_multiple_calls(self, plugin):

--- a/test/integration/setup.cfg
+++ b/test/integration/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203, E501, W503
 exclude = test/api
 
 [tool:pytest]


### PR DESCRIPTION
This PR fixes two linting errors:

* One in runner_test.py that was a legitimate error
* The other is an error, W503, that had previously been ignored by default, but recent changes in pycodestyle / flake8 make it so that we have to explicitly list it in the exclusions list.