### PR TITLE
#1347 - Fix 404 response on queue DELETE

### DIFF
--- a/src/app/test/api/http/unit/conftest.py
+++ b/src/app/test/api/http/unit/conftest.py
@@ -2,85 +2,13 @@
 import pytest
 import tornado.web
 
+from beer_garden.api.http import get_url_specs
 from beer_garden.api.http.authentication import issue_token_pair
 from beer_garden.api.http.client import SerializeHelper
-from beer_garden.api.http.handlers.v1.admin import AdminAPI
-from beer_garden.api.http.handlers.v1.command import CommandAPI, CommandListAPI
-from beer_garden.api.http.handlers.v1.command_publishing_blocklist import (
-    CommandPublishingBlocklistAPI,
-    CommandPublishingBlocklistPathAPI,
-)
-from beer_garden.api.http.handlers.v1.forward import ForwardAPI
-from beer_garden.api.http.handlers.v1.garden import GardenAPI, GardenListAPI
-from beer_garden.api.http.handlers.v1.instance import (
-    InstanceAPI,
-    InstanceLogAPI,
-    InstanceQueuesAPI,
-)
-from beer_garden.api.http.handlers.v1.job import (
-    JobAPI,
-    JobExecutionAPI,
-    JobExportAPI,
-    JobImportAPI,
-    JobListAPI,
-)
-from beer_garden.api.http.handlers.v1.logging import LoggingAPI, LoggingConfigAPI
-from beer_garden.api.http.handlers.v1.namespace import NamespaceListAPI
-from beer_garden.api.http.handlers.v1.queue import QueueAPI, QueueListAPI
-from beer_garden.api.http.handlers.v1.request import RequestAPI, RequestListAPI
-from beer_garden.api.http.handlers.v1.role import RoleListAPI
-from beer_garden.api.http.handlers.v1.system import SystemAPI, SystemListAPI
-from beer_garden.api.http.handlers.v1.token import (
-    TokenAPI,
-    TokenRefreshAPI,
-    TokenRevokeAPI,
-)
-from beer_garden.api.http.handlers.v1.user import (
-    UserAPI,
-    UserListAPI,
-    UserPasswordChangeAPI,
-)
 from beer_garden.db.mongo.models import User
 
-# TODO: Load this from conftest using the actual _setup_application call
 application = tornado.web.Application(
-    [
-        (r"/api/v1/admin/?", AdminAPI),
-        (r"/api/v1/commands/?", CommandListAPI),
-        (r"/api/v1/config/logging/?", LoggingConfigAPI),
-        (r"/api/v1/export/jobs/?", JobExportAPI),
-        (r"/api/v1/import/jobs/?", JobImportAPI),
-        (r"/api/v1/forward/?", ForwardAPI),
-        (r"/api/v1/gardens/?", GardenListAPI),
-        (r"/api/v1/gardens/(.*)/?", GardenAPI),
-        (r"/api/v1/instances/(\w+)/?", InstanceAPI),
-        (r"/api/v1/instances/(\w+)/logs/?", InstanceLogAPI),
-        (r"/api/v1/instances/(\w+)/queues/?", InstanceQueuesAPI),
-        (r"/api/v1/jobs/?", JobListAPI),
-        (r"/api/v1/jobs/(\w+)/?", JobAPI),
-        (r"/api/v1/jobs/(\w+)/execute/?", JobExecutionAPI),
-        (r"/api/v1/logging/?", LoggingAPI),
-        (r"/api/v1/password/change/?", UserPasswordChangeAPI),
-        (r"/api/v1/token/?", TokenAPI),
-        (r"/api/v1/token/revoke/?", TokenRevokeAPI),
-        (r"/api/v1/token/refresh/?", TokenRefreshAPI),
-        (r"/api/v1/namespaces/?", NamespaceListAPI),
-        (r"/api/v1/queues/?", QueueListAPI),
-        (r"/api/v1/queues/([\w\.-]+)/?", QueueAPI),
-        (r"/api/v1/requests/?", RequestListAPI),
-        (r"/api/v1/requests/(\w+)/?", RequestAPI),
-        (r"/api/v1/roles/?", RoleListAPI),
-        (r"/api/v1/systems/?", SystemListAPI),
-        (r"/api/v1/systems/(\w+)/?", SystemAPI),
-        (r"/api/v1/systems/(\w+)/commands/(\w+)/?", CommandAPI),
-        (r"/api/v1/users/?", UserListAPI),
-        (r"/api/v1/users/(\w+)/?", UserAPI),
-        (r"/api/v1/commandpublishingblocklist/?", CommandPublishingBlocklistAPI),
-        (
-            r"/api/v1/commandpublishingblocklist/(\w+)/?",
-            CommandPublishingBlocklistPathAPI,
-        ),
-    ],
+    get_url_specs(prefix="/"),
     client=SerializeHelper(),
 )
 

--- a/src/app/test/api/http/unit/handlers/v1/queue_test.py
+++ b/src/app/test/api/http/unit/handlers/v1/queue_test.py
@@ -128,6 +128,18 @@ class TestQueueAPI:
         assert excinfo.value.code == 403
         assert queue_function_mock.called is False
 
+    @pytest.mark.gen_test
+    def test_delete_works_with_special_characters(
+        self, http_client, base_url, queue_function_mock
+    ):
+        url = f"{base_url}/api/v1/queues/some->queue"
+
+        request = HTTPRequest(url, method="DELETE")
+        response = yield http_client.fetch(request)
+
+        assert response.code == 204
+        assert queue_function_mock.called is True
+
 
 class TestQueueListAPI:
     @pytest.mark.gen_test


### PR DESCRIPTION
Closes #1347 

This PR updates the url routes to be less strict on the allowed queue names.  Previously, only word characters plus hyphen were allowed.  This was problematic since the queue names are derived from instance names, which do not have this restriction.

Most of the code in this PR is refactoring the way the routes are defined so that they could be leveraged in the unit tests, rather than the unit tests having their own set of routes defined (a longstanding TODO).  This was necessary to allow a meaningful unit test to be written.

## Testing instructions
* The unit test pretty well covers this, so you could just look at that if you care to.
* To functionally test:
  * Create a plugin instance with a name like "this->breaks"
  * Go to the System Admin page and clear the queue for that instance.  Before this change it would result in a 404, but now should succeed.