### PR TITLE
System Reload Error

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/system.py
+++ b/src/app/beer_garden/api/http/handlers/v1/system.py
@@ -213,9 +213,11 @@ class SystemAPI(AuthorizationHandler):
                 raise ModelValidationError(f"Unsupported operation '{op.operation}'")
 
         if kwargs:
-            response = await self.client(
-                Operation(
-                    operation_type="SYSTEM_UPDATE", args=[system_id], kwargs=kwargs
+            response = _remove_queue_info(
+                await self.client(
+                    Operation(
+                        operation_type="SYSTEM_UPDATE", args=[system_id], kwargs=kwargs
+                    )
                 )
             )
 
@@ -225,7 +227,7 @@ class SystemAPI(AuthorizationHandler):
             )
 
         self.set_header("Content-Type", "application/json; charset=UTF-8")
-        self.write(_remove_queue_info(response))
+        self.write(response)
 
 
 class SystemListAPI(AuthorizationHandler):


### PR DESCRIPTION
Closes #1345 

I relocated the function `_remove_queue_info` in the `SystemApi` patch so it would not try to parse an empty string.

For testing go to the systems admin page and click reload on a running system. The system should shutdown then restart without the error mention in issue #1345.