### PR TITLE
#1354 - fix QUEUE_DELETE_ALL operation routing

### DIFF
--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -578,7 +578,8 @@ def _target_from_type(operation: Operation) -> str:
         )
         or "PUBLISH_EVENT" in operation.operation_type
         or "RUNNER" in operation.operation_type
-        or operation.operation_type in ("PLUGIN_LOG_RELOAD", "SYSTEM_CREATE")
+        or operation.operation_type
+        in ("PLUGIN_LOG_RELOAD", "QUEUE_DELETE_ALL", "SYSTEM_CREATE")
     ):
         return config.get("garden.name")
 


### PR DESCRIPTION
Closes #1354 

This PR semi-fixes the call behind the "Clear All Queues" button on the system admin page.  It adds the necessary route for QUEUE_DELETE_ALL to the router, but only executes the operation on the local garden.  It does not attempt to pass the operation on to all downstream gardens.  Doing so would add a great deal of complexity for little gain and could also be confusing at best, and outright dangerous at worst due to the unreliable nature of the asynchronous event processing.

## Test instructions
On the System Admin page, click the "Clear All Queues" button in the top right.  The operation should succeed (though there's no feedback in the UI).  If you look at the garden logs, you should see a bunch of INFO messages for each of the queues, showing that each one got cleared.  They'll look something like:

```
INFO - Clearing Queue: parent1.file-bytes.1-0-0-dev0.default
```