### PR TITLE
#1356 - Fix issue related to viewing local plugin logs

### DIFF
--- a/src/app/beer_garden/api/http/handlers/v1/instance.py
+++ b/src/app/beer_garden/api/http/handlers/v1/instance.py
@@ -280,6 +280,8 @@ class InstanceLogAPI(AuthorizationHandler):
         if response["status"] == "ERROR":
             raise RequestProcessingError(response["output"])
 
+        return response
+
 
 class InstanceQueuesAPI(AuthorizationHandler):
     async def get(self, instance_id):


### PR DESCRIPTION
Closes #1356 

This PR fixes to the log viewing for plugins on the local garden.  Some functionality was refactored into a function for testing purposes at some point, but said function didn't actually return a value.  This fixes that.