### PR TITLE
#1361 - add missing headers for CORS

### DIFF
--- a/src/app/beer_garden/api/http/base_handler.py
+++ b/src/app/beer_garden/api/http/base_handler.py
@@ -80,7 +80,7 @@ class BaseHandler(RequestHandler):
 
         if config.get("ui.cors_enabled"):
             self.set_header("Access-Control-Allow-Origin", "*")
-            self.set_header("Access-Control-Allow-Headers", "Content-Type")
+            self.set_header("Access-Control-Allow-Headers", "Content-Type, Origin, X-Requested-With, Authorization")
             self.set_header(
                 "Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS"
             )

--- a/src/app/beer_garden/api/http/base_handler.py
+++ b/src/app/beer_garden/api/http/base_handler.py
@@ -80,7 +80,10 @@ class BaseHandler(RequestHandler):
 
         if config.get("ui.cors_enabled"):
             self.set_header("Access-Control-Allow-Origin", "*")
-            self.set_header("Access-Control-Allow-Headers", "Content-Type, Origin, X-Requested-With, Authorization")
+            self.set_header(
+                "Access-Control-Allow-Headers",
+                "Content-Type, Origin, X-Requested-With, Authorization",
+            )
             self.set_header(
                 "Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS"
             )


### PR DESCRIPTION
Closes #1361 

Add missing headers to allow CORS requests against API from production build of React UI