### PR TITLE
#1363 - Add react-ui to RPM build process

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Make Deps
         run: |
           python -m pip install --upgrade pip
-          pip install bandit
+          pip install "importlib-metadata<5" bandit
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,15 @@ jobs:
         id: get_version
         uses: battila7/get-version-action@v2
 
+      - name: Download react-ui
+        uses: robinraju/release-downloader@v1.5
+        with:
+          repository: "beer-garden/react-ui"
+          latest: true
+          tarBall: true
+          zipBall: false
+          out-file-path: "src"
+
       - name: Build RPM
         run: make rpm-build VERSION=${{ steps.get_version.outputs.version }}
 

--- a/rpm/bin/build.py
+++ b/rpm/bin/build.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import argparse
+import glob
 import itertools
 import json
 import os
 import subprocess
 import sys
+import tarfile
 
 BUILD_IMAGE = "bgio/build"
 NODE_IMAGE = "node:16"
@@ -30,6 +32,25 @@ def parse_args(cli_args):
     return parser.parse_args(cli_args)
 
 
+def find_and_extract_react_ui():
+    release_path = f"{BASE_PATH}/src"
+
+    try:
+        react_ui_tarball = glob.glob(f"{release_path}/react-ui*.tar.gz")[0]
+    except IndexError:
+        print("Could not locate react release tarball in ${release_path}")
+        sys.exit(1)
+
+    with tarfile.open(react_ui_tarball) as _file:
+        _file.extractall(f"{release_path}/")
+
+    os.remove(react_ui_tarball)
+
+    # rename the directory to something consistent
+    react_ui_dir = glob.glob(f"{release_path}/*react-ui*")[0]
+    os.rename(react_ui_dir, f"{release_path}/react-ui")
+
+
 def build_rpms(version, iteration, cli_dist, cli_python, local, docker_envs):
 
     if cli_dist:
@@ -48,6 +69,8 @@ def build_rpms(version, iteration, cli_dist, cli_python, local, docker_envs):
         print("Supported distributions are: %s" % SUPPORTED_PYTHONS)
         sys.exit(1)
 
+    find_and_extract_react_ui()
+
     # This massages the input env dict into ["-e", "key=value"]
     # It's gross, don't worry about it
     env_vars = list(
@@ -56,30 +79,49 @@ def build_rpms(version, iteration, cli_dist, cli_python, local, docker_envs):
         )
     )
 
-    js_cmd = (
+    ui_build_cmd = (
         ["docker", "run", "--rm", "-v", f"{BASE_PATH}/src:/src"]
         + env_vars
         + [NODE_IMAGE, "make", "-C", "/src/ui", "deps", "package"]
     )
 
-    subprocess.run(js_cmd).check_returncode()
+    subprocess.run(ui_build_cmd).check_returncode()
+
+    reactui_build_cmd = (
+        ["docker", "run", "--rm", "-v", f"{BASE_PATH}/src:/src"]
+        + env_vars
+        + ["-e", "PUBLIC_URL=/preview"]
+        + [NODE_IMAGE, "make", "-C", "/src/react-ui", "deps", "package"]
+    )
+
+    subprocess.run(reactui_build_cmd).check_returncode()
 
     for dist in build_dists:
         tag = f"{dist}-python{build_python}"
         cmd = (
             [
-                "docker", "run", "--rm", "--network", "host",
-                "-v", f"{BASE_PATH}/src:/src",
-                "-v", f"{BASE_PATH}/rpm:/rpm",
-                "-v", f"{SCRIPT_PATH}/rpm_build.sh:{RPM_BUILD_SCRIPT}",
-            ] +
-            env_vars +
-            [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "host",
+                "-v",
+                f"{BASE_PATH}/src:/src",
+                "-v",
+                f"{BASE_PATH}/rpm:/rpm",
+                "-v",
+                f"{SCRIPT_PATH}/rpm_build.sh:{RPM_BUILD_SCRIPT}",
+            ]
+            + env_vars
+            + [
                 BUILD_IMAGE + ":" + tag,
                 RPM_BUILD_SCRIPT,
-                "-r", dist[-1],
-                "-v", version,
-                "-i", iteration,
+                "-r",
+                dist[-1],
+                "-v",
+                version,
+                "-i",
+                iteration,
             ]
         )
 

--- a/rpm/bin/rpm_build.sh
+++ b/rpm/bin/rpm_build.sh
@@ -70,6 +70,7 @@ INCLUDE_PATH="$APP_PATH/include"
 LIB_PATH="$APP_PATH/lib"
 SHARE_PATH="$APP_PATH/share"
 UI_PATH="$APP_PATH/ui"
+REACTUI_PATH="$APP_PATH/react-ui"
 
 PYTHON_BIN="$APP_PATH/bin/python"
 PIP_BIN="$APP_PATH/bin/pip"
@@ -109,6 +110,9 @@ install_apps() {
 
     mkdir -p "$UI_PATH"
     cp -r "$SRC_PATH/ui/dist" "$UI_PATH/dist"
+
+    mkdir -p "$REACTUI_PATH"
+    cp -r "$SRC_PATH/react-ui/build" "$REACTUI_PATH/dist"
 
     mkdir -p "$UI_PATH/conf/conf.d"
     cp "$RESOURCE_BASE/nginx/upstream.conf" "$UI_PATH/conf/conf.d/"

--- a/rpm/centos7/resources/nginx/bg.conf
+++ b/rpm/centos7/resources/nginx/bg.conf
@@ -1,5 +1,11 @@
+location /preview {
+    client_max_body_size 100m;
 
-location ~ / {
+    alias /opt/beer-garden/react-ui/dist/;
+    try_files $uri $uri/ @beergarden;
+}
+
+location / {
     client_max_body_size 100m;
 
     alias /opt/beer-garden/ui/dist/;


### PR DESCRIPTION
Closes #1363 

This PR updates the build script and github action to include the latest react-ui release in the RPM that gets built for the beer-garden release.  The result is that with the provided nginx config, the react version of the ui gets served up under the path `/preview`.

## Test Instructions

Manually testing this one is non-trivial, so I don't particularly suggest it.  You can see a successful run of the github action in my fork [here](https://github.com/scott-taubman/beer-garden/actions/runs/3184814284/jobs/5193659617), with the actual react portion of the build beginning [here](https://github.com/scott-taubman/beer-garden/actions/runs/3184814284/jobs/5193659617#step:5:177).  The release with the actual rpm artifact is found [here](https://github.com/scott-taubman/beer-garden/releases/tag/3.15.0).

You can download the rpm and install it in a centos container if you really want to see it work.