### PR TITLE
Delete Requests via System Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beer Garden Changelog
 
+# 3.20.0
+
+TBD
+
+- Adds the ability to delete Requests by Plugin on the System Admin page wihtin the plugin sub-menu. These are local deletes only
+
 # 3.19.1
 
 11/9/2023

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -604,7 +604,7 @@ class RequestListAPI(AuthorizationHandler):
           - Requests
         """
 
-        self.verify_user_permission_for_object(REQUEST_DELETE, local_garden())
+        self.verify_user_global_permission(REQUEST_DELETE)
 
         query_kwargs = {}
         for supportedArg in [

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -508,6 +508,128 @@ class RequestListAPI(AuthorizationHandler):
         self.set_header("Content-Type", "application/json; charset=UTF-8")
         self.write(response)
 
+    async def delete(self):
+        """
+        ---
+        summary: Bulk delete of Requests
+        description: |
+
+          test holding
+
+        parameters:
+          - name: system
+            in: query
+            required: false
+            description: |
+                System Name
+            type: string
+          - name: system_version
+            in: query
+            required: false
+            description: |
+                System Version
+            type: string
+          - name: instance_name
+            in: query
+            required: false
+            description: |
+                Instance Name
+            type: string
+          - name: namespace
+            in: query
+            required: false
+            description: |
+                Namespace
+            type: string
+          - name: command
+            in: query
+            required: false
+            description: |
+                Command Name
+            type: string
+          - name: id
+            in: query
+            required: false
+            description: |
+                Request ID
+            type: string
+          - name: is_event
+            in: query
+            required: false
+            description: |
+                Is Event
+            type: bool
+          - name: output_type
+            in: query
+            required: false
+            description: |
+                Output Type
+            type: string
+          - name: status
+            in: query
+            required: false
+            description: |
+                Status
+            type: string
+          - name: command_type
+            in: query
+            required: false
+            description: |
+                Command Type
+            type: string
+          - name: hidden
+            in: query
+            required: false
+            description: |
+                Hidden
+            type: bool
+          - name: has_parent
+            in: query
+            required: false
+            description: |
+                Command Type
+            type: bool
+          - name: requester
+            in: query
+            required: false
+            description: |
+                Requester
+            type: string
+        responses:
+          204:
+            description: Requests has been successfully deleted
+          50x:
+            $ref: '#/definitions/50xError'
+        tags:
+          - Requests
+        """
+
+        query_kwargs = {}
+        for supportedArg in [
+            "system",
+            "system_version",
+            "instance_name",
+            "namespace",
+            "command",
+            "id",
+            "is_event",
+            "output_type",
+            "status",
+            "command_type",
+            "hidden",
+            "has_parent",
+            "requester",
+        ]:
+            value = self.get_argument(supportedArg, default=None)
+            if value is not None:
+                query_kwargs[supportedArg] = value
+
+        await self.client(
+            Operation(operation_type="REQUEST_DELETE", kwargs=query_kwargs)
+        )
+
+        self.set_status(204)
+
     def _parse_form_request(self) -> BrewtilsRequest:
         args = {"parameters": {}}
 

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -604,6 +604,8 @@ class RequestListAPI(AuthorizationHandler):
           - Requests
         """
 
+        self.verify_user_permission_for_object(REQUEST_DELETE, local_garden())
+
         query_kwargs = {}
         for supportedArg in [
             "system",

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -575,6 +575,27 @@ def get_requests(**kwargs) -> List[Request]:
     return db.query(Request, **kwargs)
 
 
+# TODO: Add support for Request Delete event type
+# @publish_event(Events.REQUEST_DELETED)
+def delete_requests(**kwargs) -> dict:
+    """Delete Requests
+
+    Args:
+        kwargs: Parameters to be passed to the DB query
+
+    Returns:
+        The kwargs used to match Requests
+
+    """
+    requests = db.query(Request, filter_params=kwargs)
+
+    for request in requests:
+        db.delete(request)
+
+    logger.info(f"Deleted {len(requests)} requests")
+    return kwargs
+
+
 def _publish_request(request: Request, is_admin: bool, priority: int):
     """Publish a Request"""
     queue.put(
@@ -912,6 +933,9 @@ def handle_event(event):
                         update_request(existing_request, _publish_error=False)
                     except RequestStatusTransitionError:
                         pass
+        # TODO: Add support for Request Delete event type
+        # elif event.name == Events.REQUEST_DELETED.name:
+        #     delete_requests(**event.payload)
 
     if event.name in (
         Events.REQUEST_COMPLETED.name,

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -105,6 +105,7 @@ route_functions = {
     "REQUEST_COMPLETE": beer_garden.requests.complete_request,
     "REQUEST_READ": beer_garden.requests.get_request,
     "REQUEST_READ_ALL": beer_garden.requests.get_requests,
+    "REQUEST_DELETE": beer_garden.requests.delete_requests,
     "COMMAND_READ": beer_garden.commands.get_command,
     "COMMAND_READ_ALL": beer_garden.commands.get_commands,
     "INSTANCE_READ": beer_garden.systems.get_instance,
@@ -583,7 +584,7 @@ def _target_from_type(operation: Operation) -> str:
         or "PUBLISH_EVENT" in operation.operation_type
         or "RUNNER" in operation.operation_type
         or operation.operation_type
-        in ("PLUGIN_LOG_RELOAD", "QUEUE_DELETE_ALL", "SYSTEM_CREATE")
+        in ("PLUGIN_LOG_RELOAD", "QUEUE_DELETE_ALL", "SYSTEM_CREATE", "REQUEST_DELETE")
     ):
         return config.get("garden.name")
 

--- a/src/ui/src/index.js
+++ b/src/ui/src/index.js
@@ -99,6 +99,7 @@ import runnerService from './js/services//runner_service.js';
 import aboutController from './js/controllers/about.js';
 import commandPublishingBlocklistController from './js/controllers/command_publishing_blocklist.js';
 import adminQueueController from './js/controllers/admin_queue.js';
+import adminRequestDeleteController from './js/controllers/admin_request_delete.js'
 import adminSystemController from './js/controllers/admin_system.js';
 import adminSystemLogsController from './js/controllers/admin_system_logs.js';
 import adminSystemForceDeleteController from './js/controllers/admin_system_force_delete.js';
@@ -222,6 +223,7 @@ angular
     .controller('CommandPublishingBlocklistController', commandPublishingBlocklistController)
     .controller('AddCommandPublishingBlocklistController', addCommandPublishingBlocklistController)
     .controller('AdminQueueController', adminQueueController)
+    .controller('AdminRequestDeleteController',adminRequestDeleteController)
     .controller(
         'AdminSystemForceDeleteController',
         adminSystemForceDeleteController,

--- a/src/ui/src/js/configs/routes.js
+++ b/src/ui/src/js/configs/routes.js
@@ -233,6 +233,11 @@ export default function routeConfig(
       })
       .state('base.queues', {
         url: 'admin/queues/',
+        templateUrl: 'admin_request_delete.html',
+        controller: 'AdminRequestDeleteController',
+      })
+      .state('base.request_admin', {
+        url: 'admin/request/',
         templateUrl: 'admin_queue.html',
         controller: 'AdminQueueController',
       })

--- a/src/ui/src/js/controllers/admin_request_delete.js
+++ b/src/ui/src/js/controllers/admin_request_delete.js
@@ -1,0 +1,258 @@
+import angular from 'angular';
+
+adminRequestDeleteController.$inject = [
+  '$scope',
+  '$uibModalInstance',
+  'RequestService',
+  'system',
+  'instance',
+];
+
+/**
+ * adminRequestDeleteController - Angular controller for queue index page.
+ * @param  {Object} $scope            Angular's $scope object.
+ * @param  {Object} $uibModalInstance Modal instance.
+ * @param  {Object} $interval         Angular's $interval object.
+ * @param  {Object} RequestService      Beer-Garden's request service object.
+ * @param  {Object} system
+ * @param  {Object} instance
+ */
+export default function adminRequestDeleteController(
+  $scope,
+  $uibModalInstance,
+  RequestService,
+  system,
+  instance,
+) {
+  $scope.alerts = [];
+  $scope.system = system;
+  $scope.instance = instance;
+  $scope.queues = [];
+
+  $scope.success_count = 0;
+  $scope.cancelled_count = 0;
+  $scope.error_count = 0;
+  $scope.created_count = 0;
+  $scope.received_count = 0;
+  $scope.in_progress_count = 0;
+  $scope.all_count = 0;
+
+  $scope.deleteRequests = function (status) {
+    let deleteParams = {
+      "namespace": $scope.system.namespace,
+      "system": $scope.system.name,
+      "system_version": $scope.system.version,
+      "instance_name": $scope.instance.name
+    };
+
+    if (status != "ALL") {
+      deleteParams["status"] = status;
+    }
+
+    RequestService.deleteRequests(deleteParams).then($scope.addSuccessAlert, $scope.addDeleteErrorAlert);
+
+  };
+
+  $scope.closeAlert = function (index) {
+    $scope.alerts.splice(index, 1);
+  };
+
+  $scope.addSuccessAlert = function (response) {
+    $scope.alerts.push({
+      type: 'success',
+      msg: 'Success! Requests have been deleted.',
+    });
+    $scope.loadRequests();
+  };
+
+  $scope.closeDialog = function () {
+    $uibModalInstance.close();
+  };
+
+  $scope.addDeleteErrorAlert = function (response) {
+    let msg = 'Uh oh! It looks like there was a problem deleted the Requests.\n';
+    if (response.data !== undefined && response.data !== null) {
+      msg += response.data;
+    }
+    $scope.alerts.push({
+      type: 'danger',
+      msg: msg,
+    });
+  };
+
+  $scope.buildFilter = function (status) {
+    return {
+      "include_children": true,
+      "length": 1,
+      "columns": [
+        {
+          "data": "namespace",
+          "name": "",
+          "searchable": true,
+          "orderable": true,
+          "search": {
+            "value": $scope.system.namespace,
+            "regex": false
+          }
+        },
+        {
+          "data": "system",
+          "name": "",
+          "searchable": true,
+          "orderable": true,
+          "search": {
+            "value": $scope.system.name,
+            "regex": false
+          }
+        },
+        {
+          "data": "system_version",
+          "name": "",
+          "searchable": true,
+          "orderable": true,
+          "search": {
+            "value": $scope.system.version,
+            "regex": false
+          }
+        },
+        {
+          "data": "instance_name",
+          "name": "",
+          "searchable": true,
+          "orderable": true,
+          "search": {
+            "value": $scope.instance.name,
+            "regex": false
+          }
+        },
+        {
+          "data": "status",
+          "name": "",
+          "searchable": true,
+          "orderable": true,
+          "search": {
+            "value": ((status == "ALL") ? "" : status),
+            "regex": false
+          }
+        },
+      ]
+    };
+  }
+
+  $scope.loadRequests = function () {
+
+    $scope.all_count = 0;
+    $scope.success_count = 0;
+    $scope.cancelled_count = 0;
+    $scope.error_count = 0;
+    $scope.created_count = 0;
+    $scope.received_count = 0;
+    $scope.in_progress_count = 0;
+
+    RequestService.getRequests($scope.buildFilter("SUCCESS")).then(
+      (response) => {
+        $scope.success_count = parseInt(response.headers('recordsFiltered'));
+        $scope.all_count += $scope.success_count;
+      },
+      (response) => {
+        let msg = 'Uh oh! It looks like there was a problem counting the SUCCESS Requests.\n';
+        if (response.data !== undefined && response.data !== null) {
+          msg += response.data;
+        }
+        $scope.alerts.push({
+          type: 'danger',
+          msg: msg,
+        });
+      }
+    );
+
+    RequestService.getRequests($scope.buildFilter("CANCELED")).then(
+      (response) => {
+        $scope.cancelled_count = parseInt(response.headers('recordsFiltered'));
+        $scope.all_count += $scope.cancelled_count;
+      },
+      (response) => {
+        let msg = 'Uh oh! It looks like there was a problem counting the CANCELED Requests.\n';
+        if (response.data !== undefined && response.data !== null) {
+          msg += response.data;
+        }
+        $scope.alerts.push({
+          type: 'danger',
+          msg: msg,
+        });
+      }
+    );
+
+    RequestService.getRequests($scope.buildFilter("ERROR")).then(
+      (response) => {
+        $scope.error_count = parseInt(response.headers('recordsFiltered'));
+        $scope.all_count += $scope.error_count;
+      },
+      (response) => {
+        let msg = 'Uh oh! It looks like there was a problem counting the ERROR Requests.\n';
+        if (response.data !== undefined && response.data !== null) {
+          msg += response.data;
+        }
+        $scope.alerts.push({
+          type: 'danger',
+          msg: msg,
+        });
+      }
+    );
+
+    RequestService.getRequests($scope.buildFilter("CREATED")).then(
+      (response) => {
+        $scope.created_count = parseInt(response.headers('recordsFiltered'));
+        $scope.all_count += $scope.created_count;
+      },
+      (response) => {
+        let msg = 'Uh oh! It looks like there was a problem counting the CREATED Requests.\n';
+        if (response.data !== undefined && response.data !== null) {
+          msg += response.data;
+        }
+        $scope.alerts.push({
+          type: 'danger',
+          msg: msg,
+        });
+      }
+    );
+
+    RequestService.getRequests($scope.buildFilter("RECEIVED")).then(
+      (response) => {
+        $scope.received_count = parseInt(response.headers('recordsFiltered'));
+        $scope.all_count += $scope.received_count;
+      },
+      (response) => {
+        let msg = 'Uh oh! It looks like there was a problem counting the RECEIVED Requests.\n';
+        if (response.data !== undefined && response.data !== null) {
+          msg += response.data;
+        }
+        $scope.alerts.push({
+          type: 'danger',
+          msg: msg,
+        });
+      }
+    );
+
+    RequestService.getRequests($scope.buildFilter("IN_PROGRESS")).then(
+      (response) => {
+        $scope.in_progress_count = parseInt(response.headers('recordsFiltered'));
+        $scope.all_count += $scope.in_progress_count;
+      },
+      (response) => {
+        let msg = 'Uh oh! It looks like there was a problem counting the IN PROGRESS Requests.\n';
+        if (response.data !== undefined && response.data !== null) {
+          msg += response.data;
+        }
+        $scope.alerts.push({
+          type: 'danger',
+          msg: msg,
+        });
+      }
+    );
+
+
+  };
+
+  $scope.loadRequests();
+}

--- a/src/ui/src/js/controllers/admin_system.js
+++ b/src/ui/src/js/controllers/admin_system.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import readLogs from '../../templates/read_logs.html';
 import adminQueue from '../../templates/admin_queue.html';
+import adminRequestDelete from '../../templates/admin_request_delete.html';
 import forceDelete from '../../templates/system_force_delete.html';
 import {responseState} from '../services/utility_service.js';
 
@@ -15,6 +16,7 @@ adminSystemController.$inject = [
   'QueueService',
   'RunnerService',
   'EventService',
+  'RequestService',
 ];
 
 /**
@@ -29,6 +31,7 @@ adminSystemController.$inject = [
  * @param  {Object} QueueService    Beer-Garden's event service object.
  * @param  {Object} RunnerService   Beer-Garden's runner service object.
  * @param  {Object} EventService    Beer-Garden's event service object.
+ * @param  {Object} RequestService    Beer-Garden's request service object.
  */
 export default function adminSystemController(
     $scope,
@@ -41,6 +44,7 @@ export default function adminSystemController(
     QueueService,
     RunnerService,
     EventService,
+    RequestService,
 ) {
   $scope.response = undefined;
   $scope.runnerResponse = undefined;
@@ -229,6 +233,21 @@ export default function adminSystemController(
       controller: 'AdminQueueController',
       windowClass: 'app-modal-window',
     });
+  };
+
+  $scope.deleteRequests = function(system, instance) {
+
+    $uibModal.open({
+      template: adminRequestDelete,
+      resolve: {
+        system: system,
+        instance: instance,
+      },
+      controller: 'AdminRequestDeleteController',
+      windowClass: 'app-modal-window',
+    });
+
+    
   };
 
   function eventCallback(event) {

--- a/src/ui/src/js/controllers/admin_system.js
+++ b/src/ui/src/js/controllers/admin_system.js
@@ -235,8 +235,7 @@ export default function adminSystemController(
     });
   };
 
-  $scope.deleteRequests = function(system, instance) {
-
+  $scope.deleteRequests = function (system, instance) {
     $uibModal.open({
       template: adminRequestDelete,
       resolve: {
@@ -246,8 +245,6 @@ export default function adminSystemController(
       controller: 'AdminRequestDeleteController',
       windowClass: 'app-modal-window',
     });
-
-    
   };
 
   function eventCallback(event) {

--- a/src/ui/src/js/services/request_service.js
+++ b/src/ui/src/js/services/request_service.js
@@ -22,6 +22,9 @@ export default function requestService($q, $http, $interval) {
     isComplete: (request) => {
       return _.includes(completeStatuses, request.status);
     },
+    deleteRequests: (data) => {
+      return $http.delete('api/v1/requests', {params: data});
+    },
   };
 
   _.assign(service, {

--- a/src/ui/src/partials/admin_system.html
+++ b/src/ui/src/partials/admin_system.html
@@ -237,6 +237,14 @@
                       ><span>Manage Queue</span>
                     </a>
                   </li>
+                  <li>
+                    <a
+                      ng-click="deleteRequests(system, instance)"
+                      role="button"
+                      title="Delete Requests: {{instance.name}}"
+                      ><span>Delete Requests</span>
+                    </a>
+                  </li>
                 </ul>
               </span>
             </span>

--- a/src/ui/src/templates/admin_request_delete.html
+++ b/src/ui/src/templates/admin_request_delete.html
@@ -1,0 +1,107 @@
+<div class="modal-header">
+  <h3 class="modal-title" id="modal-title">
+    Delete Requests: {{system.name}}[{{system.version}}]-{{instance.name}}
+  </h3>
+</div>
+
+<div class="modal-body" id="modal-body">
+  <div uib-alert ng-repeat="alert in alerts" ng-class="'alert-{{alert.type}}'" close="closeAlert($index)">
+    {{alert.msg}}
+  </div>
+  <div>
+    Currently {{all_count}} Requests present in the database
+  </div>
+  <br>
+
+  <table>
+    <tr>
+      <th>Action</th>
+      <th>Requests</th>
+    </tr>
+    <tr>
+      <td>
+        <button type="button" class="btn btn-success btn-block" ng-click="deleteRequests('SUCCESS')"
+          confirm="Are you sure you want to delete Requests with status SUCCESS?">
+          Delete SUCCESS
+        </button>
+      </td>
+      <td align="right">
+        {{success_count}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button type="button" class="btn btn-success btn-block" ng-click="deleteRequests('CANCELED')"
+          confirm="Are you sure you want to delete Requests with status CANCELED?">
+          Delete CANCELED
+        </button>
+      </td>
+      <td align="right">
+        {{cancelled_count}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button type="button" class="btn btn-success btn-block" ng-click="deleteRequests('ERROR')"
+          confirm="Are you sure you want to delete Requests with status ERROR?">
+          Delete ERROR
+        </button>
+      </td>
+      <td align="right">
+        {{error_count}}
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        <button type="button" class="btn btn-warning btn-block" ng-click="deleteRequests('CREATED')"
+          confirm="Are you sure you want to delete Requests with status CREATED? Recommend clearing topics as well, else a plugin could still process this request.">
+          Delete CREATED
+        </button>
+      </td>
+      <td align="right">
+        {{created_count}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button type="button" class="btn btn-warning btn-block" ng-click="deleteRequests('RECEIVED')"
+          confirm="Are you sure you want to delete Requests with status RECEIVED?">
+          Delete RECEIVED
+        </button>
+      </td>
+      <td align="right">
+        {{received_count}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button type="button" class="btn btn-warning btn-block" ng-click="deleteRequests('IN PROGRESS')"
+          confirm="Are you sure you want to delete Requests with status IN PROGRESS? There may be a plugin already running the request.">
+          Delete IN PROGRESS
+        </button>
+      </td>
+      <td align="right">{{in_progress_count}}</td>
+    </tr>
+
+    <tr>
+      <td>
+        <button type="button" class="btn btn-danger btn-block" ng-click="deleteRequests('ALL')"
+          confirm="Are you sure you want to delete all the Requests?">
+          Delete All
+        </button>
+      </td>
+      <td align="right">
+        {{all_count}}
+      </td>
+    </tr>
+
+  </table>
+
+</div>
+
+<div class="modal-footer">
+  <button class="btn btn-primary" type="button" ng-click="closeDialog()">
+    Close
+  </button>
+</div>


### PR DESCRIPTION
Adds new feature to delete requests associated with a single plugin on the System Admin page. These can be deleted by Status or All. 

![Example of Delete Requests](https://github.com/beer-garden/beer-garden/assets/5104941/4d53630e-1d7c-48e4-9230-791b3df13c55)
