### PR TITLE
Dumps subscription errors to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beer Garden Changelog
 
+# 3.19.2
+
+TBD
+
+- Add error handling if Subscriber Request has exception at creation
+
 # 3.19.1
 
 11/9/2023

--- a/src/app/beer_garden/publish_request.py
+++ b/src/app/beer_garden/publish_request.py
@@ -75,7 +75,6 @@ def process_publish_event(garden: Garden, event: Event):
 
                     try:
                         process_request(event_request)
-                    except Exception ex:
+                    except Exception as ex:
                         # If an error occurs while trying to process request, log it and keep running
-                        self.logger.exception(ex)
-                    
+                        logger.exception(ex)

--- a/src/app/beer_garden/publish_request.py
+++ b/src/app/beer_garden/publish_request.py
@@ -73,4 +73,9 @@ def process_publish_event(garden: Garden, event: Event):
                     event_request.command = command.name
                     event_request.is_event = True
 
-                    process_request(event_request)
+                    try:
+                        process_request(event_request)
+                    except Exception ex:
+                        # If an error occurs while trying to process request, log it and keep running
+                        self.logger.exception(ex)
+                    


### PR DESCRIPTION
If an error occurs during the creation of a request from the Publish Request event, log the error and keep rolling. 