### PR TITLE
Toggle off navigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beer Garden Changelog
 
+# 3.21.0
+
+TBD
+
+- Adding "?showNav=false" to the end of any UI page will remove the navigation bar
+
 # 3.20.0
 
 11/16/2023

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -20,9 +20,9 @@
   <body ng-cloak>
     <!-- Navbar Start -->
     <!-- Static navbar for layout purposes -->
-    <nav class="navbar navbar-static-top"></nav>
+    <nav class="navbar navbar-static-top" ng-show="showNav"></nav>
 
-    <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+    <nav class="navbar navbar-default navbar-fixed-top" role="navigation" ng-show="showNav">
       <a style="cursor: pointer" class="navbar-brand" ui-sref="{{getHome()}}">
         <i style="padding: 3px" ng-class="getIcon(config.iconDefault)"></i>
         <span ng-cloak>{{config.applicationName}}</span>

--- a/src/ui/src/js/run.js
+++ b/src/ui/src/js/run.js
@@ -13,6 +13,7 @@ appRun.$inject = [
   '$state',
   '$stateParams',
   '$http',
+  '$location',
   '$q',
   '$uibModal',
   '$transitions',
@@ -32,6 +33,7 @@ appRun.$inject = [
  * @param  {Object} $state               Angular's $state object.
  * @param  {Object} $stateParams         Angular's $stateParams object.
  * @param  {Object} $http                Angular's $http object.
+ * @param  {Object} $location            Angular's $location object.
  * @param  {Object} $q                   Angular's $q object.
  * @param  {Object} $uibModal            Angular UI's $uibModal object.
  * @param  {Object} $transitions         Angular's $transitions object.
@@ -49,6 +51,7 @@ export default function appRun(
     $state,
     $stateParams,
     $http,
+    $location,
     $q,
     $uibModal,
     $transitions,
@@ -63,6 +66,12 @@ export default function appRun(
 ) {
   $rootScope.$state = $state;
   $rootScope.$stateParams = $stateParams;
+
+  if ($location.search()['showNav'] == 'false'){
+    $rootScope.showNav = false;
+  } else {
+    $rootScope.showNav = true;
+  }
 
   let loginModal;
   $rootScope.loginInfo = {};


### PR DESCRIPTION
By adding ?showNav=false to the end of any page URL it will hide the navigation bar until it has been removed and the page is refreshed.