### PR TITLE
API column builder update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beer Garden Changelog
 
+# 3.21.0
+
+TBD
+
+- On Request Index page, the prefix NOT is supported to invert string query or search for empty strings. 
+
 # 3.20.0
 
 11/16/2023

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -745,9 +745,9 @@ class RequestListAPI(AuthorizationHandler):
                     filter_params[column["data"] + "__exact"] = ""
                 elif column["data"] == "comment":
                     if column["search"]["value"].upper().startswith("NOT "):
-                        filter_params[column["data"] + "__not__contains"] = column["search"][
-                            "value"
-                        ][4:]
+                        filter_params[column["data"] + "__not__contains"] = column[
+                            "search"
+                        ]["value"][4:]
                     else:
                         filter_params[column["data"] + "__contains"] = column["search"][
                             "value"
@@ -755,13 +755,13 @@ class RequestListAPI(AuthorizationHandler):
 
                 else:
                     if column["search"]["value"].upper().startswith("NOT "):
-                        filter_params[column["data"] + "__not__startswith"] = column["search"][
-                            "value"
-                        ][4:]
+                        filter_params[column["data"] + "__not__startswith"] = column[
+                            "search"
+                        ]["value"][4:]
                     else:
-                        filter_params[column["data"] + "__startswith"] = column["search"][
-                            "value"
-                        ]
+                        filter_params[column["data"] + "__startswith"] = column[
+                            "search"
+                        ]["value"]
 
                 hint_helper.append(column["data"])
 

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -239,6 +239,32 @@ class RequestListAPI(AuthorizationHandler):
             "search": {"value": "SUCCESS", "regex":false}
           }
           ```
+          
+          * To query on empty values, in the value use 'NOT' to return
+            values that match ''
+          `columns` query parameters:
+          ```JSON
+          {
+            "data": "command",
+            "name": "",
+            "searchable": true,
+            "orderable": true,
+            "search": {"value":"NOT","regex":false}
+          }
+          ```
+          
+          * To invert a field set match, in the value use the prefix 'NOT ' to return
+            values that do not match that string value
+          `columns` query parameters:
+          ```JSON
+          {
+            "data": "command",
+            "name": "",
+            "searchable": true,
+            "orderable": true,
+            "search": {"value":"NOT command","regex":false}
+          }
+          ```
 
           * To sort by a field use the `order` parameter. The `column` value should be
             the index of the column to sort and the `dir` value can be either "asc" or
@@ -715,15 +741,27 @@ class RequestListAPI(AuthorizationHandler):
                         "value"
                     ]
 
+                elif column["search"]["value"].upper() in ["NOT", "NOT "]:
+                    filter_params[column["data"] + "__exact"] = ""
                 elif column["data"] == "comment":
-                    filter_params[column["data"] + "__contains"] = column["search"][
-                        "value"
-                    ]
+                    if column["search"]["value"].upper().startswith("NOT "):
+                        filter_params[column["data"] + "__not__contains"] = column["search"][
+                            "value"
+                        ][4:]
+                    else:
+                        filter_params[column["data"] + "__contains"] = column["search"][
+                            "value"
+                        ]
 
                 else:
-                    filter_params[column["data"] + "__startswith"] = column["search"][
-                        "value"
-                    ]
+                    if column["search"]["value"].upper().startswith("NOT "):
+                        filter_params[column["data"] + "__not__startswith"] = column["search"][
+                            "value"
+                        ][4:]
+                    else:
+                        filter_params[column["data"] + "__startswith"] = column["search"][
+                            "value"
+                        ]
 
                 hint_helper.append(column["data"])
 

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -239,7 +239,7 @@ class RequestListAPI(AuthorizationHandler):
             "search": {"value": "SUCCESS", "regex":false}
           }
           ```
-          
+
           * To query on empty values, in the value use 'NOT' to return
             values that match ''
           `columns` query parameters:
@@ -252,7 +252,7 @@ class RequestListAPI(AuthorizationHandler):
             "search": {"value":"NOT","regex":false}
           }
           ```
-          
+
           * To invert a field set match, in the value use the prefix 'NOT ' to return
             values that do not match that string value
           `columns` query parameters:


### PR DESCRIPTION
Adds the ability to use the prefix "NOT" on search fields to invert the query logic or search for empty strings.