### PR TITLE
Support command tags on index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Beer Garden Changelog
 
+# 3.22.0
+
+TBD
+
+- Add support for commands to have tags, used for filtering on the commands index page
+- Upgraded Brewtils version to [3.22.0](https://github.com/beer-garden/brewtils/releases/tag/3.22.0)
+
 # 3.21.0
 
 12/05/2023

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -243,6 +243,7 @@ class Command(MongoModel, EmbeddedDocument):
     hidden = BooleanField()
     icon_name = StringField()
     metadata = DictField()
+    tags = ListField(field=StringField())
     topics = ListField(field=StringField())
     allow_any_kwargs = BooleanField(default=False)
 

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/@beer-garden/builder": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@beer-garden/builder/-/builder-3.1.0.tgz",
-      "integrity": "sha512-mcch0iWKleaLMxKa62m20/kHKeRc9+zHvpwrepMive4P0Avv4K60rfic9ScwIyBom5Je+p3Lyet0hejrKsdCqA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@beer-garden/builder/-/builder-3.2.0.tgz",
+      "integrity": "sha512-aifB1nwSkOBAX7bvlPj+AXHVfoIjA+jzU/Y8xTwwzrKUozcuBDVmb/Jh9ScebzxcIlIacwWVf+pa+hShbpXWGQ==",
       "dependencies": {
         "objectpath": "^1.2.1",
         "package.json": "^2.0.1"
@@ -13186,9 +13186,9 @@
       "requires": {}
     },
     "@beer-garden/builder": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@beer-garden/builder/-/builder-3.1.0.tgz",
-      "integrity": "sha512-mcch0iWKleaLMxKa62m20/kHKeRc9+zHvpwrepMive4P0Avv4K60rfic9ScwIyBom5Je+p3Lyet0hejrKsdCqA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@beer-garden/builder/-/builder-3.2.0.tgz",
+      "integrity": "sha512-aifB1nwSkOBAX7bvlPj+AXHVfoIjA+jzU/Y8xTwwzrKUozcuBDVmb/Jh9ScebzxcIlIacwWVf+pa+hShbpXWGQ==",
       "requires": {
         "objectpath": "^1.2.1",
         "package.json": "^2.0.1"

--- a/src/ui/src/js/controllers/command_index.js
+++ b/src/ui/src/js/controllers/command_index.js
@@ -66,7 +66,7 @@ export default function commandIndexController(
     $('#commandIndexTable').on('length.dt', (event, settings, len) => {
       localStorageService.set('_command_index_length', len);
     });
-  };
+  }; 
 
   $scope.hiddenComparator = function(hidden, checkbox) {
     return checkbox || !hidden;
@@ -134,6 +134,7 @@ export default function commandIndexController(
           version: system.version,
           description: command.description || 'No Description Provided',
           topics: command.topics || [],
+          tags: command.tags || [],
         });
       });
     });

--- a/src/ui/src/partials/command_index.html
+++ b/src/ui/src/partials/command_index.html
@@ -105,7 +105,12 @@
                 ng-show="command.topics.length > 0"
               ></span>
             </td>
-            <td>{{command.description}}</td>
+            <td>
+              {{command.description}}
+              <span ng-show="command.tags.length > 0">
+                <br>{{"TAGS = " + command.tags}}
+              </span>
+            </td>
             <td ng-if="userCanTask">
               <a
                 class="btn btn-primary center-block word-wrap-button"


### PR DESCRIPTION
Adds tags for commands to the index page to allow filtering.

brewtils: command-tags

Example
![image](https://github.com/beer-garden/beer-garden/assets/5104941/545ed40f-347a-478d-9f51-a8596bef1ba0)
