### PR TITLE
Update events filter for replication

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -245,6 +245,14 @@ jobs:
       - name: Verify Local Plugins
         run: ls ./docker/docker-compose/data/localplugins
 
+      - name: Run Docker Mongodb and RabbitMQ
+        run: docker-compose up -d mongodb rabbitmq
+        working-directory: ./docker/docker-compose
+
+      - name: Wait for Mongodb and RabbitMQ to start
+        run: sleep 20s
+        shell: bash
+
       - name: Run Docker Beer Garden
         run: BG='unstable' docker-compose up -d beer-garden
         working-directory: ./docker/docker-compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 TBD
 
+- Updating Replication to mirror all events, minus child garden sync requests.
 - Add support for commands to have tags, used for filtering on the commands index page
 - Upgraded Brewtils version to [3.22.0](https://github.com/beer-garden/brewtils/releases/tag/3.22.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 TBD
 
-- Updating Replication to mirror all events, minus child garden sync requests.
+- Replication of all events, when configured, except for Garden Sync events. Garden sync events spawn off additional events that will be replicated properly.
 - Add support for commands to have tags, used for filtering on the commands index page
 - Upgraded Brewtils version to [3.22.0](https://github.com/beer-garden/brewtils/releases/tag/3.22.0)
 

--- a/src/app/beer_garden/config.py
+++ b/src/app/beer_garden/config.py
@@ -1507,7 +1507,7 @@ _REPLICATION_SPEC = {
     "items": {
         "enabled": {
             "type": "bool",
-            "default": True,
+            "default": False,
             "description": "Publish subset of events to Rabbit to allow all Gardens to stay in sync when replicated",
         },
     },

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -4,10 +4,11 @@ import uuid
 from multiprocessing import Queue
 from queue import Empty
 
-import beer_garden.config as config
-from beer_garden.queue.rabbit import put_event
 from brewtils.models import Event, Events
 from brewtils.stoppable_thread import StoppableThread
+
+import beer_garden.config as config
+from beer_garden.queue.rabbit import put_event
 
 logger = logging.getLogger(__name__)
 

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -137,18 +137,11 @@ class EventProcessor(FanoutProcessor):
 
         # Check if event should be published to Rabbit
         if not skip_checked and (
-            event.name
-            in (
-                Events.REQUEST_COMPLETED.name,
-                Events.REQUEST_UPDATED.name,
-                Events.REQUEST_CANCELED.name,
-                Events.SYSTEM_CREATED.name,
-                Events.SYSTEM_UPDATED.name,
-                Events.SYSTEM_REMOVED.name,
-                Events.GARDEN_UPDATED.name,
-                Events.GARDEN_REMOVED.name,
+            event.name != Events.GARDEN_SYNC.name
+            or (
+                event.name == Events.GARDEN_SYNC.name
+                and event.garden != config.get("garden.name")
             )
-            or (Events.GARDEN_SYNC.name and event.garden != config.get("garden.name"))
         ):
             try:
                 put_event(event)

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -156,10 +156,7 @@ class EventProcessor(FanoutProcessor):
             except Exception:
                 self.logger.error(f"Failed to publish Event: {event} to PIKA")
                 self._queue.put(event)
-        elif (
-            "_source_uuid" not in event.metadata
-            or event.metadata["_source_uuid"] != self.uuid
-        ):
+        elif "_source_uuid" not in event.metadata or event.metadata["_source_uuid"] != self.uuid:
             self._queue.put(event)
 
     def put_queue(self, event: Event):

--- a/src/app/beer_garden/events/processors.py
+++ b/src/app/beer_garden/events/processors.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 import logging
+import uuid
 from multiprocessing import Queue
 from queue import Empty
 
-from brewtils.models import Event, Events
-from brewtils.stoppable_thread import StoppableThread
-
 import beer_garden.config as config
 from beer_garden.queue.rabbit import put_event
-
-import uuid
+from brewtils.models import Event, Events
+from brewtils.stoppable_thread import StoppableThread
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +154,10 @@ class EventProcessor(FanoutProcessor):
             except Exception:
                 self.logger.error(f"Failed to publish Event: {event} to PIKA")
                 self._queue.put(event)
-        elif "_source_uuid" not in event.metadata or event.metadata["_source_uuid"] != self.uuid:
+        elif (
+            "_source_uuid" not in event.metadata
+            or event.metadata["_source_uuid"] != self.uuid
+        ):
             self._queue.put(event)
 
     def put_queue(self, event: Event):

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -658,8 +658,8 @@ def _system_name_lookup(system: Union[str, System]) -> str:
         # If we don't know about the route, attempt to find it and update the routing table
         systems = beer_garden.systems.get_systems(
             namespace=system.namespace,
-            name=system.system,
-            version=system.system_version,
+            name=system.name,
+            version=system.version,
         )
         if len(systems) == 1:
             for garden in get_gardens():
@@ -668,8 +668,10 @@ def _system_name_lookup(system: Union[str, System]) -> str:
                         with routing_lock:
                             # Then add routes to systems
                             add_routing_system(system=system, garden_name=garden.name)
+                        logger.error("Router mapping is out of sync, you should consider re-syncing")
                         return garden.name
 
+    return None
 
 def _system_id_lookup(system_id: str) -> str:
     with routing_lock:

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -668,10 +668,13 @@ def _system_name_lookup(system: Union[str, System]) -> str:
                         with routing_lock:
                             # Then add routes to systems
                             add_routing_system(system=system, garden_name=garden.name)
-                        logger.error("Router mapping is out of sync, you should consider re-syncing")
+                        logger.error(
+                            "Router mapping is out of sync, you should consider re-syncing"
+                        )
                         return garden.name
 
     return None
+
 
 def _system_id_lookup(system_id: str) -> str:
     with routing_lock:

--- a/src/app/example_configs/config.yaml
+++ b/src/app/example_configs/config.yaml
@@ -23,13 +23,15 @@ db:
   name: beer_garden
   ttl:
     action: -1
-    admin: -1
-    batch_size: -1
     file: 15
     in_progress: 15
-    info: 15
-    multithread: false
+    info: 15   
     temp: 15
+    admin: -1
+
+    batch_size: -1
+    multithread: false
+    
 entry:
   http:
     enabled: true


### PR DESCRIPTION
Mirror all events, minus garden syncs. Garden syncs kick off other events so they don't need to be mirrored across.