### PR TITLE
Fixed issue where Start spawned multiple processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 TBD
 
 - Fixed issue where replicated messages were not fanned out to all replicated Beer Gardens
+- Fixed bug where restart instance was not checking if process is currently running. Now
+  it properly kills the running instance during restart.
+- Split apart functionality of Start and Restart instance into two API operations. 
 
 # 3.23.0
 

--- a/src/app/beer_garden/api/http/handlers/v1/instance.py
+++ b/src/app/beer_garden/api/http/handlers/v1/instance.py
@@ -149,6 +149,11 @@ class InstanceAPI(AuthorizationHandler):
                     Operation(operation_type="INSTANCE_START", args=[instance_id])
                 )
 
+            elif operation == "restart":
+                response = await self.client(
+                    Operation(operation_type="INSTANCE_RESTART", args=[instance_id])
+                )
+
             elif operation == "stop":
                 response = await self.client(
                     Operation(operation_type="INSTANCE_STOP", args=[instance_id])

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -53,6 +53,7 @@ def has_instance_id(*args, **kwargs):
 def start(*args, **kwargs):
     return lpm_proxy.start(*args, **kwargs)
 
+
 @publish_event(Events.RUNNER_STARTED)
 def restart(*args, **kwargs):
     return lpm_proxy.restart(*args, **kwargs)
@@ -62,8 +63,10 @@ def restart(*args, **kwargs):
 def stop(*args, **kwargs):
     return lpm_proxy.stop_one(*args, **kwargs)
 
-def map_runner_to_instance(runner_id:str, instance_id:str) :
+
+def map_runner_to_instance(runner_id: str, instance_id: str):
     return lpm_proxy.map_runner_to_instance(runner_id, instance_id)
+
 
 @publish_event(Events.RUNNER_REMOVED)
 def remove(*args, **kwargs):
@@ -306,7 +309,7 @@ class PluginManager(StoppableThread):
                 return self._restart(the_runner).state()
             return the_runner.state()
         return None
-    
+
     def restart(
         self, runner_id: Optional[str] = None, instance_id: Optional[str] = None
     ) -> Optional[Runner]:
@@ -501,14 +504,14 @@ class PluginManager(StoppableThread):
                 return the_runner
 
         return None
-    
-    def map_runner_to_instance(self, runner_id:str, instance_id:str) -> bool:
+
+    def map_runner_to_instance(self, runner_id: str, instance_id: str) -> bool:
         the_runner = self._from_runner_id(runner_id)
 
         if the_runner:
             the_runner.instance_id = instance_id
             return True
-        
+
         return False
 
     def _restart(self, the_runner: ProcessRunner) -> ProcessRunner:

--- a/src/app/beer_garden/local_plugins/manager.py
+++ b/src/app/beer_garden/local_plugins/manager.py
@@ -280,7 +280,7 @@ class PluginManager(StoppableThread):
     def restart(
         self, runner_id: Optional[str] = None, instance_id: Optional[str] = None
     ) -> Optional[Runner]:
-        """Restart the runner for a particular Runner ID or Instance ID.
+        """Restart the runner for a particular Runner ID or Instance ID. If stopped.
 
         Args:
             runner_id: An ID string associated with a Runner object, optional
@@ -297,7 +297,9 @@ class PluginManager(StoppableThread):
         elif instance_id is not None:
             the_runner = self._from_instance_id(instance_id)
 
-        return self._restart(the_runner).state() if the_runner is not None else None
+        if the_runner.stopped:
+            return self._restart(the_runner).state() if the_runner is not None else None
+        return the_runner.state()
 
     def update(
         self,

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -119,6 +119,7 @@ def start(
 
     return instance
 
+
 @publish_event(Events.INSTANCE_STARTED)
 def restart(
     instance_id: str = None, instance: Instance = None, system: System = None

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -119,6 +119,34 @@ def start(
 
     return instance
 
+@publish_event(Events.INSTANCE_STARTED)
+def restart(
+    instance_id: str = None, instance: Instance = None, system: System = None
+) -> Instance:
+    """Starts an instance.
+
+    Args:
+        instance_id: The Instance ID
+        instance: The Instance
+        system: The System
+
+    Returns:
+        The updated Instance
+    """
+    system, instance = _from_kwargs(
+        system=system, instance=instance, instance_id=instance_id
+    )
+
+    logger.debug(f"Starting instance {system}[{instance}]")
+
+    # Only way this works is if this has a local runner, so just assume it does
+    lpm.restart(instance_id=instance.id)
+
+    # Publish the start request
+    publish_start(system, instance)
+
+    return instance
+
 
 @publish_event(Events.INSTANCE_STOPPED)
 def stop(

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -85,7 +85,8 @@ def initialize(
         },
     )
 
-    start(instance=instance, system=system)
+    if runner_id:
+        lpm.map_runner_to_instance(runner_id, instance.id)
 
     return system.get_instance_by_name(instance.name)
 

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -115,6 +115,7 @@ route_functions = {
     "INSTANCE_HEARTBEAT": beer_garden.plugin.heartbeat,
     "INSTANCE_INITIALIZE": beer_garden.plugin.initialize,
     "INSTANCE_START": beer_garden.plugin.start,
+    "INSTANCE_RESTART": beer_garden.plugin.restart,
     "INSTANCE_STOP": beer_garden.plugin.stop,
     "INSTANCE_LOGS": beer_garden.plugin.read_logs,
     "JOB_CREATE": beer_garden.scheduler.create_job,


### PR DESCRIPTION
Start instance was running Restart on the backend. But the Restart function did not kill the old process, it assumed it was already stopped. 

Now Restart checks if the plugin is running, if so, stop it first. Then rebuild the process.

Start now checks if the plugin is currently running, if it is, then do nothing. If it is not, it invokes the restart function.

Added a new option to invoke Restart directly, but not exposed on the UI at the moment. 