### PR TITLE
Fixed Request Blocking bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 TBD
 
 - Updated icons on System Admin page
+- Fixed bug where `blocking=true` on Request API returned `IN PROGRESS` status for requests sourced from downstream gardens. Delay added to 
+  allow Beer Garden to process the event.
 
 # 3.23.1
 

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -13,6 +13,7 @@ import json
 import logging
 import re
 import threading
+import time
 from builtins import str
 from copy import deepcopy
 from typing import Dict, List, Sequence, Union
@@ -896,6 +897,10 @@ def handle_wait_events(event):
     if event.name == Events.REQUEST_COMPLETED.name:
         completion_event = request_map.pop(event.payload.id, None)
         if completion_event:
+            if event.garden != config.get("garden.name"):
+                # Need to give Beer Garden a moment to process Compelte request
+                time.sleep(0.1)
+
             completion_event.set()
 
     # Only care about local garden


### PR DESCRIPTION
Added delay before setting Request wait event if the completion event is coming from a remote garden. This gives Beer Garden just enough time to process it. If this is continued to be seen, we can increase the delay.