### PR TITLE
Garden Heartbeat Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Beer Garden Changelog
 
+# 3.24.2
+
+TBD
+
+- Fixed bug where setting the heartbeat for recieving garden connections would override changes from Instance Updates in seperate threads
+- Fixed bug where heartbeat did not update the status to `RECEVING` for the receiving connection type
+
 # 3.24.1
 
 2/21/24

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -234,7 +234,9 @@ def update_garden_receiving_heartbeat(
         connection.status_info["heartbeat"] = datetime.utcnow()
         garden.receiving_connections.append(connection)
 
-    updates["receiving_connections"] = [db.from_brewtils(connection) for connection in garden.receiving_connections]
+    updates["receiving_connections"] = [
+        db.from_brewtils(connection) for connection in garden.receiving_connections
+    ]
 
     return db.modify(garden, **updates)
 

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -209,12 +209,16 @@ def update_garden_receiving_heartbeat(
     if garden is None:
         garden = create_garden(Garden(name=garden_name, connection_type="Remote"))
 
+    updates = {}
+
     connection_set = False
 
     for connection in garden.receiving_connections:
         if connection.api == api:
             connection_set = True
             connection.status_info["heartbeat"] = datetime.utcnow()
+            if connection.status != "DISABLED":
+                connection.status = "RECEIVING"
 
     # If the receiving type is unknown, enable it by default and set heartbeat
     if not connection_set:
@@ -230,7 +234,9 @@ def update_garden_receiving_heartbeat(
         connection.status_info["heartbeat"] = datetime.utcnow()
         garden.receiving_connections.append(connection)
 
-    return db.update(garden)
+    updates["receiving_connections"] = [db.from_brewtils(connection) for connection in garden.receiving_connections]
+
+    return db.modify(garden, **updates)
 
 
 def update_garden_status(garden_name: str, new_status: str) -> Garden:


### PR DESCRIPTION
Fixed an issue where multiple threads editing the instances would override

Fixed an issue where the status was not being reset when the operation came through.