### PR TITLE
Only update garden heartbeat at half interval marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ TBD
 - Now show alert on Garden Admin page when a Sync event is seen
 - Fixed order of Gardens and Connections on Garden Admin page
 - Fixed bug where child garden plugins are treated like local plugins on the System Admin page
+- Garden Receiving connections heartbeats are only updated on the half windows for timeout windows. If no timeout window is set, the value is not populated.
 - Utilized the TTL for In_Progress requests to set Expiration windows for Requests on PIKA, to handle backups of requests that Beer Garden has already cancelled.
 
 # 3.24.4

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -201,29 +201,39 @@ def update_garden_config(garden: Garden) -> Garden:
     return update_garden(db_garden)
 
 
-def update_garden_receiving_heartbeat(
-    api: str, garden_name: str = None, garden: Garden = None
-):
+def check_garden_receiving_heartbeat(api: str, garden_name: str = None, garden: Garden = None):
     if garden is None:
         garden = db.query_unique(Garden, name=garden_name)
 
     # if garden doens't exist, create it
     if garden is None:
         garden = create_garden(Garden(name=garden_name, connection_type="Remote"))
-
-    updates = {}
-
+    
     connection_set = False
+    update_heartbeat = False
 
     for connection in garden.receiving_connections:
         if connection.api == api:
             connection_set = True
-            connection.status_info["heartbeat"] = datetime.utcnow()
-            if connection.status != "DISABLED":
+            
+            if connection.status not in ["DISABLED","RECEIVING"]:
                 connection.status = "RECEIVING"
+                update_heartbeat = True
+
+            interval_value = garden.metadata.get(
+                "_unresponsive_timeout", config.get("children.unresponsive_timeout")
+            )
+
+            if interval_value > 0:
+                timeout = datetime.utcnow() - timedelta(minutes=interval_value / 2)
+
+                if connection.status_info["heartbeat"] < timeout:
+                    connection.status_info["heartbeat"] = datetime.utcnow()
+                    update_heartbeat = True
 
     # If the receiving type is unknown, enable it by default and set heartbeat
     if not connection_set:
+        update_heartbeat = True
         connection = Connection(api=api, status="DISABLED")
 
         # Check if there is a config file
@@ -233,14 +243,28 @@ def update_garden_receiving_heartbeat(
             if config.get("receiving", config=garden_config):
                 connection.status = "RECEIVING"
 
+
         connection.status_info["heartbeat"] = datetime.utcnow()
         garden.receiving_connections.append(connection)
 
-    updates["receiving_connections"] = [
-        db.from_brewtils(connection) for connection in garden.receiving_connections
-    ]
+    if update_heartbeat:
+        return update_receiving_connections(garden)
 
-    return db.modify(garden, **updates)
+    return garden
+
+@publish_event(Events.GARDEN_UPDATED)
+def update_receiving_connections(garden: Garden):
+
+    updates = {}
+
+    if update_garden:
+        updates["receiving_connections"] = [
+            db.from_brewtils(connection) for connection in garden.receiving_connections
+        ]
+
+        return db.modify(garden, **updates)
+    
+    return garden
 
 
 def update_garden_status(garden_name: str, new_status: str) -> Garden:

--- a/src/app/beer_garden/garden.py
+++ b/src/app/beer_garden/garden.py
@@ -201,22 +201,24 @@ def update_garden_config(garden: Garden) -> Garden:
     return update_garden(db_garden)
 
 
-def check_garden_receiving_heartbeat(api: str, garden_name: str = None, garden: Garden = None):
+def check_garden_receiving_heartbeat(
+    api: str, garden_name: str = None, garden: Garden = None
+):
     if garden is None:
         garden = db.query_unique(Garden, name=garden_name)
 
     # if garden doens't exist, create it
     if garden is None:
         garden = create_garden(Garden(name=garden_name, connection_type="Remote"))
-    
+
     connection_set = False
     update_heartbeat = False
 
     for connection in garden.receiving_connections:
         if connection.api == api:
             connection_set = True
-            
-            if connection.status not in ["DISABLED","RECEIVING"]:
+
+            if connection.status not in ["DISABLED", "RECEIVING"]:
                 connection.status = "RECEIVING"
                 update_heartbeat = True
 
@@ -243,7 +245,6 @@ def check_garden_receiving_heartbeat(api: str, garden_name: str = None, garden: 
             if config.get("receiving", config=garden_config):
                 connection.status = "RECEIVING"
 
-
         connection.status_info["heartbeat"] = datetime.utcnow()
         garden.receiving_connections.append(connection)
 
@@ -252,9 +253,9 @@ def check_garden_receiving_heartbeat(api: str, garden_name: str = None, garden: 
 
     return garden
 
+
 @publish_event(Events.GARDEN_UPDATED)
 def update_receiving_connections(garden: Garden):
-
     updates = {}
 
     if update_garden:
@@ -263,7 +264,7 @@ def update_receiving_connections(garden: Garden):
         ]
 
         return db.modify(garden, **updates)
-    
+
     return garden
 
 

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -485,9 +485,9 @@ def setup_routing():
                             and connection.status != "DISABLED"
                         ):
                             if garden.name not in stomp_garden_connections:
-                                stomp_garden_connections[
-                                    garden.name
-                                ] = create_stomp_connection(connection)
+                                stomp_garden_connections[garden.name] = (
+                                    create_stomp_connection(connection)
+                                )
 
             else:
                 logger.warning(f"Garden with invalid connection info: {garden!r}")
@@ -602,9 +602,9 @@ def handle_event(event):
                             event.payload.name not in stomp_garden_connections
                             and connection.status == "PUBLISHING"
                         ):
-                            stomp_garden_connections[
-                                event.payload.name
-                            ] = create_stomp_connection(connection)
+                            stomp_garden_connections[event.payload.name] = (
+                                create_stomp_connection(connection)
+                            )
 
                         elif connection.status == "DISABLED":
                             stomp_garden_connections[event.payload.name].disconnect()

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -205,7 +205,7 @@ def route(operation: Operation):
         raise RoutingRequestException(
             f"Unknown operation type '{operation.operation_type}'"
         )
-    
+
     update_api_heartbeat(operation)
 
     if invalid_source_check(operation):
@@ -277,6 +277,7 @@ def execute_local(operation: Operation):
 
     return lookup[operation.operation_type](*operation.args, **operation.kwargs)
 
+
 def update_api_heartbeat(operation: Operation):
     if (
         operation.source_garden_name is not None
@@ -286,8 +287,11 @@ def update_api_heartbeat(operation: Operation):
         source_garden = getattr(gardens, operation.source_garden_name, None)
 
         beer_garden.garden.check_garden_receiving_heartbeat(
-            operation.source_api, garden_name=operation.source_garden_name, garden = source_garden
+            operation.source_api,
+            garden_name=operation.source_garden_name,
+            garden=source_garden,
         )
+
 
 def invalid_source_check(operation: Operation):
     # Unable to validate source or api
@@ -481,9 +485,9 @@ def setup_routing():
                             and connection.status != "DISABLED"
                         ):
                             if garden.name not in stomp_garden_connections:
-                                stomp_garden_connections[garden.name] = (
-                                    create_stomp_connection(connection)
-                                )
+                                stomp_garden_connections[
+                                    garden.name
+                                ] = create_stomp_connection(connection)
 
             else:
                 logger.warning(f"Garden with invalid connection info: {garden!r}")
@@ -598,9 +602,9 @@ def handle_event(event):
                             event.payload.name not in stomp_garden_connections
                             and connection.status == "PUBLISHING"
                         ):
-                            stomp_garden_connections[event.payload.name] = (
-                                create_stomp_connection(connection)
-                            )
+                            stomp_garden_connections[
+                                event.payload.name
+                            ] = create_stomp_connection(connection)
 
                         elif connection.status == "DISABLED":
                             stomp_garden_connections[event.payload.name].disconnect()

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -205,6 +205,8 @@ def route(operation: Operation):
         raise RoutingRequestException(
             f"Unknown operation type '{operation.operation_type}'"
         )
+    
+    update_api_heartbeat(operation)
 
     if invalid_source_check(operation):
         raise RoutingRequestException(
@@ -275,6 +277,17 @@ def execute_local(operation: Operation):
 
     return lookup[operation.operation_type](*operation.args, **operation.kwargs)
 
+def update_api_heartbeat(operation: Operation):
+    if (
+        operation.source_garden_name is not None
+        and operation.source_garden_name != config.get("garden.name")
+        and operation.source_api is not None
+    ):
+        source_garden = getattr(gardens, operation.source_garden_name, None)
+
+        beer_garden.garden.check_garden_receiving_heartbeat(
+            operation.source_api, garden_name=operation.source_garden_name, garden = source_garden
+        )
 
 def invalid_source_check(operation: Operation):
     # Unable to validate source or api
@@ -285,12 +298,7 @@ def invalid_source_check(operation: Operation):
     ):
         return False
 
-    # Grabs the garden to check and updates the heartbeat for the entry point
-    source_garden = beer_garden.garden.update_garden_receiving_heartbeat(
-        operation.source_api, garden_name=operation.source_garden_name
-    )
-
-    for connection in source_garden.receiving_connections:
+    for connection in gardens[operation.source_garden_name].receiving_connections:
         if connection.api == operation.source_api and connection.status != "DISABLED":
             return False
 
@@ -609,6 +617,8 @@ def handle_event(event):
                     del stomp_garden_connections[event.payload.name]
             except KeyError:
                 pass
+        elif event.name == Events.GARDEN_UPDATED.name:
+            gardens[event.payload.name] = event.payload
 
 
 def _operation_conversion(operation: Operation) -> Operation:

--- a/src/app/test/garden_test.py
+++ b/src/app/test/garden_test.py
@@ -18,7 +18,7 @@ from beer_garden.garden import (
     local_garden,
     remove_garden,
     load_garden_connections,
-    update_garden_receiving_heartbeat,
+    check_garden_receiving_heartbeat,
     update_garden_status,
     upsert_garden,
     garden_unresponsive_trigger,
@@ -389,13 +389,13 @@ stomp:
 
         assert remote_user_count == 0
 
-    def test_update_garden_receiving_heartbeat_update_heartbeat(self):
-        garden = update_garden_receiving_heartbeat("http", garden_name="new_garden")
+    def test_check_garden_receiving_heartbeat_update_heartbeat(self):
+        garden = check_garden_receiving_heartbeat("http", garden_name="new_garden")
 
         assert len(garden.receiving_connections) == 1
         assert garden.receiving_connections[0].status == "DISABLED"
 
-    def test_update_garden_receiving_heartbeat_existing_garden_new_api_with_config(
+    def test_check_garden_receiving_heartbeat_existing_garden_new_api_with_config(
         self, tmpdir, bg_garden
     ):
         bg_garden.systems = []
@@ -447,7 +447,7 @@ stomp:
 
         config._CONFIG = {"children": {"directory": tmpdir}}
 
-        garden = update_garden_receiving_heartbeat("STOMP", garden_name=garden.name)
+        garden = check_garden_receiving_heartbeat("STOMP", garden_name=garden.name)
 
         assert len(garden.receiving_connections) == 2
 
@@ -456,13 +456,13 @@ stomp:
 
         os.remove(config_file)
 
-    def test_update_garden_receiving_heartbeat_existing_garden_new_api(self, bg_garden):
+    def test_check_garden_receiving_heartbeat_existing_garden_new_api(self, bg_garden):
         bg_garden.systems = []
 
         garden = create_garden(bg_garden)
         assert len(garden.receiving_connections) == 1
 
-        garden = update_garden_receiving_heartbeat("STOMP", garden_name=garden.name)
+        garden = check_garden_receiving_heartbeat("STOMP", garden_name=garden.name)
 
         assert len(garden.receiving_connections) == 2
 


### PR DESCRIPTION
Instead of updating at every API call, only update the database record at the half expiration marks.