### PR TITLE
Stomp Disabled Connection Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ TBD
 
 - Now show alert on Garden Admin page when a Sync event is seen
 - Fixed order of Gardens and Connections on Garden Admin page
+= Fixed bug where Disabled STOMP Receving connection could be re-enabled if it is shared and unresponsive
 - Fixed bug where child garden plugins are treated like local plugins on the System Admin page
 - Utilized the TTL for In_Progress requests to set Expiration windows for Requests on PIKA, to handle backups of requests that Beer Garden has already cancelled.
 - Optimized UI Rest calls to load only Local Garden with Children

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ TBD
 
 - Now show alert on Garden Admin page when a Sync event is seen
 - Fixed order of Gardens and Connections on Garden Admin page
-= Fixed bug where Disabled STOMP Receving connection could be re-enabled if it is shared and unresponsive
+- Fixed bug where Disabled STOMP Receiving connection could be re-enabled if it is shared and unresponsive
 - Fixed bug where child garden plugins are treated like local plugins on the System Admin page
 - Utilized the TTL for In_Progress requests to set Expiration windows for Requests on PIKA, to handle backups of requests that Beer Garden has already cancelled.
 - Optimized UI Rest calls to load only Local Garden with Children

--- a/src/app/beer_garden/api/stomp/transport.py
+++ b/src/app/beer_garden/api/stomp/transport.py
@@ -285,7 +285,7 @@ class Connection:
             for garden in get_gardens():
                 connection_updated = False
                 for connection in garden.receiving_connections:
-                    if connection.api == "STOMP":
+                    if connection.api == "STOMP" and connection.status != "DISABLED":
                         if (
                             connection.config.get("host", None)
                             and connection.config.get("port", None)
@@ -301,7 +301,7 @@ class Connection:
                                 connection_updated = True
 
                 for connection in garden.publishing_connections:
-                    if connection.api == "STOMP":
+                    if connection.api == "STOMP" and connection.status != "DISABLED":
                         if (
                             connection.config.get("host", None)
                             and connection.config.get("port", None)


### PR DESCRIPTION
If the connection is disabled and shared, when it goes unresponsive it updates the disabled status, this was fixed.