### PR TITLE
Fixing name of max-concurrent plugin

### DIFF
--- a/test/jmeter/stress_test.jmx
+++ b/test/jmeter/stress_test.jmx
@@ -181,7 +181,7 @@
                 <elementProp name="" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
                   <stringProp name="Argument.value">{&#xd;
-  &quot;system&quot;: &quot;max_conccurent&quot;,&#xd;
+  &quot;system&quot;: &quot;max_concurrent&quot;,&#xd;
   &quot;system_version&quot;: &quot;3.0.0.dev0&quot;,&#xd;
   &quot;namespace&quot;: &quot;${childGardenName}&quot;,&#xd;
   &quot;command&quot;: &quot;five_concurrent&quot;,&#xd;
@@ -426,7 +426,7 @@
                 <elementProp name="" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
                   <stringProp name="Argument.value">{&#xd;
-  &quot;system&quot;: &quot;max_conccurent&quot;,&#xd;
+  &quot;system&quot;: &quot;max_concurrent&quot;,&#xd;
   &quot;system_version&quot;: &quot;3.0.0.dev0&quot;,&#xd;
   &quot;namespace&quot;: &quot;${parentGardenName}&quot;,&#xd;
   &quot;command&quot;: &quot;five_concurrent&quot;,&#xd;


### PR DESCRIPTION
Example plugin name fixed so fixing misspelling of name here.