### PR TITLE
Updating Garden Admin Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 TBD
 
+- Updated Garden Admin page to only update page data based on Local Garden Update Events and notify when a child sync is being processed 
 - Fixed logging statement
 
 # 3.26.0

--- a/src/ui/src/js/controllers/admin_garden.js
+++ b/src/ui/src/js/controllers/admin_garden.js
@@ -365,12 +365,14 @@ export default function adminGardenController(
       case 'GARDEN_CREATED':
       case 'GARDEN_CONFIGURED':
       case 'GARDEN_UPDATED':
-        $scope.eventUpsetGarden(event.payload)
-        $scope.$digest();
+        if (event.payload.name == $scope.config.gardenName) {
+          $scope.eventUpsetGarden(event.payload)
+          $scope.$digest();
+        }
         break;
       case 'GARDEN_SYNC':
         if (event.payload.name != $scope.config.gardenName) {
-          $scope.pushAlert('info', 'Garden sync event seen from ' + event.payload.name);
+          $scope.pushAlert('info', 'Processing Garden sync event from ' + event.payload.name);
         }
     }
   });


### PR DESCRIPTION
Only update page data on local garden updates, to avoid mixing downstream configurations on UI.

Notify that a Garden Sync is being processed, since the UI doesn't do anything with the event. This change in verbiage gives us time to update the UI at a later point.