### PR TITLE
Fixed Delete Request Counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ TBD
 - Fixed issue where Topic delete was called with `args` instead of `kwargs`
 - Updated each `handle_event` function to be processed in independent threads
 - Beer Garden will only emit locally generated events to any listening or configured APIs. 
+- Fixed counters displayed on Delete Request pop up to match exact values instead of starts with
 - Fixed bug where Garden Sync response doesn't null check before evaluating API response
 - Fixed issue where if user sync with child garden fails at startup will stop Beer Garden
 - Fixed issue where Requester was added to requests when auth was disabled

--- a/src/app/beer_garden/api/http/handlers/v1/request.py
+++ b/src/app/beer_garden/api/http/handlers/v1/request.py
@@ -844,14 +844,19 @@ class RequestListAPI(AuthorizationHandler):
             query_columns.append(column)
 
             if column["data"]:
-                include_fields.append(column["data"])
+                if "__" in column["data"]:
+                    include_fields.append(column["data"].split("__")[0])
+                else:
+                    include_fields.append(column["data"])
 
             if (
                 "searchable" in column
                 and column["searchable"]
                 and column["search"]["value"]
             ):
-                if column["data"] in ["created_at", "updated_at"]:
+                if "__" in column["data"]:
+                    filter_params[column["data"]] = column["search"]["value"]
+                elif column["data"] in ["created_at", "updated_at"]:
                     search_dates = column["search"]["value"].split("~")
 
                     if search_dates[0]:

--- a/src/ui/src/js/controllers/admin_request_delete.js
+++ b/src/ui/src/js/controllers/admin_request_delete.js
@@ -86,7 +86,7 @@ export default function adminRequestDeleteController(
       "length": 1,
       "columns": [
         {
-          "data": "namespace",
+          "data": "namespace__exact",
           "name": "",
           "searchable": true,
           "orderable": true,
@@ -96,7 +96,7 @@ export default function adminRequestDeleteController(
           }
         },
         {
-          "data": "system",
+          "data": "system__exact",
           "name": "",
           "searchable": true,
           "orderable": true,
@@ -106,7 +106,7 @@ export default function adminRequestDeleteController(
           }
         },
         {
-          "data": "system_version",
+          "data": "system_version__exact",
           "name": "",
           "searchable": true,
           "orderable": true,
@@ -116,7 +116,7 @@ export default function adminRequestDeleteController(
           }
         },
         {
-          "data": "instance_name",
+          "data": "instance_name__exact",
           "name": "",
           "searchable": true,
           "orderable": true,


### PR DESCRIPTION
The counter was originally counting everything that started with the same value, so `echo` and `echo-sleep` would both be counted