### PR TITLE
pypi naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beer Garden Changelog
 
+# TBD
+
+TBD
+
+- Updated Pypi release package name from `beer-garden` to `beer_garden` to comply with PEP 625. 
+
 # 3.29.0
 
 11/25/2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Beer Garden Changelog
 
-# TBD
+# 3.29.1
 
 TBD
 

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -5,13 +5,13 @@
 #    pip-compile setup.py
 #
 apispec==0.38.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 appdirs==1.4.4
     # via brewtils
 apscheduler==3.10.1
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 brewtils==3.29.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 certifi==2023.5.7
     # via
     #   elastic-apm
@@ -23,65 +23,65 @@ docopt==0.6.2
 ecs-logging==2.2.0
     # via elastic-apm
 elastic-apm==6.18.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 idna==3.4
     # via requests
 lark-parser==0.6.7
     # via brewtils
 ldap3==2.9.1
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 marshmallow==2.21.0
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   brewtils
     #   marshmallow-polyfield
 marshmallow-polyfield==3.2
     # via brewtils
 mongoengine==0.20.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 more-itertools==8.14.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 motor==2.5.1
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 packaging==23.1
     # via brewtils
 passlib==1.7.4
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 pika==1.2.0
     # via brewtils
 prometheus-client==0.17.1
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 pyasn1==0.5.1
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   ldap3
 pyjwt==2.8.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 pymongo==3.13.0
     # via
     #   mongoengine
     #   motor
 pyrabbit2==1.0.7
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 python-box==3.4.6
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   yapconf
 pytz==2020.5
     # via
     #   apscheduler
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   brewtils
 pyyaml==5.3.1
     # via
     #   apispec
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
 requests==2.31.0
     # via
     #   brewtils
     #   pyrabbit2
 ruamel-yaml==0.16.13
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 simplejson==3.19.1
     # via brewtils
 six==1.16.0
@@ -90,28 +90,28 @@ six==1.16.0
     #   brewtils
     #   yapconf
 stomp-py==6.0.0
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 tornado==6.2
-    # via beer-garden (setup.py)
+    # via beer_garden (setup.py)
 tzlocal==5.0.1
     # via apscheduler
 urllib3==1.26.16
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   elastic-apm
     #   requests
 watchdog==3.0.0
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   yapconf
 wrapt==1.15.0
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   brewtils
     #   elastic-apm
 yapconf==1.0.0
     # via
-    #   beer-garden (setup.py)
+    #   beer_garden (setup.py)
     #   brewtils
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/app/setup.py
+++ b/src/app/setup.py
@@ -17,7 +17,7 @@ def find_version(version_file):
 
 
 setup(
-    name="beer-garden",
+    name="beer_garden",
     version=find_version("beer_garden/__version__.py"),
     description="Beergarden Application",
     long_description=readme,


### PR DESCRIPTION
"""
In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'beer-garden-3.29.0.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'beer_garden'.

In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.
"""