### PR TITLE
3.30.0 Filter Latest with Instance Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ TBD
 - Updated Events Websocket to support Async calls
 - Fixed bug where Publish Topic did not evalute downstream garden systems
 - Optimized how publish request handles topic matching
+- Fixed logic when `instance_name` is included on Request object with the system version of `latest` that
+  the instance name is included in the filter criteria
 
 # 3.29.1
 

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -602,7 +602,7 @@ def determine_latest_system_version(request: Request):
     filter_criteria = {"name": request.system}
 
     if request.instance_name:
-        filter_criteria["instances_name"] = request.instance_name
+        filter_criteria["instances__name"] = request.instance_name
 
     if request.namespace:
         filter_criteria["namespace"] = request.namespace

--- a/src/app/beer_garden/requests.py
+++ b/src/app/beer_garden/requests.py
@@ -599,12 +599,19 @@ def determine_latest_system_version(request: Request):
     if request.system_version and request.system_version.lower() != "latest":
         return request
 
+    filter_criteria = {"name": request.system}
+
+    if request.instance_name:
+        filter_criteria["instances_name"] = request.instance_name
+
+    if request.namespace:
+        filter_criteria["namespace"] = request.namespace
+    else:
+        filter_criteria["namespace"] = config.get("garden.name")
+
     systems = db.query(
         System,
-        filter_params={
-            "namespace": request.namespace,
-            "name": request.system,
-        },
+        filter_params=filter_criteria,
     )
 
     versions = []

--- a/src/app/test/requests_test.py
+++ b/src/app/test/requests_test.py
@@ -7,7 +7,7 @@ from box import Box
 from brewtils.errors import ModelValidationError
 from brewtils.models import Choices, Command, Event, Events
 from brewtils.models import Garden as BrewtilsGarden
-from brewtils.models import Parameter
+from brewtils.models import Instance, Parameter
 from brewtils.models import Request as BrewtilsRequest
 from brewtils.models import System
 from mock import Mock, call, patch
@@ -1169,6 +1169,7 @@ class TestLatestRequest(object):
                 name="original",
                 version="1.0.0dev",
                 namespace="beer_garden",
+                instances=[Instance(name="1"), Instance(name="2")],
                 commands=[Command(name="original")],
             )
         )
@@ -1182,6 +1183,7 @@ class TestLatestRequest(object):
                 name="original",
                 version="2.0.0",
                 namespace="beer_garden",
+                instances=[Instance(name="2"), Instance(name="3")],
                 commands=[Command(name="original")],
             )
         )
@@ -1209,6 +1211,32 @@ class TestLatestRequest(object):
 
         assert latest_request.system_version != system_v1.version
         assert latest_request.system_version == system_v2.version
+
+    def test_latest_instance_request(self, system_v1, system_v2):
+        latest_request = determine_latest_system_version(
+            Request(
+                system="original",
+                namespace="beer_garden",
+                instance_name="2",
+                system_version="latest"
+            )
+        )
+
+        assert latest_request.system_version != system_v1.version
+        assert latest_request.system_version == system_v2.version
+
+    def test_latest_instance_request_unique_instance(self, system_v1, system_v2):
+        latest_request = determine_latest_system_version(
+            Request(
+                system="original",
+                namespace="beer_garden",
+                instance_name="1",
+                system_version="latest"
+            )
+        )
+
+        assert latest_request.system_version == system_v1.version
+        assert latest_request.system_version != system_v2.version
 
     def test_v1_request_no_version(self, system_v1):
         latest_request = determine_latest_system_version(

--- a/src/app/test/requests_test.py
+++ b/src/app/test/requests_test.py
@@ -1218,7 +1218,7 @@ class TestLatestRequest(object):
                 system="original",
                 namespace="beer_garden",
                 instance_name="2",
-                system_version="latest"
+                system_version="latest",
             )
         )
 
@@ -1231,7 +1231,7 @@ class TestLatestRequest(object):
                 system="original",
                 namespace="beer_garden",
                 instance_name="1",
-                system_version="latest"
+                system_version="latest",
             )
         )
 


### PR DESCRIPTION
Use Instance Name when filtering

brewtils: migrate_handler_optimization

Fixes: #1816