### PR TITLE
3.30.0 Optimize instance heartbeat update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ TBD
 - Updated pruner configuration to consolidate options under `db.prune`
 - Fixed bug where Paused Jobs being imported were Running in the background
 - Updated 3.24 migration script to skip children config creation if only one garden
+- Reduced mongodb calls required to update instance heartbeat
 
 # 3.29.1
 

--- a/src/app/beer_garden/plugin.py
+++ b/src/app/beer_garden/plugin.py
@@ -483,17 +483,43 @@ async def heartbeat_async(
 ) -> dict:
     query = {"instances._id": ObjectIdField().to_mongo(instance_id)}
     projection = {"instances.$": 1, "_id": 0}
-    update = {
-        "$set": {"instances.$.status_info.heartbeat": datetime.utcnow()},
-        "$push": {
-            "instances.$.status_info.history": {
-                "status": "RUNNING",
-                "heartbeat": datetime.utcnow(),
-            }
-        },
-    }
 
-    return await _update_instance_async(query, projection, update)
+    result = await moto.query(collection="system", filter=query, projection=projection)
+
+    instance = result["instances"][0]
+    if "_id" in instance:
+        instance["id"] = str(instance["_id"])
+        del instance["_id"]
+
+    update_time = datetime.utcnow()
+    history = {
+        "status": "RUNNING",
+        "heartbeat": update_time,
+    }
+    instance["status_info"]["heartbeat"] = update_time
+
+    instance["status_info"]["history"].append(history)
+
+    if config.get("plugin.status_history") > 0 and len(
+        instance["status_info"]["history"]
+    ) + 1 > config.get("plugin.status_history"):
+        instance["status_info"]["history"].pop(0)
+
+        update = {
+            "$set": {
+                "instances.$.status_info.heartbeat": update_time,
+                "instances.$.status_info.history": instance["status_info"]["history"],
+            },
+        }
+    else:
+        update = {
+            "$set": {"instances.$.status_info.heartbeat": update_time},
+            "$push": {"instances.$.status_info.history": history},
+        }
+
+    await moto.update_one(collection="system", filter=query, update=update)
+
+    return SchemaParser.parse_instance(instance)
 
 
 async def _get_instance_async(filter, projection) -> dict:


### PR DESCRIPTION
brewtils: migrate_handler_optimization

Cut the speed from 2.8s to 1.4s per transaction