### PR TITLE
3.30.0 Fix HTTP Updater for metric collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ TBD
 - Updated orphan pruner to delete orphaned files
 - Updated Topic Sync logging to track update/delete counts
 - Fixed bug where pour again invalid property caused broken UI
+- Fixed metric collection on queue depth of HTTP Parent Updater
 - Updated pruner configuration to consolidate options under `db.prune`
 - Fixed bug where Paused Jobs being imported were Running in the background
 - Fixed bug where Request pruning did not remove GridFS stored objects. 

--- a/src/app/beer_garden/events/parent_processors.py
+++ b/src/app/beer_garden/events/parent_processors.py
@@ -21,6 +21,7 @@ class HttpParentUpdater(QueueListener):
         self._ez_client = easy_client
         self._reconnect_action = reconnect_action
         self._connected = True
+        self._handler_tag = "HTTP Parent Updater"
 
         super().__init__(
             logger_name=self.__module__ + "." + self.__class__.__name__, **kwargs


### PR DESCRIPTION
brewtils: migrate_handler_optimization

Fixes this error message:
```
elasticapm.utils.threading - ERROR - Exception in interval timer function
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/elasticapm/utils/threading.py", line 84, in run
    rval = self._function(*self._args, **self._kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/elasticapm/metrics/base_metrics.py", line 100, in collect
    for data in metricset.collect():
  File "/usr/local/lib/python3.11/site-packages/elasticapm/metrics/base_metrics.py", line 218, in collect
    self.before_collect()
  File "/usr/local/lib/python3.11/site-packages/beer_garden/metrics.py", line 313, in before_collect
    f"processor_metrics.{processor._handler_tag.replace(' ', '_').lower()}",
                         ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'HttpParentUpdater' object has no attribute '_handler_tag'
```