### PR TITLE
3.30.0 Accept Target Garden for multi hops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ TBD
 - Reduced mongodb calls required to update instance heartbeat
 - Updated logic for forwarding Requests to remove DB call
 - Updated pour it again requests to respect command type override
+- Updated Routing Logic to accept Target Garden provided
 
 # 3.29.1
 

--- a/src/app/beer_garden/router.py
+++ b/src/app/beer_garden/router.py
@@ -827,13 +827,10 @@ def _pre_execute(operation: Operation) -> Operation:
 
 
 def _determine_target(operation: Operation) -> str:
-    """Determine the garden the operation is targeting
+    """Determine the garden the operation is targeting"""
 
-    Note that while the operation can already have a target garden field this will only
-    be used as a fallback if a better target can't be calculated.
-
-    See https://github.com/beer-garden/beer-garden/issues/1076
-    """
+    if operation.target_garden_name:
+        return operation.target_garden_name
 
     target_garden = _target_from_type(operation)
 

--- a/src/app/test/router_test.py
+++ b/src/app/test/router_test.py
@@ -45,10 +45,10 @@ class TestDetermineTarget:
 
         assert _determine_target(op) == "child"
 
-    def test_mismatch(self, monkeypatch, op):
+    def test_provided(self, monkeypatch, op):
         monkeypatch.setattr(
             beer_garden.router, "_target_from_type", Mock(return_value="child")
         )
         op.target_garden_name = "parent"
 
-        assert _determine_target(op) == "child"
+        assert _determine_target(op) == "parent"


### PR DESCRIPTION
Now that we know of the entire path, we can accept the provided Target Garden from the Upstream Garden.

This resolves the issues seen with: https://github.com/beer-garden/beer-garden/issues/1076
