### PR TITLE
Fixed pruner check for gridfs

### DIFF
--- a/src/app/beer_garden/db/mongo/pruner.py
+++ b/src/app/beer_garden/db/mongo/pruner.py
@@ -157,9 +157,21 @@ def prune_request_cursor(
             request_ids.append(request.id)
 
             if request.output_gridfs:
-                request_grids_fs_files.append(request.output_gridfs._id)
+                try:
+                    request_grids_fs_files.append(request.output_gridfs._id)
+                except AttributeError:
+                    logger.error(
+                        f"AttributeError: Attempted to delete request {request.id} "
+                        "but does not have a output_gridfs file id"
+                    )
             if request.parameters_gridfs:
-                request_grids_fs_files.append(request.parameters_gridfs._id)
+                try:
+                    request_grids_fs_files.append(request.parameters_gridfs._id)
+                except AttributeError:
+                    logger.error(
+                        f"AttributeError: Attempted to delete request {request.id} "
+                        "but does not have a parameters_gridfs file id"
+                    )
 
             parameters = request.parameters or {}
 


### PR DESCRIPTION
Add dumping to the logs what failed, but the pruner can carry on.