### PR TITLE
Bug fix for update associated systems after sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ TBD
   handle pruning. (#1940)
 - Scheduler starts after the HTTP entry point has started to ensure plugins have a chance to start running (#1963)
 - Fixed bug where Pub/Sub generated requests did not map properly root_command_type field (#1968)
+- Fixed bug removing known systems because ID didn't match (#1972)
 
 ## 3.30.0rc2
 

--- a/src/app/beer_garden/db/mongo/models.py
+++ b/src/app/beer_garden/db/mongo/models.py
@@ -1404,13 +1404,14 @@ class Garden(MongoModel, Document):
                 if triple in child_systems_already_known:
                     system_id_to_remove = child_systems_already_known.pop(triple)
 
-                    if system_id_to_remove != str(system.id):
+                    # system_id_to_remove and system.id are ObjectIds
+                    if system_id_to_remove != system.id:
                         # remove the system from before this update with the same triple
                         logger.error(
                             f"Removing System <{triple[0]}"
                             f", {triple[1]}"
                             f", {triple[2]}> with ID={system_id_to_remove}"
-                            f"; doesn't match ID={str(system.id)}"
+                            f"; doesn't match ID={system.id}"
                             " for known system with same attributes"
                         )
                         remove_system(system_id=system_id_to_remove)


### PR DESCRIPTION
Fixes ObjectId comparison causing errors similar to`Removing System <parent, complex, 3.0.0.dev0> with ID=68c02b947565a299ef996d95; doesn't match ID=68c02b947565a299ef996d95 for known system with same attributes`